### PR TITLE
README: document the sibling-spec build requirement and branch state

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,42 @@
-Demonstration of Integration with TSANet API - In Java
+# Connect_SDK
+
+Demonstration of Integration with TSANet API - In Java.
+
+Modules: `connect-library` (the Java client for the TSANet Connect API),
+`TSANet-integration-app` (console app), `TSANet-integration-demo` (demo scenarios).
+
+## Building
+
+The client code in `connect-library` is generated from the Connect API's OpenAPI
+specification at build time, and the build reads that specification from a **sibling
+clone** of `tsanetgit/Connect-API-Code` (the `connect.openapi.spec` property in the
+root pom resolves to `../Connect-API-Code/connect-core-api/src/main/resources/openapi.yaml`).
+A clone of this repository alone does not build.
+
+The working steps, in order:
+
+1. Clone `tsanetgit/Connect-API-Code` beside this repository (the directory must be
+   named `Connect-API-Code`) and check out the `beta` branch. The generated symbols
+   depend on which specification the sibling provides, so the branch matters.
+2. In this repository, check out the commit you are building (see the branch notes
+   below).
+3. `mvn install` from the root, or `mvn -pl connect-library -am install` for the
+   library alone. JDK 21.
+
+## Branch notes: what builds today
+
+- **`oauth` at `0f57facd3326` builds against the beta specification and passes the
+  live BETA contract suite.** This is the commit the Connect Gateway's `v0.1.0`
+  certifies against, and the pin to use until `oauth` merges and a release is
+  tagged.
+- **`main` at `332e5c7` does not compile against the beta specification**:
+  `ConnectApiWebhooksGateway` references generated symbols that specification does
+  not produce (cannot-find-symbol at its webhook-gateway call sites), because that
+  code tracks a newer specification than the sibling's `beta` branch carries. This
+  is a known condition on the release path, not a local setup problem; do not
+  debug your environment over it.
+
+An alternative to the sibling clone, for consumers who need a hermetic build, is
+vendoring the specification into the repository and pointing `connect.openapi.spec`
+at the vendored file (the pattern the Fin adapter uses). That is a maintainer
+decision and is deliberately not part of this document.


### PR DESCRIPTION
The README was one line, and the build's hardest fact was recorded nowhere: codegen reads the Connect OpenAPI spec from a sibling clone of `Connect-API-Code`, so a lone clone of this repository does not build, and the sibling's checked-out branch decides which symbols get generated. Alignment-agenda conditions 4 and 6.

Every documented step was run before being written, today:

- Sibling on `beta` + this repo at `0f57facd3326`: `mvn install` green, and that stack passes the live BETA contract suite (the Connect_Gateway `v0.1.0` certification pin).
- Same sibling + `main` at `332e5c7`: compile FAILS with cannot-find-symbol in `ConnectApiWebhooksGateway` (three sites) - documented as a known release-path condition so nobody debugs their environment over it.
- The `connect.openapi.spec` path quoted in the README was checked against the root pom on both `main` and `oauth` (`pom.xml:31`, identical) - the pre-PR gate flagged this as its one confirm-before-merge item; confirmed.

Deliberately NOT in this PR: vendoring the spec (surfaced as a maintainer option). One consequence worth deciding at the alignment session: `Connect-API-Code` is private, so an external engineer building this library from source needs either access to it, a vendored spec, or a published artifact - the sibling requirement is an access question, not just a build step.

Siblings: #39 (jsr310), #40 (testCase), #41 (per-call test flag).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
