### PR TITLE
Declare jackson-datatype-jsr310 in connect-library

### DIFF
--- a/connect-library/pom.xml
+++ b/connect-library/pom.xml
@@ -32,6 +32,14 @@
             <artifactId>jackson-databind</artifactId>
         </dependency>
         <dependency>
+            <!-- The client relies on findAndRegisterModules(); outside Spring Boot nothing
+                 else puts the java.time module on the classpath, and date serialization
+                 fails with InvalidDefinitionException. Declared here so every consumer
+                 gets it, not only Boot apps. -->
+            <groupId>com.fasterxml.jackson.datatype</groupId>
+            <artifactId>jackson-datatype-jsr310</artifactId>
+        </dependency>
+        <dependency>
             <groupId>org.springframework</groupId>
             <artifactId>spring-jdbc</artifactId>
         </dependency>


### PR DESCRIPTION
One dependency, proposed for Slava's review: `connect-library` declares `jackson-datatype-jsr310` so the client is self-sufficient outside Spring Boot. Alignment-agenda condition 5.

**Why.** The client relies on `ObjectMapper.findAndRegisterModules()`, which registers only what is on the classpath. Inside Boot the starter supplies the java.time module invisibly; in any other embedding nothing does, and serialization of `java.time` types fails. Found live during the Connect_Gateway engine extraction: 3 of 9 BETA contract tests failed outside Boot for exactly this, and passed 9/9 once the module was on the classpath.

**Receipts.**
- Red: a scratch consumer on the library's exact pre-fix runtime classpath (`dependency:build-classpath`, zero jsr310 entries) throws `InvalidDefinitionException: Java 8 date/time type java.time.OffsetDateTime not supported by default: add Module "com.fasterxml.jackson.datatype:jackson-datatype-jsr310"` - Jackson names this module verbatim.
- Green: same probe on the post-fix classpath serializes; the module arrives transitively.
- Full library build with codegen: exit 0. Module suite: 81 tests, 0 failures, 0 skips.
- Wire format is unaffected: the generated `ApiClient` pins `RFC3339DateFormat` (`invoker/ApiClient.java`, "Use RFC3339 format for date and datetime"), so dates on the wire stay RFC3339 regardless of mapper defaults; this change only fixes mapper construction on plain classpaths. End-to-end receipt: the extracted engine ran the live BETA suite 9/9 with this module declared.

**Version** is deliberately omitted: managed by the Spring Boot 3.3.4 BOM via `tsanet-client-parent`, matching the version-less `jackson-databind` declaration above it. Compile scope is deliberate too - it must flow transitively to consumers.

**Base is `oauth`**, the validated stack (`main@332e5c7` does not build standalone; the oauth tip is the pin the Connect_Gateway v0.1.0 certification ran against).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
