### PR TITLE
Surface testCase through the facade DTO and cache

### DIFF
--- a/connect-library/src/main/java/com/tsanet/api/connectapi/dto/CollaborationRequestStatusDto.java
+++ b/connect-library/src/main/java/com/tsanet/api/connectapi/dto/CollaborationRequestStatusDto.java
@@ -13,6 +13,30 @@ public record CollaborationRequestStatusDto(
     Long receiveCompanyId,
     String token,
     String createdAt,
-    String updatedAt
+    String updatedAt,
+    Boolean testCase
 ) {
+    /**
+     * Compatibility constructor from before {@code testCase} existed; leaves it null,
+     * which readers must treat as "unknown", never as "real case".
+     *
+     * @deprecated pass {@code testCase} explicitly; scheduled for removal at the next
+     *     release boundary.
+     */
+    @Deprecated
+    public CollaborationRequestStatusDto(
+        Long id,
+        String status,
+        String summary,
+        String submitCompanyName,
+        Long submitCompanyId,
+        String receiveCompanyName,
+        Long receiveCompanyId,
+        String token,
+        String createdAt,
+        String updatedAt
+    ) {
+        this(id, status, summary, submitCompanyName, submitCompanyId, receiveCompanyName,
+            receiveCompanyId, token, createdAt, updatedAt, null);
+    }
 }

--- a/connect-library/src/main/java/com/tsanet/api/connectapi/internal/ConnectApiCollaborationGateway.java
+++ b/connect-library/src/main/java/com/tsanet/api/connectapi/internal/ConnectApiCollaborationGateway.java
@@ -80,7 +80,8 @@ public class ConnectApiCollaborationGateway {
             dto.getReceiveCompanyId(),
             dto.getToken(),
             formatDateTime(dto.getCreatedAt()),
-            formatDateTime(dto.getUpdatedAt())
+            formatDateTime(dto.getUpdatedAt()),
+            dto.getTestCase()
         );
     }
 

--- a/connect-library/src/main/java/com/tsanet/api/connectapi/internal/ConnectApiResponsesGateway.java
+++ b/connect-library/src/main/java/com/tsanet/api/connectapi/internal/ConnectApiResponsesGateway.java
@@ -218,7 +218,8 @@ public class ConnectApiResponsesGateway {
             dto.getReceiveCompanyId(),
             dto.getToken(),
             formatDateTime(dto.getCreatedAt()),
-            formatDateTime(dto.getUpdatedAt())
+            formatDateTime(dto.getUpdatedAt()),
+            dto.getTestCase()
         );
     }
 

--- a/connect-library/src/main/java/com/tsanet/api/storage/CollaborationRequestRepository.java
+++ b/connect-library/src/main/java/com/tsanet/api/storage/CollaborationRequestRepository.java
@@ -28,8 +28,9 @@ public class CollaborationRequestRepository {
             """
             INSERT INTO collaboration_request (
                 id, status, summary, submit_company_name, submit_company_id,
-                receive_company_name, receive_company_id, token, created_at, updated_at, fetched_at
-            ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+                receive_company_name, receive_company_id, token, created_at, updated_at,
+                test_case, fetched_at
+            ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
             ON CONFLICT(id) DO UPDATE SET
                 status = excluded.status,
                 summary = excluded.summary,
@@ -40,6 +41,7 @@ public class CollaborationRequestRepository {
                 token = excluded.token,
                 created_at = excluded.created_at,
                 updated_at = excluded.updated_at,
+                test_case = excluded.test_case,
                 fetched_at = excluded.fetched_at
             """,
             requests,
@@ -55,7 +57,8 @@ public class CollaborationRequestRepository {
                 ps.setString(8, request.token());
                 ps.setString(9, request.createdAt());
                 ps.setString(10, request.updatedAt());
-                ps.setString(11, fetchedAt);
+                ps.setObject(11, toStoredBoolean(request.testCase()));
+                ps.setString(12, fetchedAt);
             }
         );
     }
@@ -64,7 +67,8 @@ public class CollaborationRequestRepository {
         return jdbcTemplate.query(
             """
             SELECT id, status, summary, submit_company_name, submit_company_id,
-                   receive_company_name, receive_company_id, token, created_at, updated_at
+                   receive_company_name, receive_company_id, token, created_at, updated_at,
+                   test_case
             FROM collaboration_request
             ORDER BY id
             """,
@@ -76,7 +80,8 @@ public class CollaborationRequestRepository {
         return jdbcTemplate.query(
             """
             SELECT id, status, summary, submit_company_name, submit_company_id,
-                   receive_company_name, receive_company_id, token, created_at, updated_at
+                   receive_company_name, receive_company_id, token, created_at, updated_at,
+                   test_case
             FROM collaboration_request
             WHERE submit_company_id = ? OR receive_company_id = ?
             ORDER BY id
@@ -98,7 +103,19 @@ public class CollaborationRequestRepository {
             rs.getObject("receive_company_id", Long.class),
             rs.getString("token"),
             rs.getString("created_at"),
-            rs.getString("updated_at")
+            rs.getString("updated_at"),
+            readStoredBoolean(rs, "test_case")
         );
+    }
+
+    private static Integer toStoredBoolean(Boolean value) {
+        return value == null ? null : (value ? 1 : 0);
+    }
+
+    // The SQLite driver's typed getObject(col, Integer.class) throws on NULL, so read
+    // the JDBC-1 way: primitive get plus wasNull.
+    private static Boolean readStoredBoolean(ResultSet rs, String column) throws SQLException {
+        int raw = rs.getInt(column);
+        return rs.wasNull() ? null : raw != 0;
     }
 }

--- a/connect-library/src/main/java/com/tsanet/api/storage/DatabaseInitializer.java
+++ b/connect-library/src/main/java/com/tsanet/api/storage/DatabaseInitializer.java
@@ -15,6 +15,7 @@ public final class DatabaseInitializer {
             token TEXT NOT NULL UNIQUE,
             created_at TEXT,
             updated_at TEXT,
+            test_case INTEGER,
             fetched_at TEXT NOT NULL
         )
         """;
@@ -151,6 +152,7 @@ public final class DatabaseInitializer {
 
     public static void createSchema(JdbcTemplate jdbcTemplate) {
         jdbcTemplate.execute(COLLABORATION_REQUEST_TABLE);
+        ensureColumn(jdbcTemplate, "collaboration_request", "test_case", "INTEGER");
         jdbcTemplate.execute(CASE_NOTE_TABLE);
         jdbcTemplate.execute(CASE_RESPONSE_TABLE);
         jdbcTemplate.execute(USER_CONTEXT_TABLE);

--- a/connect-library/src/test/java/com/tsanet/api/storage/CollaborationRequestRepositoryTest.java
+++ b/connect-library/src/test/java/com/tsanet/api/storage/CollaborationRequestRepositoryTest.java
@@ -60,4 +60,71 @@ class CollaborationRequestRepositoryTest {
             .extracting(CollaborationRequestStatusDto::status, CollaborationRequestStatusDto::summary)
             .containsExactly("CLOSED", "New");
     }
+
+    @Test
+    void itRoundTripsTestCaseThroughTheCache() {
+        repository.saveAll(
+            List.of(
+                new CollaborationRequestStatusDto(1L, "OPEN", "Real", "Acme", 1L, "Beta", 2L, "tok1", null, null, false),
+                new CollaborationRequestStatusDto(2L, "OPEN", "Test", "Acme", 1L, "Beta", 2L, "tok2", null, null, true)
+            )
+        );
+
+        assertThat(repository.findAll())
+            .extracting(CollaborationRequestStatusDto::id, CollaborationRequestStatusDto::testCase)
+            .containsExactly(
+                org.assertj.core.groups.Tuple.tuple(1L, Boolean.FALSE),
+                org.assertj.core.groups.Tuple.tuple(2L, Boolean.TRUE)
+            );
+    }
+
+    /**
+     * The DDL below is a FROZEN copy of collaboration_request as it existed before the
+     * test_case column, on purpose: deriving it from current constants would make this
+     * test pass by construction. It proves the two claims an upgrade rests on:
+     * createSchema adds the column to a pre-existing database (CREATE TABLE IF NOT
+     * EXISTS alone is a no-op there), and the upsert's UPDATE arm populates test_case
+     * on a refreshed pre-upgrade row rather than leaving it null forever.
+     */
+    @Test
+    void itUpgradesAPreExistingDatabaseAndBackfillsTestCaseOnRefresh() {
+        SQLiteDataSource dataSource = new SQLiteDataSource();
+        dataSource.setUrl("jdbc:sqlite:file:target/test-collaboration-request-upgrade-" + System.nanoTime() + ".db");
+        JdbcTemplate jdbcTemplate = new JdbcTemplate(dataSource);
+        jdbcTemplate.execute("""
+            CREATE TABLE IF NOT EXISTS collaboration_request (
+                id INTEGER PRIMARY KEY,
+                status TEXT,
+                summary TEXT,
+                submit_company_name TEXT,
+                submit_company_id INTEGER,
+                receive_company_name TEXT,
+                receive_company_id INTEGER,
+                token TEXT NOT NULL UNIQUE,
+                created_at TEXT,
+                updated_at TEXT,
+                fetched_at TEXT NOT NULL
+            )
+            """);
+        jdbcTemplate.update(
+            "INSERT INTO collaboration_request (id, status, summary, submit_company_name, submit_company_id,"
+                + " receive_company_name, receive_company_id, token, created_at, updated_at, fetched_at)"
+                + " VALUES (1, 'OPEN', 'Old row', 'Acme', 1, 'Beta', 2, 'tok1', NULL, NULL, 'x'),"
+                + " (2, 'OPEN', 'Untouched old row', 'Acme', 1, 'Beta', 2, 'tok2', NULL, NULL, 'x')"
+        );
+
+        DatabaseInitializer.createSchema(jdbcTemplate);
+        CollaborationRequestRepository upgraded = new CollaborationRequestRepository(jdbcTemplate);
+
+        upgraded.saveAll(
+            List.of(new CollaborationRequestStatusDto(1L, "OPEN", "Old row", "Acme", 1L, "Beta", 2L, "tok1", null, null, true))
+        );
+
+        assertThat(upgraded.findAll())
+            .extracting(CollaborationRequestStatusDto::id, CollaborationRequestStatusDto::testCase)
+            .containsExactly(
+                org.assertj.core.groups.Tuple.tuple(1L, Boolean.TRUE),
+                org.assertj.core.groups.Tuple.tuple(2L, null)
+            );
+    }
 }


### PR DESCRIPTION
Implements #38: `testCase` now travels from the generated model through the facade DTO and round-trips the SQLite cache. Base is `oauth` for the same reason as #39. Closes #38.

## Design (two decisions for your sign-off)

1. **Record compatibility.** `CollaborationRequestStatusDto` gains `testCase` as an 11th component plus a `@Deprecated` 10-arg compatibility constructor that delegates null (null = unknown, never "real"). Chosen over a positional-only change because the record has ~42 call sites across three modules; the overload keeps every legacy site compiling and keeps each of the sibling condition-PRs' diffs to production code. All three production construction sites now use the 11-arg form; only tests ride the overload. The deprecation javadoc promises removal at the next release boundary, which naturally rides the first tagged release (alignment-agenda condition 2) - say the word if you want it tracked as its own issue.
2. **Refresh semantics: demote-to-unknown.** The upsert's `DO UPDATE SET` arm sets `test_case = excluded.test_case` unconditionally, so a refresh carrying null overwrites a known value back to "unknown". That is consistent with null-means-unknown, and it is last-write-wins like every other column; a `COALESCE` (sticky) variant would be a semantics change. Flagging it so the choice is yours, not implicit. In practice API rows always carry the flag, so null arrives only from pre-upgrade cache rows and legacy constructors.

## Migration behavior

The cache is a durable per-account SQLite file and `CREATE TABLE IF NOT EXISTS` is a no-op on it, so the column arrives via the repo's existing `ensureColumn` evolution mechanism (same pattern as `webhook_subscription.secret`). Existing rows read null until refetched; a refreshed row backfills. Physical column order differs between fresh (before `fetched_at`) and upgraded (appended) databases - verified no `SELECT *` or column-list-free access exists, everything names columns.

## Receipts

- Full reactor green: 119 tests (connect-library 83, integration-app 30, demo 6), zero failures - which is also the executable proof that all ~42 legacy call sites compile via the overload.
- **Red probe on the subtle half:** removing the `DO UPDATE SET test_case` arm fails exactly the frozen-DDL upgrade test (`failures=1`) - without that arm, a pre-upgrade row refreshed from the API keeps NULL forever, invisible to fresh-DB tests.
- The upgrade test's old DDL is a frozen verbatim copy of the pre-change `COLLABORATION_REQUEST_TABLE` (diffed against `origin/oauth`, normalized: identical) - deriving it from current constants would pass by construction.
- First test run caught a real defect: the SQLite driver's typed `getObject(col, Integer.class)` throws "Bad value for type Integer" on NULL; reads now use `getInt` + `wasNull()`.
- Non-test construction sites enumerated by command: exactly the three in this diff.

Sibling PR: #39 (jsr310). The write-side flag (#37) lands separately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
