### PR TITLE
Make the test flag a per-call parameter on the facade create API

### DIFF
--- a/TSANet-integration-app/src/main/java/com/tsanet/facade/cli/CreateRequestExecutor.java
+++ b/TSANet-integration-app/src/main/java/com/tsanet/facade/cli/CreateRequestExecutor.java
@@ -37,7 +37,8 @@ public class CreateRequestExecutor {
                 caseNumber,
                 summary,
                 description,
-                customFieldValues
+                customFieldValues,
+                true
             );
             CollaborationRequestPrinter.printList(cliRunContext, "Created collaboration request", List.of(created));
             System.out.println(EntityPrinter.info(

--- a/TSANet-integration-demo/src/main/java/com/tsanet/application/scenarios/AcmeCreateCollaborationRequestsScenario.java
+++ b/TSANet-integration-demo/src/main/java/com/tsanet/application/scenarios/AcmeCreateCollaborationRequestsScenario.java
@@ -124,7 +124,8 @@ public class AcmeCreateCollaborationRequestsScenario implements IntegrationScena
             BETA_COMPANY_ID,
             caseNumber,
             summary,
-            description
+            description,
+            true
         );
         existing.add(created);
         log.info("Created id={} status={} token={}", created.id(), created.status(), created.token());

--- a/connect-library/src/main/java/com/tsanet/api/facade/CollaborationRequestsFacade.java
+++ b/connect-library/src/main/java/com/tsanet/api/facade/CollaborationRequestsFacade.java
@@ -28,20 +28,66 @@ public interface CollaborationRequestsFacade {
 
     List<CollaborationRequestFormDto> listStoredFormsForDocument(long documentId);
 
+    /**
+     * @param testSubmission whether the case is created test-flagged. There is no
+     *     default on purpose: every case that is not test-flagged pages a real
+     *     engineer at a real partner, so the choice is made per call, deliberately.
+     */
     CollaborationRequestStatusDto createRequest(
         long receiverCompanyId,
         String caseNumber,
         String summary,
-        String description
+        String description,
+        boolean testSubmission
     );
 
+    /**
+     * @param testSubmission whether the case is created test-flagged. See
+     *     {@link #createRequest(long, String, String, String, boolean)}.
+     */
     CollaborationRequestStatusDto createRequest(
         CollaborationRequestFormTemplateDto formTemplate,
         String caseNumber,
         String summary,
         String description,
-        Map<Long, String> customFieldValues
+        Map<Long, String> customFieldValues,
+        boolean testSubmission
     );
+
+    /**
+     * Compatibility form from before the flag was per-call; keeps the pre-existing
+     * behavior of always creating a TEST submission.
+     *
+     * @deprecated pass {@code testSubmission} explicitly; scheduled for removal at
+     *     the next release boundary.
+     */
+    @Deprecated(forRemoval = true)
+    default CollaborationRequestStatusDto createRequest(
+        long receiverCompanyId,
+        String caseNumber,
+        String summary,
+        String description
+    ) {
+        return createRequest(receiverCompanyId, caseNumber, summary, description, true);
+    }
+
+    /**
+     * Compatibility form from before the flag was per-call; keeps the pre-existing
+     * behavior of always creating a TEST submission.
+     *
+     * @deprecated pass {@code testSubmission} explicitly; scheduled for removal at
+     *     the next release boundary.
+     */
+    @Deprecated(forRemoval = true)
+    default CollaborationRequestStatusDto createRequest(
+        CollaborationRequestFormTemplateDto formTemplate,
+        String caseNumber,
+        String summary,
+        String description,
+        Map<Long, String> customFieldValues
+    ) {
+        return createRequest(formTemplate, caseNumber, summary, description, customFieldValues, true);
+    }
 
     CollaborationRequestStatusDto fetchRequestByToken(String caseToken);
 

--- a/connect-library/src/main/java/com/tsanet/api/internal/DefaultTsaNetApiSession.java
+++ b/connect-library/src/main/java/com/tsanet/api/internal/DefaultTsaNetApiSession.java
@@ -308,10 +308,11 @@ final class DefaultTsaNetApiSession implements TsaNetApiSession, AuthFacade, Col
         long receiverCompanyId,
         String caseNumber,
         String summary,
-        String description
+        String description,
+        boolean testSubmission
     ) {
         CollaborationRequestFormTemplateDto template = getCreateFormByCompanyId(receiverCompanyId);
-        return createRequest(template, caseNumber, summary, description, Collections.emptyMap());
+        return createRequest(template, caseNumber, summary, description, Collections.emptyMap(), testSubmission);
     }
 
     @Override
@@ -320,7 +321,8 @@ final class DefaultTsaNetApiSession implements TsaNetApiSession, AuthFacade, Col
         String caseNumber,
         String summary,
         String description,
-        Map<Long, String> customFieldValues
+        Map<Long, String> customFieldValues,
+        boolean testSubmission
     ) {
         CollaborationRequestDTO form = formGateway.getFormByDocumentId(formTemplate.documentId());
         long storageCompanyId = formTemplate.receiverCompanyId() != null
@@ -333,7 +335,8 @@ final class DefaultTsaNetApiSession implements TsaNetApiSession, AuthFacade, Col
             caseNumber,
             summary,
             description,
-            customFieldValues
+            customFieldValues,
+            testSubmission
         );
     }
 
@@ -344,7 +347,8 @@ final class DefaultTsaNetApiSession implements TsaNetApiSession, AuthFacade, Col
         String caseNumber,
         String summary,
         String description,
-        Map<Long, String> customFieldValues
+        Map<Long, String> customFieldValues,
+        boolean testSubmission
     ) {
         storeFormMetadata(storageCompanyId, departmentId, form);
         FormTemplateMapper.applyCustomFieldValues(form, customFieldValues);
@@ -358,7 +362,7 @@ final class DefaultTsaNetApiSession implements TsaNetApiSession, AuthFacade, Col
         form.setInternalCaseNumber(caseNumber);
         form.setProblemSummary(summary);
         form.setProblemDescription(description);
-        form.setTestSubmission(true);
+        form.setTestSubmission(testSubmission);
         if (form.getPriority() == null) {
             form.setPriority(CasePriority.MEDIUM);
         }

--- a/connect-library/src/test/java/com/tsanet/api/internal/DefaultTsaNetApiSessionCreateRequestTest.java
+++ b/connect-library/src/test/java/com/tsanet/api/internal/DefaultTsaNetApiSessionCreateRequestTest.java
@@ -1,0 +1,121 @@
+package com.tsanet.api.internal;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyLong;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import com.tsanet.api.TsaNetApiConfiguration;
+import com.tsanet.api.connectapi.dto.CollaborationRequestStatusDto;
+import com.tsanet.api.connectapi.internal.ConnectApiAttachmentsGateway;
+import com.tsanet.api.connectapi.internal.ConnectApiAuthGateway;
+import com.tsanet.api.connectapi.internal.ConnectApiCollaborationGateway;
+import com.tsanet.api.connectapi.internal.ConnectApiFormGateway;
+import com.tsanet.api.connectapi.internal.ConnectApiNotesGateway;
+import com.tsanet.api.connectapi.internal.ConnectApiPartnersGateway;
+import com.tsanet.api.connectapi.internal.ConnectApiResponsesGateway;
+import com.tsanet.api.connectapi.internal.ConnectApiSessionStore;
+import com.tsanet.api.connectapi.internal.ConnectApiUserGateway;
+import com.tsanet.api.connectapi.internal.ConnectApiWebhooksGateway;
+import com.tsanet.api.connectapi.internal.TokenManager;
+import com.tsanet.api.generated.model.CollaborationRequestDTO;
+import com.tsanet.api.storage.AttachmentConfigStorageService;
+import com.tsanet.api.storage.AttachmentForwardResultStorageService;
+import com.tsanet.api.storage.CaseNoteStorageService;
+import com.tsanet.api.storage.CaseResponseStorageService;
+import com.tsanet.api.storage.CollaborationRequestFormStorageService;
+import com.tsanet.api.storage.CollaborationRequestStorageService;
+import com.tsanet.api.storage.PartnerSelectionStorageService;
+import com.tsanet.api.storage.UserContextStorageService;
+import com.tsanet.api.storage.WebhookInboundEventStorageService;
+import com.tsanet.api.storage.WebhookSubscriptionStorageService;
+import com.tsanet.api.connectapi.dto.CollaborationRequestFormTemplateDto;
+import java.util.Collections;
+import java.util.Map;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.mockito.ArgumentCaptor;
+
+/**
+ * The write-side test flag must reach the wire exactly as passed. Asserted on the
+ * form handed to the collaboration gateway because that IS the outgoing request
+ * body; the read-side name differs (testCase), which is why asserting the request
+ * object here is the strongest check available without a live round trip.
+ */
+class DefaultTsaNetApiSessionCreateRequestTest {
+
+    private ConnectApiCollaborationGateway collaborationGateway;
+    private ConnectApiFormGateway formGateway;
+    private DefaultTsaNetApiSession session;
+
+    @BeforeEach
+    void setUp() {
+        collaborationGateway = mock(ConnectApiCollaborationGateway.class);
+        formGateway = mock(ConnectApiFormGateway.class);
+        session = new DefaultTsaNetApiSession(
+            mock(TsaNetApiConfiguration.class),
+            mock(ConnectApiSessionStore.class),
+            mock(TokenManager.class),
+            mock(ConnectApiAuthGateway.class),
+            collaborationGateway,
+            formGateway,
+            mock(ConnectApiNotesGateway.class),
+            mock(ConnectApiResponsesGateway.class),
+            mock(ConnectApiUserGateway.class),
+            mock(ConnectApiWebhooksGateway.class),
+            mock(ConnectApiPartnersGateway.class),
+            mock(ConnectApiAttachmentsGateway.class),
+            mock(CollaborationRequestStorageService.class),
+            mock(CollaborationRequestFormStorageService.class),
+            mock(CaseNoteStorageService.class),
+            mock(CaseResponseStorageService.class),
+            mock(UserContextStorageService.class),
+            mock(WebhookSubscriptionStorageService.class),
+            mock(WebhookInboundEventStorageService.class),
+            mock(PartnerSelectionStorageService.class),
+            mock(AttachmentConfigStorageService.class),
+            mock(AttachmentForwardResultStorageService.class)
+        );
+
+        CollaborationRequestDTO form = new CollaborationRequestDTO();
+        form.setDocumentId(77L);
+        form.setCustomFields(Collections.emptyList());
+        when(formGateway.getFormByDocumentId(anyLong())).thenReturn(form);
+        when(collaborationGateway.createCollaborationRequest(any())).thenReturn(
+            new CollaborationRequestStatusDto(1L, "OPEN", "s", "A", 1L, "B", 2L, "tok", null, null)
+        );
+    }
+
+    private CollaborationRequestFormTemplateDto template() {
+        return new CollaborationRequestFormTemplateDto(77L, 5L, null, Collections.emptyList());
+    }
+
+    @Test
+    void itSendsFalseWhenAProductionConsumerPassesFalse() {
+        session.createRequest(template(), "CASE-1", "s", "d", Map.of(), false);
+
+        assertThat(capturedForm().getTestSubmission()).isFalse();
+    }
+
+    @Test
+    void itSendsTrueWhenPassedTrue() {
+        session.createRequest(template(), "CASE-1", "s", "d", Map.of(), true);
+
+        assertThat(capturedForm().getTestSubmission()).isTrue();
+    }
+
+    @Test
+    void theDeprecatedOverloadKeepsTheOldAlwaysTestBehavior() {
+        session.createRequest(template(), "CASE-1", "s", "d", Map.of());
+
+        assertThat(capturedForm().getTestSubmission()).isTrue();
+    }
+
+    private CollaborationRequestDTO capturedForm() {
+        ArgumentCaptor<CollaborationRequestDTO> captor = ArgumentCaptor.forClass(CollaborationRequestDTO.class);
+        verify(collaborationGateway).createCollaborationRequest(captor.capture());
+        return captor.getValue();
+    }
+}


### PR DESCRIPTION
Implements #37: the test flag becomes a per-call parameter on the facade create API, replacing the hardcoded `form.setTestSubmission(true)` that made every facade-created case a test submission. Base is `oauth`, same as #39/#40. Closes #37.

## Design

- Both `createRequest` signatures on `CollaborationRequestsFacade` gain `boolean testSubmission` with **no default**: every case that is not test-flagged pages a real engineer at a real partner, so the choice is per-call and deliberate (the issue's stated preference).
- The old signatures remain as `@Deprecated(forRemoval = true)` default methods delegating `true` - the pre-existing always-test behavior, preserved loudly. External consumers (`shawn-tsanet/connect-sdk-demo`) keep compiling; their migration to explicit `true` is the named follow-up, and the removal rides the first tagged release (alignment-agenda condition 2), same schedule as #40's DTO compat constructor.
- Both in-repo callers (CLI `CreateRequestExecutor`, demo Acme scenario) now pass `true` explicitly - zero behavior change. Whether the CLI should grow a production flag (`--production`?) is deliberately NOT in this PR - your call on whether that is wanted at all.

## Receipts

- Full reactor 120 tests green (connect-library 84 incl. 3 new, integration-app 30, demo 6).
- **The flag is asserted on the outgoing wire form** (captured gateway argument), not on a request object proxy: `false` reaches the wire, `true` reaches the wire, and the deprecated overload still sends `true`. Read-back through `testCase` (the read-side name) requires #40's facade change, so the wire-form capture is the strongest check available here; noted rather than stubbed.
- Red probe: re-hardcoding `true` fails exactly `itSendsFalseWhenAProductionConsumerPassesFalse` (Failures: 1), then restored to green.
- Old-decision sweep: `setTestSubmission` appears exactly once in non-generated code (the parameterized line). Caller sweep: both real call sites updated; remaining grep hits are javadoc. Implementor sweep: `DefaultTsaNetApiSession` is the interface's only implementor, and the reactor compile is the mechanical proof the new abstract methods are fully implemented.
- Untested compat path, named: the 4-arg deprecated overload (by receiverCompanyId) has no dedicated test - it routes through `getCreateFormByCompanyId`, which needs materially more mocking; the 5-arg overload test covers the delegation pattern.

Siblings: #39 (jsr310), #40 (testCase read side). Together they close the write/read asymmetry end to end: a consumer can create a real case and can tell it apart afterwards.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
