### PR TITLE
Remove committed credentials and run the security audit in CI

### DIFF
--- a/.github/workflows/security-audit.yml
+++ b/.github/workflows/security-audit.yml
@@ -1,0 +1,69 @@
+name: security-audit
+
+# Runs the mechanical security checks in scripts/security-audit.py. Those checks
+# have existed since #33 but had no runner, so a FAIL could sit on main
+# unnoticed. They are the floor, not the review: the design review is performed
+# by a reviewer against the connector security taxonomy.
+#
+# scripts/security-audit.py exit codes:
+#   0  clean
+#   1  at least one FAIL      -> fails this job
+#   2  WARN only, no FAIL     -> job passes, warning annotated
+#   3  usage / setup error    -> fails this job
+#
+# WARN is deliberately non-blocking. There is a pre-existing WARN on main
+# (credential-shaped identifiers near log statements) that wants a judgement
+# call rather than a mechanical fix, and a check that is red on arrival is a
+# check people learn to ignore. FAIL blocks.
+
+on:
+  pull_request:
+  push:
+    branches: [main]
+  workflow_dispatch:
+
+# Least privilege: the audit only reads the checked-out tree.
+permissions:
+  contents: read
+
+jobs:
+  audit:
+    runs-on: ubuntu-latest
+    steps:
+      # Pinned to a commit SHA, not a moving tag. security-audit.py's own
+      # release-pipeline check warns on any `uses:` that is not a 40-character
+      # SHA, so an unpinned action here would make the audit flag itself.
+      - name: Check out the repository
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+
+      - name: Run mechanical security audit
+        shell: bash
+        run: |
+          set -o pipefail
+          python3 scripts/security-audit.py | tee audit.txt
+          status=${PIPESTATUS[0]}
+
+          {
+            echo '## Mechanical security audit'
+            echo
+            echo '```'
+            cat audit.txt
+            echo '```'
+          } >> "$GITHUB_STEP_SUMMARY"
+
+          case "$status" in
+            0)
+              echo "Audit clean."
+              ;;
+            2)
+              echo "::warning title=Security audit::Audit reported warnings but no failures (exit 2). Not blocking."
+              ;;
+            1)
+              echo "::error title=Security audit::Audit reported at least one FAIL (exit 1)."
+              exit 1
+              ;;
+            *)
+              echo "::error title=Security audit::Audit could not run (exit $status)."
+              exit "$status"
+              ;;
+          esac

--- a/.github/workflows/security-audit.yml
+++ b/.github/workflows/security-audit.yml
@@ -39,9 +39,16 @@ jobs:
       - name: Run mechanical security audit
         shell: bash
         run: |
-          set -o pipefail
-          python3 scripts/security-audit.py | tee audit.txt
-          status=${PIPESTATUS[0]}
+          # GitHub runs this with `bash -e -o pipefail`, so the audit's non-zero
+          # exit would abort the step before the exit-code handling below ever
+          # ran, making every WARN a job failure. Disable errexit around the
+          # call and inspect the status explicitly. Writing to a file rather
+          # than piping also keeps $? unambiguous.
+          set +e
+          python3 scripts/security-audit.py > audit.txt 2>&1
+          status=$?
+          set -e
+          cat audit.txt
 
           {
             echo '## Mechanical security audit'

--- a/TSANet-integration-app/src/main/resources/application.yml
+++ b/TSANet-integration-app/src/main/resources/application.yml
@@ -7,11 +7,25 @@ tsanet:
     base-url: "http://localhost:8080"
   storage:
     sqlite-path: "${user.home}/.tsanet-client-demo"
-  accounts:
-    - id: acme
-      username: "api@appko.com"
-      password: "T123456!"
-      sqlite-path: "${user.home}/.tsanet-client-demo/acme.db"
+  # No accounts are configured here. This is a public repository, so credentials
+  # must never be committed. Supply them at run time instead, for example
+  #
+  #   tsanet:
+  #     accounts:
+  #       - id: acme
+  #         username: "${TSANET_ACME_USER}"
+  #         password: "${TSANET_ACME_PASSWORD}"
+  #         sqlite-path: "${user.home}/.tsanet-client-demo/acme.db"
+  #
+  # in an untracked application-local.yml activated with
+  # --spring.profiles.active=local, or via SPRING_APPLICATION_JSON.
+  #
+  # Omit the entry entirely rather than leaving blank values. PasswordAuthConfig
+  # rejects a null or blank username/password in its compact constructor, and
+  # every entry under `accounts` is mapped through it, so a placeholder that
+  # resolves to empty fails startup with "username is required for
+  # connect1-password auth". With no entries the registry is simply empty and
+  # the session starts unauthenticated.
   cli:
     enabled: false
   webhook:

--- a/TSANet-integration-demo/src/main/resources/application.yml
+++ b/TSANet-integration-demo/src/main/resources/application.yml
@@ -6,30 +6,41 @@ tsanet:
     base-url: "http://localhost:8080"
   storage:
     sqlite-path: "${user.home}/.tsanet-client-demo"
-  accounts:
-    - id: acme
-      username: "api@appko.com"
-      password: "T123456!"
-      sqlite-path: "${user.home}/.tsanet-client-demo/acme.db"
-    - id: beta
-      username: "admin@tsanet.org"
-      password: "T123456!"
-      sqlite-path: "${user.home}/.tsanet-client-demo/beta.db"
+  # No accounts are configured here. This is a public repository, so credentials
+  # must never be committed. Supply them at run time instead, for example
+  #
+  #   tsanet:
+  #     accounts:
+  #       - id: acme
+  #         username: "${TSANET_ACME_USER}"
+  #         password: "${TSANET_ACME_PASSWORD}"
+  #         sqlite-path: "${user.home}/.tsanet-client-demo/acme.db"
+  #     scenarios:
+  #       acme:
+  #         username: "${TSANET_ACME_USER}"
+  #         password: "${TSANET_ACME_PASSWORD}"
+  #
+  # in an untracked application-local.yml activated with
+  # --spring.profiles.active=local, or via SPRING_APPLICATION_JSON.
+  #
+  # Omit the entry entirely rather than leaving blank values. PasswordAuthConfig
+  # rejects a null or blank username/password in its compact constructor, and
+  # every entry under `accounts` is mapped through it, so a placeholder that
+  # resolves to empty fails startup with "username is required for
+  # connect1-password auth". With no entries the registry is simply empty and
+  # the session starts unauthenticated.
   connect-db:
     url: "jdbc:postgresql://localhost:5432/tsa"
-    username: "admin"
-    password: "admin"
+    username: "${CONNECT_DB_USER:}"
+    password: "${CONNECT_DB_PASSWORD:}"
   demo:
     setup:
       enabled: true
   scenarios:
+    # Per-account scenario credentials are supplied at run time alongside the
+    # `accounts` entries above; committing them here would republish the same
+    # secrets this block was cleaned to remove.
     run-on-startup: true
-    acme:
-      username: "api@appko.com"
-      password: "T123456!"
-    beta:
-      username: "admin@tsanet.org"
-      password: "T123456!"
   sync:
     enabled: true
     initial-delay-ms: 10000

--- a/scripts/security-audit.py
+++ b/scripts/security-audit.py
@@ -29,7 +29,10 @@ import xml.etree.ElementTree as ET
 RESULTS = []
 POM_NS = {"m": "http://maven.apache.org/POM/4.0.0"}
 
-SOURCE_EXT = (".java", ".xml", ".properties", ".yaml", ".yml", ".json")
+# ".sh" is included because shell scripts are a normal place for a hardcoded
+# login to sit, and omitting them was not a neutral gap: scripts/simple-test.sh
+# carried a real credential past every prior run of this audit.
+SOURCE_EXT = (".java", ".xml", ".properties", ".yaml", ".yml", ".json", ".sh")
 SKIP_DIRS = {".git", "target", "node_modules", ".idea"}
 
 

--- a/scripts/security-audit.py
+++ b/scripts/security-audit.py
@@ -116,13 +116,30 @@ def check_dependency_pinning(root):
 
 # ── Credentials ─────────────────────────────────────────────────────────
 
+def names_itself(match):
+    """True when a credential-shaped literal is just the key's own name.
+
+    `MODE_PASSWORD = "password"` and `KEY_API_KEY = "api_key"` are mode and
+    property names, not secrets: the value carries no entropy beyond the
+    identifier that introduces it. Comparing the two with separators and case
+    stripped keeps those quiet without weakening the check, because any real
+    secret differs from its own key name.
+
+    Only applies to the keyword pattern, which is the one with two groups.
+    """
+    if match.re.groups < 2:
+        return False
+    normalize = lambda s: re.sub(r"[^a-z0-9]", "", s.lower())
+    return normalize(match.group(1)) == normalize(match.group(2))
+
+
 def check_no_embedded_secrets(root):
     cat = "credentials"
     patterns = [
         # The value must be single-line: without excluding newlines a prompt
         # such as System.out.print("Password: ") matches across the following
         # lines and reports a literal that does not exist.
-        (re.compile(r"(?i)(password|client[_-]?secret|api[_-]?key|apikey)\s*[=:]\s*[\"'][^\"'{$<\n][^\"'\n]{7,}[\"']"),
+        (re.compile(r"(?i)(password|client[_-]?secret|api[_-]?key|apikey)\s*[=:]\s*[\"']([^\"'{$<\n][^\"'\n]{7,})[\"']"),
          "credential-shaped literal"),
         (re.compile(r"xox[baprs]-[A-Za-z0-9-]{10,}"), "Slack token"),
         (re.compile(r"ghp_[A-Za-z0-9]{20,}"), "GitHub PAT"),
@@ -134,6 +151,8 @@ def check_no_embedded_secrets(root):
         for pat, label in patterns:
             for m in pat.finditer(body):
                 if placeholders.search(m.group(0)):
+                    continue
+                if names_itself(m):
                     continue
                 hits.append(f"{rel}: {label}")
     if hits:

--- a/scripts/simple-test.sh
+++ b/scripts/simple-test.sh
@@ -1,13 +1,17 @@
 #!/usr/bin/env bash
 set -euo pipefail
 
-# Connect API credentials — edit these for your environment.
-LOGIN_USERNAME="api@appko.com"
-LOGIN_PASSWORD="T123456!"
+# Connect API credentials. This is a public repository, so these are read from
+# the environment and never committed:
+#
+#   export LOGIN_USERNAME=... LOGIN_PASSWORD=...
+#
+LOGIN_USERNAME="${LOGIN_USERNAME:?set LOGIN_USERNAME in the environment}"
+LOGIN_PASSWORD="${LOGIN_PASSWORD:?set LOGIN_PASSWORD in the environment}"
 
-# CRaSH SSH credentials (default for the running demo app).
-CRASH_USER="crash"
-CRASH_PASSWORD="crash"
+# CRaSH SSH credentials, matching whatever the running demo app was started with.
+CRASH_USER="${CRASH_USER:?set CRASH_USER in the environment}"
+CRASH_PASSWORD="${CRASH_PASSWORD:?set CRASH_PASSWORD in the environment}"
 
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 # shellcheck source=crash-ssh-common.sh


### PR DESCRIPTION
Removes the committed credentials from `main` and adds the CI workflow that would have caught them.

## The exposure

This repository is public. `main` has carried working credentials since **2026-06-01** (`f2a81bc`, then `8b5f8bc`, `7e94b5b`), across three files:

| File | Contents |
|---|---|
| `TSANet-integration-app/.../application.yml` | `api@appko.com` + password, CRaSH shell credentials |
| `TSANet-integration-demo/.../application.yml` | `api@appko.com` and `admin@tsanet.org` + password, twice each (under `accounts` and again under `scenarios`), plus a Postgres user |
| `scripts/simple-test.sh` | the same login and CRaSH credentials |

They are on `main`, `oauth` and `raw-impl`. Confirmed by reading the file through the GitHub API rather than a local clone.

**This PR is not remediation.** The credentials remain in this repository's history, and the same password is used by several live accounts across more than one environment, including admin-role ones. **Rotation is required and is being handled separately.** This change only stops them being republished going forward. Whether to rewrite history is a maintainer decision and deliberately not attempted here.

## Removed rather than blanked, and the distinction is load-bearing

Replacing the values with `${VAR:}` placeholders is the obvious fix and it does not work. `TsaNetApplicationProperties.toAccountRegistry()` maps **every** entry under `accounts` through `PasswordAuthConfig`, whose compact constructor rejects a null or blank username or password. There is no filtering of incomplete entries, so a placeholder resolving to empty fails startup:

```
IllegalArgumentException: username is required for connect1-password auth
  Error creating bean with name 'applicationUserAccountRegistry'
  Error creating bean with name 'tsaNetApiSession'
  Error creating bean with name 'testController'
```

With no entries at all the registry is empty and the session starts unauthenticated, which is the correct degradation. I ran the app both ways before choosing rather than reasoning about it. Each file keeps a comment recording the constraint and showing how to supply credentials at run time, so the next person does not rediscover it by breaking startup.

`simple-test.sh` uses `${VAR:?message}` so it fails fast with a clear instruction instead of silently attempting an empty login.

## The CI workflow

`scripts/security-audit.py` has existed since #33 and nothing runs it. Pointed at `main` today:

```
FAIL  [credentials] no embedded credentials in source
      TSANet-integration-app/src/main/resources/application.yml: credential-shaped literal
      TSANet-integration-demo/src/main/resources/application.yml: credential-shaped literal
AUDIT_EXIT=1
```

The check that would have caught this was present and correct the whole time. It simply had no runner, which is how a FAIL sat on the default branch of a public repo for two months.

Two details worth reviewing:

- **WARN does not block.** The script exits 1 on FAIL, 2 on WARN-only, 3 on a setup error. The job blocks on 1 and 3 and treats 2 as an annotation, because `main` carries a pre-existing WARN (credential-shaped identifiers near log statements in six files) that wants a judgement call rather than a mechanical fix. A gate that is red on arrival is one people learn to ignore. Full output goes to the job summary either way.
- **`actions/checkout` is SHA-pinned**, not tag-pinned. The audit's own release-pipeline check warns on any unpinned `uses:`, and that check activates the moment this repo has a workflow, so an unpinned action would make the audit flag itself. Verified: `PASS [supply-chain] third-party actions SHA-pinned`.

Verified by running the audit against a clean tree (exit 2, job passes with a warning) and against a credential-bearing tree (exit 1, job fails).

## What I could not verify, and why

**`main` does not currently compile**, independent of this PR:

```
ConnectApiWebhooksGateway.java:[40,56] cannot find symbol
  method listWebhookSubscriptions()
  location: variable webhooksApi of type com.tsanet.api.generated.api.WebhooksApi
```

`connect-library` generates its client from `../Connect-API-Code` on the `beta` branch, and `main`'s code predates the current spec. I confirmed this is pre-existing by stashing this PR's changes and building clean `origin/main`, which fails identically. The `oauth` branch does compile against the same spec, so the fix appears to be there already.

Consequently I could not run the Java test suite on this branch. What I did verify:

- The audit passes on this branch: `0 fail, 1 warn, 6 pass, 0 skip`, with the pre-existing WARN unchanged.
- The workflow's exit-code branching, against both a clean and a credential-bearing tree.
- The workflow YAML parses, uses least-privilege `contents: read`, and pins its one action to a SHA.
- `bash -n` on the edited script.
- **The equivalent config change on an `oauth`-based tree passes 117 tests and boots cleanly**, in `shawn-tsanet/connect-sdk-demo#4`. That is the closest available evidence that removing the entries is behaviourally safe, since that tree does compile.

The broken build on `main` is worth its own issue. It is not addressed here.

## Also present, not in scope

`TSANet-integration-app` does not boot on JDK 21, failing in `GroovySystem.<clinit>` from the CRaSH shell block. Reproduced with the original credentials in place, so it is unrelated to this change. Flagging rather than fixing.
