### PR TITLE
Merge the oauth branch: OAuth client-credentials auth plus the facade and packaging work

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,0 +1,105 @@
+name: publish
+
+# A published GitHub Release is what cuts a version, deliberately rather than on
+# every push: consumers pin a version, so a library change reaches them only when
+# someone decides it should. Same pattern as Connect_Gateway's connector-core
+# publish. Publishes the root pom (connect-library's parent, which consumers must
+# be able to resolve) and connect-library ONLY; the app and demo modules are
+# never published.
+on:
+  release:
+    types: [published]
+  workflow_dispatch:
+    inputs:
+      version:
+        description: "Version to publish (e.g. 0.1.0; a leading v is tolerated)"
+        required: true
+
+permissions:
+  contents: read
+  packages: write
+
+jobs:
+  publish:
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+    steps:
+      # connect-library's codegen reads the Connect OpenAPI spec from a sibling
+      # checkout of Connect-API-Code (the connect.openapi.spec property), which is
+      # a PRIVATE repository, so this checkout needs a token with read access to
+      # it. If the secret is missing, FAIL LOUDLY rather than skip: a green
+      # publish run that shipped no artifact is the skip-reads-as-success trap
+      # Fin-Intercom_App's CI documented after living it. The two checkout paths
+      # below place the repos as siblings, which is the layout the pom expects.
+      - name: Require the spec-repo token
+        env:
+          HAVE_TOKEN: ${{ secrets.CONNECT_API_CODE_TOKEN != '' }}
+        run: |
+          set -euo pipefail
+          if [ "$HAVE_TOKEN" != "true" ]; then
+            echo "::error::The CONNECT_API_CODE_TOKEN secret is not configured. Publishing builds connect-library from the Connect-API-Code spec (a private repo), so a read token for it is required. Configure the secret and re-run."
+            exit 1
+          fi
+
+      - uses: actions/checkout@v4
+        with:
+          path: Connect_SDK
+          persist-credentials: false
+
+      - uses: actions/checkout@v4
+        with:
+          repository: tsanetgit/Connect-API-Code
+          ref: beta
+          token: ${{ secrets.CONNECT_API_CODE_TOKEN }}
+          path: Connect-API-Code
+          persist-credentials: false
+
+      - uses: actions/setup-java@v4
+        with:
+          distribution: temurin
+          java-version: "21"
+          cache: maven
+          # Writes the ~/.m2/settings.xml server entry that the root pom's
+          # distributionManagement <id>github</id> resolves against.
+          server-id: github
+          server-username: MAVEN_USERNAME
+          server-password: MAVEN_TOKEN
+
+      - name: Resolve the version to publish
+        id: v
+        env:
+          EVENT: ${{ github.event_name }}
+          TAG: ${{ github.ref_name }}
+          INPUT: ${{ inputs.version }}
+        run: |
+          set -euo pipefail
+          if [ "$EVENT" = "release" ]; then V="${TAG#v}"; else V="${INPUT#v}"; fi
+
+          # Refuse a SNAPSHOT: a consumer pinned to a SNAPSHOT is pinned to
+          # nothing, which reintroduces the silent drift publishing removes.
+          case "$V" in
+            *-SNAPSHOT) echo "::error::Refusing to publish a SNAPSHOT ($V)."; exit 1 ;;
+          esac
+          if ! printf '%s' "$V" | grep -qE '^[0-9]+\.[0-9]+\.[0-9]+$'; then
+            echo "::error::Version '$V' is not x.y.z."; exit 1
+          fi
+          echo "version=$V" >> "$GITHUB_OUTPUT"
+          echo "publishing $V"
+
+      - name: Set the project version
+        working-directory: Connect_SDK
+        run: |
+          mvn -B --no-transfer-progress versions:set \
+            -DnewVersion="${{ steps.v.outputs.version }}" -DgenerateBackupPoms=false
+
+      # `deploy` runs the full lifecycle, so connect-library's tests gate the
+      # release: a broken client cannot be published. Reactor selection publishes
+      # the parent pom and the library only.
+      - name: Build, test and publish connect-library
+        working-directory: Connect_SDK
+        env:
+          MAVEN_USERNAME: ${{ github.actor }}
+          MAVEN_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        # -Dmaven.deploy.skip=false arms the deploy that the root pom disarms by
+        # default, so this workflow is the only path that publishes.
+        run: mvn -B --no-transfer-progress -pl .,connect-library deploy -Dmaven.deploy.skip=false

--- a/README.md
+++ b/README.md
@@ -1,1 +1,42 @@
-Demonstration of Integration with TSANet API - In Java
+# Connect_SDK
+
+Demonstration of Integration with TSANet API - In Java.
+
+Modules: `connect-library` (the Java client for the TSANet Connect API),
+`TSANet-integration-app` (console app), `TSANet-integration-demo` (demo scenarios).
+
+## Building
+
+The client code in `connect-library` is generated from the Connect API's OpenAPI
+specification at build time, and the build reads that specification from a **sibling
+clone** of `tsanetgit/Connect-API-Code` (the `connect.openapi.spec` property in the
+root pom resolves to `../Connect-API-Code/connect-core-api/src/main/resources/openapi.yaml`).
+A clone of this repository alone does not build.
+
+The working steps, in order:
+
+1. Clone `tsanetgit/Connect-API-Code` beside this repository (the directory must be
+   named `Connect-API-Code`) and check out the `beta` branch. The generated symbols
+   depend on which specification the sibling provides, so the branch matters.
+2. In this repository, check out the commit you are building (see the branch notes
+   below).
+3. `mvn install` from the root, or `mvn -pl connect-library -am install` for the
+   library alone. JDK 21.
+
+## Branch notes: what builds today
+
+- **`oauth` at `0f57facd3326` builds against the beta specification and passes the
+  live BETA contract suite.** This is the commit the Connect Gateway's `v0.1.0`
+  certifies against, and the pin to use until `oauth` merges and a release is
+  tagged.
+- **`main` at `332e5c7` does not compile against the beta specification**:
+  `ConnectApiWebhooksGateway` references generated symbols that specification does
+  not produce (cannot-find-symbol at its webhook-gateway call sites), because that
+  code tracks a newer specification than the sibling's `beta` branch carries. This
+  is a known condition on the release path, not a local setup problem; do not
+  debug your environment over it.
+
+An alternative to the sibling clone, for consumers who need a hermetic build, is
+vendoring the specification into the repository and pointing `connect.openapi.spec`
+at the vendored file (the pattern the Fin adapter uses). That is a maintainer
+decision and is deliberately not part of this document.

--- a/TSANet-integration-app/src/main/java/com/tsanet/facade/cli/CreateRequestExecutor.java
+++ b/TSANet-integration-app/src/main/java/com/tsanet/facade/cli/CreateRequestExecutor.java
@@ -37,7 +37,8 @@ public class CreateRequestExecutor {
                 caseNumber,
                 summary,
                 description,
-                customFieldValues
+                customFieldValues,
+                true
             );
             CollaborationRequestPrinter.printList(cliRunContext, "Created collaboration request", List.of(created));
             System.out.println(EntityPrinter.info(

--- a/TSANet-integration-app/src/main/java/com/tsanet/facade/cli/commands/SessionStatusCommand.java
+++ b/TSANet-integration-app/src/main/java/com/tsanet/facade/cli/commands/SessionStatusCommand.java
@@ -7,7 +7,9 @@ import static com.tsanet.facade.cli.TerminalColors.YELLOW;
 
 import com.tsanet.facade.cli.CliRunContext;
 import com.tsanet.api.TsaNetApiSession;
+import com.tsanet.api.auth.AuthMode;
 import com.tsanet.api.session.AccountSessionView;
+import java.time.Instant;
 import java.util.Scanner;
 import org.springframework.stereotype.Component;
 
@@ -36,6 +38,9 @@ public class SessionStatusCommand implements Command {
         if (session.auth().isAuthorized()) {
             String username = session.auth().currentUsername().orElse("unknown");
             println(GREEN, "Logged in as: " + username);
+            session.auth().authMode().ifPresent(mode -> printAuthMode(mode));
+            session.auth().currentAccountId().ifPresent(accountId -> printLine("Account id: " + accountId));
+            session.auth().tokenExpiresAt().ifPresent(this::printTokenExpiry);
             if (session instanceof AccountSessionView accountSession) {
                 accountSession.activeAccountLabel().ifPresent(label -> {
                     if (!cliRunContext.isPlainOutput()) {
@@ -72,6 +77,30 @@ public class SessionStatusCommand implements Command {
         if (cliRunContext.isPlainOutput()) {
             System.out.println("authorized: false");
         }
+    }
+
+    private void printAuthMode(AuthMode mode) {
+        if (cliRunContext.isPlainOutput()) {
+            System.out.println("authMode: " + mode);
+            return;
+        }
+        System.out.println(BLUE + "Auth mode: " + mode + RESET);
+    }
+
+    private void printTokenExpiry(Instant expiresAt) {
+        if (cliRunContext.isPlainOutput()) {
+            System.out.println("tokenExpiresAt: " + expiresAt);
+            return;
+        }
+        System.out.println(BLUE + "Token expires: " + expiresAt + RESET);
+    }
+
+    private void printLine(String message) {
+        if (cliRunContext.isPlainOutput()) {
+            System.out.println(message);
+            return;
+        }
+        System.out.println(BLUE + message + RESET);
     }
 
     private void println(String color, String message) {

--- a/TSANet-integration-app/src/main/java/com/tsanet/facade/config/ConnectFacadeProperties.java
+++ b/TSANet-integration-app/src/main/java/com/tsanet/facade/config/ConnectFacadeProperties.java
@@ -1,6 +1,7 @@
 package com.tsanet.facade.config;
 
 import com.tsanet.api.ApplicationUserAccount;
+import com.tsanet.api.ApplicationUserAccountConfigMapper;
 import com.tsanet.api.ApplicationUserAccountRegistry;
 import java.util.List;
 import org.springframework.boot.context.properties.ConfigurationProperties;
@@ -24,20 +25,50 @@ public record ConnectFacadeProperties(
     public record Storage(String sqlitePath) {
     }
 
-    public record ApplicationUserAccountConfig(String id, String username, String password, String sqlitePath) {
+    public record ApplicationUserAccountConfig(
+        String id,
+        String sqlitePath,
+        String username,
+        String password,
+        AccountAuthProperties auth
+    ) {
+        public ApplicationUserAccount toAccount() {
+            if (auth != null) {
+                return ApplicationUserAccountConfigMapper.fromAuthType(
+                    id,
+                    sqlitePath,
+                    auth.type(),
+                    auth.username() != null ? auth.username() : username,
+                    auth.password() != null ? auth.password() : password,
+                    auth.tenantId(),
+                    auth.tokenUrl(),
+                    auth.clientId(),
+                    auth.clientSecret(),
+                    auth.audience(),
+                    auth.scope()
+                );
+            }
+            return ApplicationUserAccountConfigMapper.fromLegacyFields(id, sqlitePath, username, password);
+        }
+    }
+
+    public record AccountAuthProperties(
+        String type,
+        String username,
+        String password,
+        String tenantId,
+        String tokenUrl,
+        String clientId,
+        String clientSecret,
+        String audience,
+        String scope
+    ) {
     }
 
     public ApplicationUserAccountRegistry toAccountRegistry() {
         if (accounts != null && !accounts.isEmpty()) {
             return ApplicationUserAccountRegistry.of(
-                accounts.stream()
-                    .map(account -> new ApplicationUserAccount(
-                        account.id(),
-                        account.username(),
-                        account.password(),
-                        account.sqlitePath()
-                    ))
-                    .toList()
+                accounts.stream().map(ApplicationUserAccountConfig::toAccount).toList()
             );
         }
         if (auth != null && auth.isConfigured() && storage != null && storage.sqlitePath() != null) {

--- a/TSANet-integration-demo/src/main/java/com/tsanet/application/config/TsaNetApplicationProperties.java
+++ b/TSANet-integration-demo/src/main/java/com/tsanet/application/config/TsaNetApplicationProperties.java
@@ -1,6 +1,7 @@
 package com.tsanet.application.config;
 
 import com.tsanet.api.ApplicationUserAccount;
+import com.tsanet.api.ApplicationUserAccountConfigMapper;
 import com.tsanet.api.ApplicationUserAccountRegistry;
 import java.util.List;
 import org.springframework.boot.context.properties.ConfigurationProperties;
@@ -24,20 +25,50 @@ public record TsaNetApplicationProperties(
     public record Storage(String sqlitePath) {
     }
 
-    public record ApplicationUserAccountConfig(String id, String username, String password, String sqlitePath) {
+    public record ApplicationUserAccountConfig(
+        String id,
+        String sqlitePath,
+        String username,
+        String password,
+        AccountAuthProperties auth
+    ) {
+        public ApplicationUserAccount toAccount() {
+            if (auth != null) {
+                return ApplicationUserAccountConfigMapper.fromAuthType(
+                    id,
+                    sqlitePath,
+                    auth.type(),
+                    auth.username() != null ? auth.username() : username,
+                    auth.password() != null ? auth.password() : password,
+                    auth.tenantId(),
+                    auth.tokenUrl(),
+                    auth.clientId(),
+                    auth.clientSecret(),
+                    auth.audience(),
+                    auth.scope()
+                );
+            }
+            return ApplicationUserAccountConfigMapper.fromLegacyFields(id, sqlitePath, username, password);
+        }
+    }
+
+    public record AccountAuthProperties(
+        String type,
+        String username,
+        String password,
+        String tenantId,
+        String tokenUrl,
+        String clientId,
+        String clientSecret,
+        String audience,
+        String scope
+    ) {
     }
 
     public ApplicationUserAccountRegistry toAccountRegistry() {
         if (accounts != null && !accounts.isEmpty()) {
             return ApplicationUserAccountRegistry.of(
-                accounts.stream()
-                    .map(account -> new ApplicationUserAccount(
-                        account.id(),
-                        account.username(),
-                        account.password(),
-                        account.sqlitePath()
-                    ))
-                    .toList()
+                accounts.stream().map(ApplicationUserAccountConfig::toAccount).toList()
             );
         }
         if (auth != null && auth.isConfigured() && storage != null && storage.sqlitePath() != null) {

--- a/TSANet-integration-demo/src/main/java/com/tsanet/application/scenarios/AcmeCreateCollaborationRequestsScenario.java
+++ b/TSANet-integration-demo/src/main/java/com/tsanet/application/scenarios/AcmeCreateCollaborationRequestsScenario.java
@@ -124,7 +124,8 @@ public class AcmeCreateCollaborationRequestsScenario implements IntegrationScena
             BETA_COMPANY_ID,
             caseNumber,
             summary,
-            description
+            description,
+            true
         );
         existing.add(created);
         log.info("Created id={} status={} token={}", created.id(), created.status(), created.token());

--- a/TSANet-integration-demo/src/main/java/com/tsanet/application/sync/ConnectApiPollingCoordinator.java
+++ b/TSANet-integration-demo/src/main/java/com/tsanet/application/sync/ConnectApiPollingCoordinator.java
@@ -36,7 +36,7 @@ public class ConnectApiPollingCoordinator {
     public void pollConfiguredAccounts() {
         List<ApplicationUserAccount> accounts = PollingAccountRegistry.resolve(accountRegistry);
         if (accounts.isEmpty()) {
-            log.warn("Polling skipped: configure tsaet.accounts in application.yml");
+            log.warn("Polling skipped: configure tsanet.accounts in application.yml");
             return;
         }
 
@@ -58,18 +58,13 @@ public class ConnectApiPollingCoordinator {
 
     private CommunicationSyncSnapshot pollAccount(ApplicationUserAccount account) {
         try {
-            String password = requirePassword(account);
-            TsaNetApiSession session = sessionFactory.openSessionWithSqlitePath(
-                account.sqlitePath(),
-                account.username(),
-                password
-            );
-            session.auth().login(account.username(), password);
+            TsaNetApiSession session = sessionFactory.openSessionForApplicationUser(account);
+            session.auth().authenticate();
             CommunicationSyncSnapshot snapshot = session.collaborationRequests().syncCommunicationContext();
             log.info(
                 "Polled application user {} ({}, sqlite={}): {}",
                 account.id(),
-                account.username(),
+                account.usernameForDisplay(),
                 account.sqlitePath(),
                 snapshot.summarize()
             );
@@ -78,12 +73,5 @@ public class ConnectApiPollingCoordinator {
             log.error("Polling failed for application user {}: {}", account.id(), ex.getMessage());
             return new CommunicationSyncSnapshot(0, 0, 0, 0, 0, false);
         }
-    }
-
-    private static String requirePassword(ApplicationUserAccount account) {
-        if (account.password() == null || account.password().isBlank()) {
-            throw new IllegalStateException("Password is required for application user '" + account.id() + "'");
-        }
-        return account.password();
     }
 }

--- a/TSANet-integration-demo/src/test/java/com/tsanet/application/sync/PollingAccountRegistryTest.java
+++ b/TSANet-integration-demo/src/test/java/com/tsanet/application/sync/PollingAccountRegistryTest.java
@@ -4,16 +4,15 @@ import static org.assertj.core.api.Assertions.assertThat;
 
 import com.tsanet.api.ApplicationUserAccount;
 import com.tsanet.api.ApplicationUserAccountRegistry;
-import java.util.List;
 import org.junit.jupiter.api.Test;
 
 class PollingAccountRegistryTest {
     @Test
-    void itReturnsConfiguredApplicationUsers() {
+    void itReturnsAllConfiguredAccounts() {
         ApplicationUserAccountRegistry registry = ApplicationUserAccountRegistry.of(
-            List.of(
-                new ApplicationUserAccount("acme", "api@appko.com", "pass-a", "/tmp/acme.db"),
-                new ApplicationUserAccount("beta", "beta@corp.com", "pass-b", "/tmp/beta.db")
+            java.util.List.of(
+                ApplicationUserAccount.passwordAccount("acme", "/tmp/acme.db", "api@appko.com", "pass-a"),
+                ApplicationUserAccount.passwordAccount("beta", "/tmp/beta.db", "beta@corp.com", "pass-b")
             )
         );
 

--- a/connect-library/README.md
+++ b/connect-library/README.md
@@ -101,18 +101,70 @@ session.partners();
 session.attachments();
 ```
 
-Unless noted, remote operations require a prior successful `login()`. Unauthenticated calls throw `IllegalStateException: Not logged in`.
+Unless noted, remote operations require a prior successful `authenticate()` or `login()`. Unauthenticated calls throw `IllegalStateException: Not logged in`.
 
 ### Auth — `session.auth()`
 
 | Method | Description |
 |--------|-------------|
-| `login(username, password)` | Authenticates against Connect API and stores the bearer token in the session. Returns the JWT. |
-| `loginWithConfiguredCredentials()` | Logs in using `username` / `password` from `TsaNetApiConfiguration`. |
-| `isAuthorized()` | `true` when a bearer token is present in the session. |
+| `authenticate()` | Uses configured auth: Azure AD client-credentials for production accounts, or Connect1 password when configured. Refreshes OAuth tokens proactively before expiry. |
+| `login(username, password)` | Connect1 username/password login. Only available when the session is configured for `connect1-password` auth. |
+| `loginWithConfiguredCredentials()` | Alias for `authenticate()`. |
+| `isAuthorized()` | `true` when a valid bearer token is present in the session. |
 | `currentUsername()` | Username from the last successful login, if any. |
+| `currentAccountId()` | Application user id for OAuth sessions. |
+| `authMode()` | `CLIENT_CREDENTIALS` or `CONNECT1_PASSWORD`. |
+| `tokenExpiresAt()` | OAuth token expiry (OAuth sessions only). |
 | `currentBearerToken()` | Current JWT, if any. |
 | `logout()` | Clears in-memory session state (token and username). Does not delete SQLite data. |
+
+#### OAuth client-credentials (Azure AD M2M)
+
+```java
+import com.tsanet.api.ApplicationUserAccount;
+import com.tsanet.api.ApplicationUserAccountConfigMapper;
+import com.tsanet.api.TsaNetApiConfiguration;
+
+ApplicationUserAccount account = ApplicationUserAccountConfigMapper.clientCredentialsAccount(
+    "production",
+    System.getProperty("user.home") + "/.tsanet/production.db",
+    "your-tenant-id",
+    null,
+    "your-client-id",
+    System.getenv("TSANET_CLIENT_SECRET"),
+    "api://your-connect-api-audience",
+    null
+);
+
+TsaNetApiSession session = TsaNetApi.sessionFactory(
+    TsaNetApiConnectionSettings.of("https://connect.example.com", account.sqlitePath())
+).openSessionForApplicationUser(account);
+
+session.auth().authenticate();
+```
+
+Spring Boot apps can configure accounts in `application.yml`:
+
+```yaml
+tsanet:
+  accounts:
+    - id: production
+      sqlite-path: "${user.home}/.tsanet/production.db"
+      auth:
+        type: client-credentials
+        tenant-id: "..."
+        client-id: "..."
+        client-secret: "${TSANET_CLIENT_SECRET}"
+        audience: "api://..."
+    - id: local-dev
+      sqlite-path: "${user.home}/.tsanet/local.db"
+      auth:
+        type: connect1-password
+        username: "api@appko.com"
+        password: "..."
+```
+
+Legacy top-level `username` / `password` on an account entry still map to `connect1-password`.
 
 ### Collaboration requests — `session.collaborationRequests()`
 

--- a/connect-library/pom.xml
+++ b/connect-library/pom.xml
@@ -32,6 +32,14 @@
             <artifactId>jackson-databind</artifactId>
         </dependency>
         <dependency>
+            <!-- The client relies on findAndRegisterModules(); outside Spring Boot nothing
+                 else puts the java.time module on the classpath, and date serialization
+                 fails with InvalidDefinitionException. Declared here so every consumer
+                 gets it, not only Boot apps. -->
+            <groupId>com.fasterxml.jackson.datatype</groupId>
+            <artifactId>jackson-datatype-jsr310</artifactId>
+        </dependency>
+        <dependency>
             <groupId>org.springframework</groupId>
             <artifactId>spring-jdbc</artifactId>
         </dependency>

--- a/connect-library/src/main/java/com/tsanet/api/ApplicationUserAccount.java
+++ b/connect-library/src/main/java/com/tsanet/api/ApplicationUserAccount.java
@@ -1,15 +1,44 @@
 package com.tsanet.api;
 
-public record ApplicationUserAccount(String id, String username, String password, String sqlitePath) {
+import com.tsanet.api.auth.AccountAuthConfig;
+import com.tsanet.api.auth.PasswordAuthConfig;
+import java.util.Optional;
+
+public record ApplicationUserAccount(String id, String sqlitePath, AccountAuthConfig auth) {
     public ApplicationUserAccount {
         if (id == null || id.isBlank()) {
             throw new IllegalArgumentException("account id is required");
         }
-        if (username == null || username.isBlank()) {
-            throw new IllegalArgumentException("account username is required");
-        }
         if (sqlitePath == null || sqlitePath.isBlank()) {
             throw new IllegalArgumentException("account sqlitePath is required");
         }
+        if (auth == null) {
+            throw new IllegalArgumentException("account auth is required");
+        }
+    }
+
+    public static ApplicationUserAccount passwordAccount(String id, String sqlitePath, String username, String password) {
+        return new ApplicationUserAccount(id, sqlitePath, new PasswordAuthConfig(username, password));
+    }
+
+    public String usernameForDisplay() {
+        if (auth instanceof PasswordAuthConfig passwordAuth) {
+            return passwordAuth.username();
+        }
+        return id;
+    }
+
+    public Optional<String> username() {
+        if (auth instanceof PasswordAuthConfig passwordAuth) {
+            return Optional.of(passwordAuth.username());
+        }
+        return Optional.empty();
+    }
+
+    public Optional<String> password() {
+        if (auth instanceof PasswordAuthConfig passwordAuth) {
+            return Optional.of(passwordAuth.password());
+        }
+        return Optional.empty();
     }
 }

--- a/connect-library/src/main/java/com/tsanet/api/ApplicationUserAccountConfigMapper.java
+++ b/connect-library/src/main/java/com/tsanet/api/ApplicationUserAccountConfigMapper.java
@@ -1,0 +1,52 @@
+package com.tsanet.api;
+
+import com.tsanet.api.auth.ClientCredentialsAuthConfig;
+
+public final class ApplicationUserAccountConfigMapper {
+    private ApplicationUserAccountConfigMapper() {
+    }
+
+    public static ApplicationUserAccount passwordAccount(String id, String sqlitePath, String username, String password) {
+        return ApplicationUserAccount.passwordAccount(id, sqlitePath, username, password);
+    }
+
+    public static ApplicationUserAccount clientCredentialsAccount(
+        String id,
+        String sqlitePath,
+        String tenantId,
+        String tokenUrl,
+        String clientId,
+        String clientSecret,
+        String audience,
+        String scope
+    ) {
+        return new ApplicationUserAccount(
+            id,
+            sqlitePath,
+            new ClientCredentialsAuthConfig(tenantId, tokenUrl, clientId, clientSecret, audience, scope)
+        );
+    }
+
+    public static ApplicationUserAccount fromAuthType(
+        String id,
+        String sqlitePath,
+        String authType,
+        String username,
+        String password,
+        String tenantId,
+        String tokenUrl,
+        String clientId,
+        String clientSecret,
+        String audience,
+        String scope
+    ) {
+        if (authType != null && authType.equalsIgnoreCase("client-credentials")) {
+            return clientCredentialsAccount(id, sqlitePath, tenantId, tokenUrl, clientId, clientSecret, audience, scope);
+        }
+        return passwordAccount(id, sqlitePath, username, password);
+    }
+
+    public static ApplicationUserAccount fromLegacyFields(String id, String sqlitePath, String username, String password) {
+        return passwordAccount(id, sqlitePath, username, password);
+    }
+}

--- a/connect-library/src/main/java/com/tsanet/api/ApplicationUserAccountRegistry.java
+++ b/connect-library/src/main/java/com/tsanet/api/ApplicationUserAccountRegistry.java
@@ -1,5 +1,6 @@
 package com.tsanet.api;
 
+import com.tsanet.api.auth.PasswordAuthConfig;
 import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
@@ -7,16 +8,22 @@ import java.util.Optional;
 
 public final class ApplicationUserAccountRegistry {
     private final List<ApplicationUserAccount> accounts;
+    private final Map<String, ApplicationUserAccount> byId;
     private final Map<String, ApplicationUserAccount> byUsername;
     private final ApplicationUserAccount defaultAccount;
 
     private ApplicationUserAccountRegistry(List<ApplicationUserAccount> accounts) {
         this.accounts = List.copyOf(accounts);
-        Map<String, ApplicationUserAccount> index = new LinkedHashMap<>();
+        Map<String, ApplicationUserAccount> idIndex = new LinkedHashMap<>();
+        Map<String, ApplicationUserAccount> usernameIndex = new LinkedHashMap<>();
         for (ApplicationUserAccount account : this.accounts) {
-            index.put(account.username().trim().toLowerCase(), account);
+            idIndex.put(account.id(), account);
+            if (account.auth() instanceof PasswordAuthConfig passwordAuth) {
+                usernameIndex.put(passwordAuth.username().trim().toLowerCase(), account);
+            }
         }
-        this.byUsername = Map.copyOf(index);
+        this.byId = Map.copyOf(idIndex);
+        this.byUsername = Map.copyOf(usernameIndex);
         this.defaultAccount = this.accounts.isEmpty() ? null : this.accounts.getFirst();
     }
 
@@ -28,7 +35,7 @@ public final class ApplicationUserAccountRegistry {
     }
 
     public static ApplicationUserAccountRegistry fromLegacyAuth(String username, String password, String sqlitePath) {
-        return of(List.of(new ApplicationUserAccount("default", username, password, sqlitePath)));
+        return of(List.of(ApplicationUserAccount.passwordAccount("default", sqlitePath, username, password)));
     }
 
     public static ApplicationUserAccountRegistry empty() {
@@ -37,6 +44,21 @@ public final class ApplicationUserAccountRegistry {
 
     public List<ApplicationUserAccount> all() {
         return accounts;
+    }
+
+    public Optional<ApplicationUserAccount> findById(String accountId) {
+        if (accountId == null || accountId.isBlank()) {
+            return Optional.empty();
+        }
+        return Optional.ofNullable(byId.get(accountId.trim()));
+    }
+
+    public ApplicationUserAccount requireById(String accountId) {
+        return findById(accountId).orElseThrow(
+            () -> new IllegalArgumentException(
+                "Unknown application user id '" + accountId + "'. Configure it under tsanet.accounts in application.yml."
+            )
+        );
     }
 
     public Optional<ApplicationUserAccount> findByUsername(String username) {
@@ -49,7 +71,7 @@ public final class ApplicationUserAccountRegistry {
     public ApplicationUserAccount requireByUsername(String username) {
         return findByUsername(username).orElseThrow(
             () -> new IllegalArgumentException(
-                "Unknown application user '" + username + "'. Configure it under tsaet.accounts in application.yml."
+                "Unknown application user '" + username + "'. Configure it under tsanet.accounts in application.yml."
             )
         );
     }

--- a/connect-library/src/main/java/com/tsanet/api/TsaNetApiConfiguration.java
+++ b/connect-library/src/main/java/com/tsanet/api/TsaNetApiConfiguration.java
@@ -1,10 +1,13 @@
 package com.tsanet.api;
 
+import com.tsanet.api.auth.AccountAuthConfig;
+import com.tsanet.api.auth.PasswordAuthConfig;
+
 public record TsaNetApiConfiguration(
     String apiBaseUrl,
     String sqlitePath,
-    String username,
-    String password
+    String accountId,
+    AccountAuthConfig auth
 ) {
     public TsaNetApiConfiguration {
         if (apiBaseUrl == null || apiBaseUrl.isBlank()) {
@@ -13,9 +16,43 @@ public record TsaNetApiConfiguration(
         if (sqlitePath == null || sqlitePath.isBlank()) {
             throw new IllegalArgumentException("sqlitePath is required");
         }
+        if (accountId == null || accountId.isBlank()) {
+            throw new IllegalArgumentException("accountId is required");
+        }
+        if (auth == null) {
+            throw new IllegalArgumentException("auth is required");
+        }
     }
 
     public static TsaNetApiConfiguration of(String apiBaseUrl, String sqlitePath, String username, String password) {
-        return new TsaNetApiConfiguration(apiBaseUrl, sqlitePath, username, password);
+        return new TsaNetApiConfiguration(
+            apiBaseUrl,
+            sqlitePath,
+            "default",
+            new PasswordAuthConfig(username, password)
+        );
+    }
+
+    public static TsaNetApiConfiguration forAccount(
+        String apiBaseUrl,
+        String sqlitePath,
+        String accountId,
+        AccountAuthConfig auth
+    ) {
+        return new TsaNetApiConfiguration(apiBaseUrl, sqlitePath, accountId, auth);
+    }
+
+    public String username() {
+        if (auth instanceof PasswordAuthConfig passwordAuth) {
+            return passwordAuth.username();
+        }
+        return null;
+    }
+
+    public String password() {
+        if (auth instanceof PasswordAuthConfig passwordAuth) {
+            return passwordAuth.password();
+        }
+        return null;
     }
 }

--- a/connect-library/src/main/java/com/tsanet/api/TsaNetApiSessionFactory.java
+++ b/connect-library/src/main/java/com/tsanet/api/TsaNetApiSessionFactory.java
@@ -30,11 +30,17 @@ public final class TsaNetApiSessionFactory {
     }
 
     public TsaNetApiSession openSessionWithSqlitePath(String sqlitePath, String username, String password) {
-        TsaNetApiConfiguration configuration = TsaNetApiConfiguration.of(
+        return openSessionForApplicationUser(
+            ApplicationUserAccount.passwordAccount("default", sqlitePath, username, password)
+        );
+    }
+
+    public TsaNetApiSession openSessionForApplicationUser(ApplicationUserAccount account) {
+        TsaNetApiConfiguration configuration = TsaNetApiConfiguration.forAccount(
             connectionSettings.apiBaseUrl(),
-            sqlitePath,
-            username,
-            password
+            account.sqlitePath(),
+            account.id(),
+            account.auth()
         );
         return TsaNetApi.initialize(configuration);
     }

--- a/connect-library/src/main/java/com/tsanet/api/auth/AccountAuthConfig.java
+++ b/connect-library/src/main/java/com/tsanet/api/auth/AccountAuthConfig.java
@@ -1,0 +1,5 @@
+package com.tsanet.api.auth;
+
+public sealed interface AccountAuthConfig permits ClientCredentialsAuthConfig, PasswordAuthConfig {
+    AuthMode mode();
+}

--- a/connect-library/src/main/java/com/tsanet/api/auth/AuthMode.java
+++ b/connect-library/src/main/java/com/tsanet/api/auth/AuthMode.java
@@ -1,0 +1,6 @@
+package com.tsanet.api.auth;
+
+public enum AuthMode {
+    CLIENT_CREDENTIALS,
+    CONNECT1_PASSWORD
+}

--- a/connect-library/src/main/java/com/tsanet/api/auth/ClientCredentialsAuthConfig.java
+++ b/connect-library/src/main/java/com/tsanet/api/auth/ClientCredentialsAuthConfig.java
@@ -1,0 +1,48 @@
+package com.tsanet.api.auth;
+
+public record ClientCredentialsAuthConfig(
+    String tenantId,
+    String tokenUrl,
+    String clientId,
+    String clientSecret,
+    String audience,
+    String scope
+) implements AccountAuthConfig {
+    public ClientCredentialsAuthConfig {
+        if (clientId == null || clientId.isBlank()) {
+            throw new IllegalArgumentException("clientId is required for client-credentials auth");
+        }
+        if (clientSecret == null || clientSecret.isBlank()) {
+            throw new IllegalArgumentException("clientSecret is required for client-credentials auth");
+        }
+        if ((tenantId == null || tenantId.isBlank()) && (tokenUrl == null || tokenUrl.isBlank())) {
+            throw new IllegalArgumentException("tenantId or tokenUrl is required for client-credentials auth");
+        }
+        if ((audience == null || audience.isBlank()) && (scope == null || scope.isBlank())) {
+            throw new IllegalArgumentException("audience or scope is required for client-credentials auth");
+        }
+    }
+
+    @Override
+    public AuthMode mode() {
+        return AuthMode.CLIENT_CREDENTIALS;
+    }
+
+    public String resolvedTokenUrl() {
+        if (tokenUrl != null && !tokenUrl.isBlank()) {
+            return tokenUrl.trim();
+        }
+        return "https://login.microsoftonline.com/" + tenantId.trim() + "/oauth2/v2.0/token";
+    }
+
+    public String resolvedScope() {
+        if (scope != null && !scope.isBlank()) {
+            return scope.trim();
+        }
+        String normalizedAudience = audience.trim();
+        if (normalizedAudience.endsWith("/.default")) {
+            return normalizedAudience;
+        }
+        return normalizedAudience + "/.default";
+    }
+}

--- a/connect-library/src/main/java/com/tsanet/api/auth/OAuthAccessToken.java
+++ b/connect-library/src/main/java/com/tsanet/api/auth/OAuthAccessToken.java
@@ -1,0 +1,12 @@
+package com.tsanet.api.auth;
+
+public record OAuthAccessToken(String accessToken, long expiresInSeconds) {
+    public OAuthAccessToken {
+        if (accessToken == null || accessToken.isBlank()) {
+            throw new IllegalStateException("OAuth token response did not include access_token");
+        }
+        if (expiresInSeconds <= 0) {
+            expiresInSeconds = 3600;
+        }
+    }
+}

--- a/connect-library/src/main/java/com/tsanet/api/auth/PasswordAuthConfig.java
+++ b/connect-library/src/main/java/com/tsanet/api/auth/PasswordAuthConfig.java
@@ -1,0 +1,17 @@
+package com.tsanet.api.auth;
+
+public record PasswordAuthConfig(String username, String password) implements AccountAuthConfig {
+    public PasswordAuthConfig {
+        if (username == null || username.isBlank()) {
+            throw new IllegalArgumentException("username is required for connect1-password auth");
+        }
+        if (password == null || password.isBlank()) {
+            throw new IllegalArgumentException("password is required for connect1-password auth");
+        }
+    }
+
+    @Override
+    public AuthMode mode() {
+        return AuthMode.CONNECT1_PASSWORD;
+    }
+}

--- a/connect-library/src/main/java/com/tsanet/api/connectapi/dto/CollaborationRequestStatusDto.java
+++ b/connect-library/src/main/java/com/tsanet/api/connectapi/dto/CollaborationRequestStatusDto.java
@@ -13,6 +13,30 @@ public record CollaborationRequestStatusDto(
     Long receiveCompanyId,
     String token,
     String createdAt,
-    String updatedAt
+    String updatedAt,
+    Boolean testCase
 ) {
+    /**
+     * Compatibility constructor from before {@code testCase} existed; leaves it null,
+     * which readers must treat as "unknown", never as "real case".
+     *
+     * @deprecated pass {@code testCase} explicitly; scheduled for removal at the next
+     *     release boundary.
+     */
+    @Deprecated
+    public CollaborationRequestStatusDto(
+        Long id,
+        String status,
+        String summary,
+        String submitCompanyName,
+        Long submitCompanyId,
+        String receiveCompanyName,
+        Long receiveCompanyId,
+        String token,
+        String createdAt,
+        String updatedAt
+    ) {
+        this(id, status, summary, submitCompanyName, submitCompanyId, receiveCompanyName,
+            receiveCompanyId, token, createdAt, updatedAt, null);
+    }
 }

--- a/connect-library/src/main/java/com/tsanet/api/connectapi/dto/WebhookDeliveryDto.java
+++ b/connect-library/src/main/java/com/tsanet/api/connectapi/dto/WebhookDeliveryDto.java
@@ -2,7 +2,7 @@ package com.tsanet.api.connectapi.dto;
 
 public record WebhookDeliveryDto(
     Long id,
-    Long integrationId,
+    String cloudEventId,
     String eventType,
     Integer httpStatus,
     Integer attemptNumber,

--- a/connect-library/src/main/java/com/tsanet/api/connectapi/internal/ConnectApiCollaborationGateway.java
+++ b/connect-library/src/main/java/com/tsanet/api/connectapi/internal/ConnectApiCollaborationGateway.java
@@ -80,7 +80,8 @@ public class ConnectApiCollaborationGateway {
             dto.getReceiveCompanyId(),
             dto.getToken(),
             formatDateTime(dto.getCreatedAt()),
-            formatDateTime(dto.getUpdatedAt())
+            formatDateTime(dto.getUpdatedAt()),
+            dto.getTestCase()
         );
     }
 

--- a/connect-library/src/main/java/com/tsanet/api/connectapi/internal/ConnectApiResponsesGateway.java
+++ b/connect-library/src/main/java/com/tsanet/api/connectapi/internal/ConnectApiResponsesGateway.java
@@ -218,7 +218,8 @@ public class ConnectApiResponsesGateway {
             dto.getReceiveCompanyId(),
             dto.getToken(),
             formatDateTime(dto.getCreatedAt()),
-            formatDateTime(dto.getUpdatedAt())
+            formatDateTime(dto.getUpdatedAt()),
+            dto.getTestCase()
         );
     }
 

--- a/connect-library/src/main/java/com/tsanet/api/connectapi/internal/ConnectApiSessionStore.java
+++ b/connect-library/src/main/java/com/tsanet/api/connectapi/internal/ConnectApiSessionStore.java
@@ -1,14 +1,29 @@
 package com.tsanet.api.connectapi.internal;
 
+import com.tsanet.api.auth.AuthMode;
+import java.time.Instant;
 import java.util.Optional;
 
 public class ConnectApiSessionStore {
     private volatile String bearerToken;
     private volatile String username;
+    private volatile String accountId;
+    private volatile AuthMode authMode;
+    private volatile Instant expiresAt;
 
-    public void save(String username, String bearerToken) {
+    public void savePassword(String username, String bearerToken) {
         this.username = username;
         this.bearerToken = bearerToken;
+        this.authMode = AuthMode.CONNECT1_PASSWORD;
+        this.expiresAt = null;
+    }
+
+    public void saveOAuth(String accountId, String bearerToken, Instant expiresAt) {
+        this.accountId = accountId;
+        this.username = accountId;
+        this.bearerToken = bearerToken;
+        this.authMode = AuthMode.CLIENT_CREDENTIALS;
+        this.expiresAt = expiresAt;
     }
 
     public Optional<String> getBearerToken() {
@@ -19,12 +34,34 @@ public class ConnectApiSessionStore {
         return Optional.ofNullable(username);
     }
 
+    public Optional<String> getAccountId() {
+        return Optional.ofNullable(accountId);
+    }
+
+    public Optional<AuthMode> getAuthMode() {
+        return Optional.ofNullable(authMode);
+    }
+
+    public Optional<Instant> getExpiresAt() {
+        return Optional.ofNullable(expiresAt);
+    }
+
     public boolean isAuthorized() {
-        return bearerToken != null && !bearerToken.isBlank();
+        return bearerToken != null && !bearerToken.isBlank() && !isExpired(Instant.now());
+    }
+
+    public boolean isExpired(Instant now) {
+        if (expiresAt == null) {
+            return false;
+        }
+        return !now.isBefore(expiresAt.minus(TokenManager.EXPIRY_SKEW));
     }
 
     public void clear() {
         this.username = null;
         this.bearerToken = null;
+        this.accountId = null;
+        this.authMode = null;
+        this.expiresAt = null;
     }
 }

--- a/connect-library/src/main/java/com/tsanet/api/connectapi/internal/ConnectApiWebhooksGateway.java
+++ b/connect-library/src/main/java/com/tsanet/api/connectapi/internal/ConnectApiWebhooksGateway.java
@@ -8,6 +8,7 @@ import com.tsanet.api.connectapi.dto.WebhookDeliveryPageDto;
 import com.tsanet.api.connectapi.dto.WebhookSubscriptionDto;
 import com.tsanet.api.connectapi.dto.WebhookSubscriptionResponseDto;
 import com.tsanet.api.generated.api.WebhooksApi;
+import com.tsanet.api.generated.api.WebhooksV1Api;
 import com.tsanet.api.generated.model.CreateWebhookSubscriptionRequestDTO;
 import com.tsanet.api.generated.model.WebhookDeliveryLogDTO;
 import com.tsanet.api.generated.model.WebhookDeliveryLogPageDTO;
@@ -20,15 +21,18 @@ import java.util.Collections;
 import java.util.List;
 
 public class ConnectApiWebhooksGateway {
+    private final WebhooksV1Api webhooksV1Api;
     private final WebhooksApi webhooksApi;
     private final ConnectApiSessionStore sessionStore;
     private final WebhookSubscriptionStorageService storageService;
 
     public ConnectApiWebhooksGateway(
+        WebhooksV1Api webhooksV1Api,
         WebhooksApi webhooksApi,
         ConnectApiSessionStore sessionStore,
         WebhookSubscriptionStorageService storageService
     ) {
+        this.webhooksV1Api = webhooksV1Api;
         this.webhooksApi = webhooksApi;
         this.sessionStore = sessionStore;
         this.storageService = storageService;
@@ -37,7 +41,7 @@ public class ConnectApiWebhooksGateway {
     public List<WebhookSubscriptionDto> listWebhookSubscriptions() {
         requireLogin();
 
-        List<WebhookSubscriptionDTO> body = webhooksApi.listWebhookSubscriptions();
+        List<WebhookSubscriptionDTO> body = webhooksV1Api.listWebhookSubscriptions();
         if (body == null) {
             return Collections.emptyList();
         }
@@ -55,12 +59,11 @@ public class ConnectApiWebhooksGateway {
             request.setEventTypes(eventTypes.stream().map(WebhookEventType::fromValue).toList());
         }
 
-        WebhookSubscriptionResponseDTO response = webhooksApi.createWebhookSubscription(request);
+        WebhookSubscriptionResponseDTO response = webhooksV1Api.createWebhookSubscription(request);
         if (response == null) {
             throw new IllegalStateException("Create webhook subscription returned empty response");
         }
 
-        // Refresh stored list after mutation.
         listWebhookSubscriptions();
         storageService.storeSecret(response.getId(), response.getSecret());
         return toResponseDto(response);
@@ -86,7 +89,6 @@ public class ConnectApiWebhooksGateway {
     public void deleteWebhookSubscription(Long id) {
         requireLogin();
         webhooksApi.deleteWebhookSubscription(id);
-        // Refresh stored list after mutation.
         listWebhookSubscriptions();
     }
 
@@ -115,7 +117,7 @@ public class ConnectApiWebhooksGateway {
     private WebhookDeliveryDto toDeliveryDto(WebhookDeliveryLogDTO dto) {
         return new WebhookDeliveryDto(
             dto.getId(),
-            dto.getIntegrationId(),
+            dto.getCloudEventId(),
             dto.getEventType(),
             dto.getHttpStatus(),
             dto.getAttemptNumber(),

--- a/connect-library/src/main/java/com/tsanet/api/connectapi/internal/OAuth401RetryInterceptor.java
+++ b/connect-library/src/main/java/com/tsanet/api/connectapi/internal/OAuth401RetryInterceptor.java
@@ -1,0 +1,29 @@
+package com.tsanet.api.connectapi.internal;
+
+import java.io.IOException;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.HttpRequest;
+import org.springframework.http.client.ClientHttpRequestExecution;
+import org.springframework.http.client.ClientHttpRequestInterceptor;
+import org.springframework.http.client.ClientHttpResponse;
+
+public final class OAuth401RetryInterceptor implements ClientHttpRequestInterceptor {
+    private final TokenManager tokenManager;
+
+    public OAuth401RetryInterceptor(TokenManager tokenManager) {
+        this.tokenManager = tokenManager;
+    }
+
+    @Override
+    public ClientHttpResponse intercept(HttpRequest request, byte[] body, ClientHttpRequestExecution execution)
+        throws IOException {
+        ClientHttpResponse response = execution.execute(request, body);
+        if (response.getStatusCode().value() != 401 || !tokenManager.supportsRefresh()) {
+            return response;
+        }
+        response.close();
+        String refreshedToken = tokenManager.refreshAccessToken();
+        request.getHeaders().set(HttpHeaders.AUTHORIZATION, "Bearer " + refreshedToken);
+        return execution.execute(request, body);
+    }
+}

--- a/connect-library/src/main/java/com/tsanet/api/connectapi/internal/OAuthTokenGateway.java
+++ b/connect-library/src/main/java/com/tsanet/api/connectapi/internal/OAuthTokenGateway.java
@@ -1,0 +1,74 @@
+package com.tsanet.api.connectapi.internal;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.tsanet.api.auth.ClientCredentialsAuthConfig;
+import com.tsanet.api.auth.OAuthAccessToken;
+import java.util.List;
+import org.springframework.http.HttpEntity;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.MediaType;
+import org.springframework.http.ResponseEntity;
+import org.springframework.util.LinkedMultiValueMap;
+import org.springframework.util.MultiValueMap;
+import org.springframework.web.client.RestClientResponseException;
+import org.springframework.web.client.RestTemplate;
+
+public class OAuthTokenGateway {
+    private static final ObjectMapper OBJECT_MAPPER = new ObjectMapper();
+
+    private final RestTemplate restTemplate;
+
+    public OAuthTokenGateway() {
+        this(new RestTemplate());
+    }
+
+    OAuthTokenGateway(RestTemplate restTemplate) {
+        this.restTemplate = restTemplate;
+    }
+
+    public OAuthAccessToken fetchClientCredentialsToken(ClientCredentialsAuthConfig config) {
+        MultiValueMap<String, String> form = new LinkedMultiValueMap<>();
+        form.add("grant_type", "client_credentials");
+        form.add("client_id", config.clientId());
+        form.add("client_secret", config.clientSecret());
+        form.add("scope", config.resolvedScope());
+
+        HttpHeaders headers = new HttpHeaders();
+        headers.setContentType(MediaType.APPLICATION_FORM_URLENCODED);
+        headers.setAccept(java.util.List.of(MediaType.APPLICATION_JSON));
+
+        try {
+            ResponseEntity<String> response = restTemplate.postForEntity(
+                config.resolvedTokenUrl(),
+                new HttpEntity<>(form, headers),
+                String.class
+            );
+            return parseTokenResponse(response.getBody());
+        } catch (RestClientResponseException ex) {
+            throw new IllegalStateException(
+                "OAuth client-credentials request failed: HTTP " + ex.getStatusCode().value(),
+                ex
+            );
+        }
+    }
+
+    private static OAuthAccessToken parseTokenResponse(String body) {
+        try {
+            JsonNode root = OBJECT_MAPPER.readTree(body);
+            String accessToken = textValue(root, "access_token");
+            long expiresIn = root.path("expires_in").asLong(3600);
+            return new OAuthAccessToken(accessToken, expiresIn);
+        } catch (Exception ex) {
+            throw new IllegalStateException("Failed to parse OAuth token response", ex);
+        }
+    }
+
+    private static String textValue(JsonNode root, String field) {
+        JsonNode node = root.get(field);
+        if (node == null || node.isNull() || node.asText().isBlank()) {
+            throw new IllegalStateException("OAuth token response missing " + field);
+        }
+        return node.asText();
+    }
+}

--- a/connect-library/src/main/java/com/tsanet/api/connectapi/internal/TokenManager.java
+++ b/connect-library/src/main/java/com/tsanet/api/connectapi/internal/TokenManager.java
@@ -1,0 +1,94 @@
+package com.tsanet.api.connectapi.internal;
+
+import com.tsanet.api.auth.AccountAuthConfig;
+import com.tsanet.api.auth.AuthMode;
+import com.tsanet.api.auth.ClientCredentialsAuthConfig;
+import com.tsanet.api.auth.OAuthAccessToken;
+import com.tsanet.api.auth.PasswordAuthConfig;
+import java.time.Clock;
+import java.time.Duration;
+import java.time.Instant;
+import java.util.Optional;
+
+public final class TokenManager {
+    static final Duration EXPIRY_SKEW = Duration.ofSeconds(60);
+
+    private final ConnectApiSessionStore sessionStore;
+    private final ConnectApiAuthGateway passwordAuthGateway;
+    private final OAuthTokenGateway oauthTokenGateway;
+    private final AccountAuthConfig authConfig;
+    private final String accountId;
+    private final Clock clock;
+
+    public TokenManager(
+        ConnectApiSessionStore sessionStore,
+        ConnectApiAuthGateway passwordAuthGateway,
+        OAuthTokenGateway oauthTokenGateway,
+        String accountId,
+        AccountAuthConfig authConfig
+    ) {
+        this(sessionStore, passwordAuthGateway, oauthTokenGateway, accountId, authConfig, Clock.systemUTC());
+    }
+
+    TokenManager(
+        ConnectApiSessionStore sessionStore,
+        ConnectApiAuthGateway passwordAuthGateway,
+        OAuthTokenGateway oauthTokenGateway,
+        String accountId,
+        AccountAuthConfig authConfig,
+        Clock clock
+    ) {
+        this.sessionStore = sessionStore;
+        this.passwordAuthGateway = passwordAuthGateway;
+        this.oauthTokenGateway = oauthTokenGateway;
+        this.accountId = accountId;
+        this.authConfig = authConfig;
+        this.clock = clock;
+    }
+
+    public String authenticate() {
+        return switch (authConfig.mode()) {
+            case CLIENT_CREDENTIALS -> authenticateClientCredentials((ClientCredentialsAuthConfig) authConfig);
+            case CONNECT1_PASSWORD -> authenticatePassword((PasswordAuthConfig) authConfig);
+        };
+    }
+
+    public String ensureValidAccessToken() {
+        if (authConfig.mode() == AuthMode.CLIENT_CREDENTIALS && sessionStore.isExpired(clock.instant())) {
+            return refreshAccessToken();
+        }
+        return sessionStore.getBearerToken().orElseThrow(() -> new IllegalStateException("Not authenticated"));
+    }
+
+    public String refreshAccessToken() {
+        if (authConfig.mode() != AuthMode.CLIENT_CREDENTIALS) {
+            throw new IllegalStateException("Token refresh is only supported for client-credentials auth");
+        }
+        return authenticateClientCredentials((ClientCredentialsAuthConfig) authConfig);
+    }
+
+    public boolean supportsRefresh() {
+        return authConfig.mode() == AuthMode.CLIENT_CREDENTIALS;
+    }
+
+    public AuthMode authMode() {
+        return authConfig.mode();
+    }
+
+    public Optional<Instant> tokenExpiresAt() {
+        return sessionStore.getExpiresAt();
+    }
+
+    private String authenticateClientCredentials(ClientCredentialsAuthConfig config) {
+        OAuthAccessToken token = oauthTokenGateway.fetchClientCredentialsToken(config);
+        Instant expiresAt = clock.instant().plusSeconds(token.expiresInSeconds());
+        sessionStore.saveOAuth(accountId, token.accessToken(), expiresAt);
+        return token.accessToken();
+    }
+
+    private String authenticatePassword(PasswordAuthConfig config) {
+        String token = passwordAuthGateway.login(config.username(), config.password());
+        sessionStore.savePassword(config.username(), token);
+        return token;
+    }
+}

--- a/connect-library/src/main/java/com/tsanet/api/facade/AuthFacade.java
+++ b/connect-library/src/main/java/com/tsanet/api/facade/AuthFacade.java
@@ -1,8 +1,12 @@
 package com.tsanet.api.facade;
 
+import com.tsanet.api.auth.AuthMode;
+import java.time.Instant;
 import java.util.Optional;
 
 public interface AuthFacade {
+    String authenticate();
+
     String login(String username, String password);
 
     String loginWithConfiguredCredentials();
@@ -10,6 +14,12 @@ public interface AuthFacade {
     boolean isAuthorized();
 
     Optional<String> currentUsername();
+
+    Optional<String> currentAccountId();
+
+    Optional<AuthMode> authMode();
+
+    Optional<Instant> tokenExpiresAt();
 
     Optional<String> currentBearerToken();
 

--- a/connect-library/src/main/java/com/tsanet/api/facade/CollaborationRequestsFacade.java
+++ b/connect-library/src/main/java/com/tsanet/api/facade/CollaborationRequestsFacade.java
@@ -28,20 +28,66 @@ public interface CollaborationRequestsFacade {
 
     List<CollaborationRequestFormDto> listStoredFormsForDocument(long documentId);
 
+    /**
+     * @param testSubmission whether the case is created test-flagged. There is no
+     *     default on purpose: every case that is not test-flagged pages a real
+     *     engineer at a real partner, so the choice is made per call, deliberately.
+     */
     CollaborationRequestStatusDto createRequest(
         long receiverCompanyId,
         String caseNumber,
         String summary,
-        String description
+        String description,
+        boolean testSubmission
     );
 
+    /**
+     * @param testSubmission whether the case is created test-flagged. See
+     *     {@link #createRequest(long, String, String, String, boolean)}.
+     */
     CollaborationRequestStatusDto createRequest(
         CollaborationRequestFormTemplateDto formTemplate,
         String caseNumber,
         String summary,
         String description,
-        Map<Long, String> customFieldValues
+        Map<Long, String> customFieldValues,
+        boolean testSubmission
     );
+
+    /**
+     * Compatibility form from before the flag was per-call; keeps the pre-existing
+     * behavior of always creating a TEST submission.
+     *
+     * @deprecated pass {@code testSubmission} explicitly; scheduled for removal at
+     *     the next release boundary.
+     */
+    @Deprecated(forRemoval = true)
+    default CollaborationRequestStatusDto createRequest(
+        long receiverCompanyId,
+        String caseNumber,
+        String summary,
+        String description
+    ) {
+        return createRequest(receiverCompanyId, caseNumber, summary, description, true);
+    }
+
+    /**
+     * Compatibility form from before the flag was per-call; keeps the pre-existing
+     * behavior of always creating a TEST submission.
+     *
+     * @deprecated pass {@code testSubmission} explicitly; scheduled for removal at
+     *     the next release boundary.
+     */
+    @Deprecated(forRemoval = true)
+    default CollaborationRequestStatusDto createRequest(
+        CollaborationRequestFormTemplateDto formTemplate,
+        String caseNumber,
+        String summary,
+        String description,
+        Map<Long, String> customFieldValues
+    ) {
+        return createRequest(formTemplate, caseNumber, summary, description, customFieldValues, true);
+    }
 
     CollaborationRequestStatusDto fetchRequestByToken(String caseToken);
 

--- a/connect-library/src/main/java/com/tsanet/api/internal/DefaultTsaNetApiSession.java
+++ b/connect-library/src/main/java/com/tsanet/api/internal/DefaultTsaNetApiSession.java
@@ -53,7 +53,10 @@ import com.tsanet.api.storage.UserContextStorageService;
 import com.tsanet.api.storage.WebhookInboundEventStorageService;
 import com.tsanet.api.storage.WebhookSubscriptionStorageService;
 import com.tsanet.api.webhook.WebhookInboundService;
+import com.tsanet.api.auth.AuthMode;
+import com.tsanet.api.connectapi.internal.TokenManager;
 import java.nio.file.Path;
+import java.time.Instant;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
@@ -65,6 +68,7 @@ final class DefaultTsaNetApiSession implements TsaNetApiSession, AuthFacade, Col
 
     private final TsaNetApiConfiguration configuration;
     private final ConnectApiSessionStore sessionStore;
+    private final TokenManager tokenManager;
     private final ConnectApiAuthGateway authGateway;
     private final ConnectApiCollaborationGateway collaborationGateway;
     private final ConnectApiFormGateway formGateway;
@@ -89,6 +93,7 @@ final class DefaultTsaNetApiSession implements TsaNetApiSession, AuthFacade, Col
     DefaultTsaNetApiSession(
         TsaNetApiConfiguration configuration,
         ConnectApiSessionStore sessionStore,
+        TokenManager tokenManager,
         ConnectApiAuthGateway authGateway,
         ConnectApiCollaborationGateway collaborationGateway,
         ConnectApiFormGateway formGateway,
@@ -111,6 +116,7 @@ final class DefaultTsaNetApiSession implements TsaNetApiSession, AuthFacade, Col
     ) {
         this.configuration = configuration;
         this.sessionStore = sessionStore;
+        this.tokenManager = tokenManager;
         this.authGateway = authGateway;
         this.collaborationGateway = collaborationGateway;
         this.formGateway = formGateway;
@@ -180,19 +186,23 @@ final class DefaultTsaNetApiSession implements TsaNetApiSession, AuthFacade, Col
     }
 
     @Override
+    public String authenticate() {
+        return tokenManager.authenticate();
+    }
+
+    @Override
     public String login(String username, String password) {
+        if (configuration.auth().mode() != AuthMode.CONNECT1_PASSWORD) {
+            throw new IllegalStateException("Password login is not configured for this session. Use authenticate().");
+        }
         String token = authGateway.login(username, password);
-        sessionStore.save(username, token);
+        sessionStore.savePassword(username, token);
         return token;
     }
 
     @Override
     public String loginWithConfiguredCredentials() {
-        if (configuration.username() == null || configuration.username().isBlank()
-            || configuration.password() == null || configuration.password().isBlank()) {
-            throw new IllegalStateException("Configured username and password are required");
-        }
-        return login(configuration.username(), configuration.password());
+        return authenticate();
     }
 
     @Override
@@ -206,7 +216,25 @@ final class DefaultTsaNetApiSession implements TsaNetApiSession, AuthFacade, Col
     }
 
     @Override
+    public Optional<String> currentAccountId() {
+        return sessionStore.getAccountId().or(() -> Optional.of(configuration.accountId()));
+    }
+
+    @Override
+    public Optional<AuthMode> authMode() {
+        return sessionStore.getAuthMode().or(() -> Optional.of(configuration.auth().mode()));
+    }
+
+    @Override
+    public Optional<Instant> tokenExpiresAt() {
+        return tokenManager.tokenExpiresAt();
+    }
+
+    @Override
     public Optional<String> currentBearerToken() {
+        if (!sessionStore.isAuthorized()) {
+            return Optional.empty();
+        }
         return sessionStore.getBearerToken();
     }
 
@@ -666,7 +694,7 @@ final class DefaultTsaNetApiSession implements TsaNetApiSession, AuthFacade, Col
 
     private void ensureAuthenticatedForWebhook() {
         if (!auth().isAuthorized()) {
-            auth().loginWithConfiguredCredentials();
+            auth().authenticate();
         }
     }
 }

--- a/connect-library/src/main/java/com/tsanet/api/internal/DefaultTsaNetApiSession.java
+++ b/connect-library/src/main/java/com/tsanet/api/internal/DefaultTsaNetApiSession.java
@@ -308,10 +308,11 @@ final class DefaultTsaNetApiSession implements TsaNetApiSession, AuthFacade, Col
         long receiverCompanyId,
         String caseNumber,
         String summary,
-        String description
+        String description,
+        boolean testSubmission
     ) {
         CollaborationRequestFormTemplateDto template = getCreateFormByCompanyId(receiverCompanyId);
-        return createRequest(template, caseNumber, summary, description, Collections.emptyMap());
+        return createRequest(template, caseNumber, summary, description, Collections.emptyMap(), testSubmission);
     }
 
     @Override
@@ -320,7 +321,8 @@ final class DefaultTsaNetApiSession implements TsaNetApiSession, AuthFacade, Col
         String caseNumber,
         String summary,
         String description,
-        Map<Long, String> customFieldValues
+        Map<Long, String> customFieldValues,
+        boolean testSubmission
     ) {
         CollaborationRequestDTO form = formGateway.getFormByDocumentId(formTemplate.documentId());
         long storageCompanyId = formTemplate.receiverCompanyId() != null
@@ -333,7 +335,8 @@ final class DefaultTsaNetApiSession implements TsaNetApiSession, AuthFacade, Col
             caseNumber,
             summary,
             description,
-            customFieldValues
+            customFieldValues,
+            testSubmission
         );
     }
 
@@ -344,7 +347,8 @@ final class DefaultTsaNetApiSession implements TsaNetApiSession, AuthFacade, Col
         String caseNumber,
         String summary,
         String description,
-        Map<Long, String> customFieldValues
+        Map<Long, String> customFieldValues,
+        boolean testSubmission
     ) {
         storeFormMetadata(storageCompanyId, departmentId, form);
         FormTemplateMapper.applyCustomFieldValues(form, customFieldValues);
@@ -358,7 +362,7 @@ final class DefaultTsaNetApiSession implements TsaNetApiSession, AuthFacade, Col
         form.setInternalCaseNumber(caseNumber);
         form.setProblemSummary(summary);
         form.setProblemDescription(description);
-        form.setTestSubmission(true);
+        form.setTestSubmission(testSubmission);
         if (form.getPriority() == null) {
             form.setPriority(CasePriority.MEDIUM);
         }

--- a/connect-library/src/main/java/com/tsanet/api/internal/TsaNetApiRuntime.java
+++ b/connect-library/src/main/java/com/tsanet/api/internal/TsaNetApiRuntime.java
@@ -20,6 +20,7 @@ import com.tsanet.api.generated.api.EntitySearchApi;
 import com.tsanet.api.generated.api.FormRequestApi;
 import com.tsanet.api.generated.api.IdentityApi;
 import com.tsanet.api.generated.api.WebhooksApi;
+import com.tsanet.api.generated.api.WebhooksV1Api;
 import com.tsanet.api.generated.invoker.ApiClient;
 import com.tsanet.api.storage.AttachmentConfigRepository;
 import com.tsanet.api.storage.AttachmentConfigStorageService;
@@ -42,9 +43,15 @@ import com.tsanet.api.storage.WebhookInboundEventRepository;
 import com.tsanet.api.storage.WebhookInboundEventStorageService;
 import com.tsanet.api.storage.WebhookSubscriptionRepository;
 import com.tsanet.api.storage.WebhookSubscriptionStorageService;
-import com.tsanet.api.webhook.WebhookInboundService;
+import com.tsanet.api.auth.AuthMode;
+import com.tsanet.api.connectapi.internal.OAuth401RetryInterceptor;
+import com.tsanet.api.connectapi.internal.OAuthTokenGateway;
+import com.tsanet.api.connectapi.internal.TokenManager;
 import java.nio.file.Files;
 import java.nio.file.Path;
+import org.springframework.http.client.BufferingClientHttpRequestFactory;
+import org.springframework.http.client.SimpleClientHttpRequestFactory;
+import org.springframework.web.client.RestTemplate;
 import org.springframework.jdbc.core.JdbcTemplate;
 import org.sqlite.SQLiteDataSource;
 
@@ -55,16 +62,33 @@ public final class TsaNetApiRuntime {
     public static TsaNetApiSession create(TsaNetApiConfiguration configuration) {
         ConnectApiSessionStore sessionStore = new ConnectApiSessionStore();
 
-        ApiClient apiClient = new ApiClient();
+        RestTemplate restTemplate = new RestTemplate(
+            new BufferingClientHttpRequestFactory(new SimpleClientHttpRequestFactory())
+        );
+        ApiClient apiClient = new ApiClient(restTemplate);
         apiClient.setBasePath(configuration.apiBaseUrl());
-        apiClient.setBearerToken(() -> sessionStore.getBearerToken().orElse(null));
 
         IdentityApi identityApi = new IdentityApi(apiClient);
+        ConnectApiAuthGateway authGateway = new ConnectApiAuthGateway(identityApi);
+        OAuthTokenGateway oauthTokenGateway = new OAuthTokenGateway();
+        TokenManager tokenManager = new TokenManager(
+            sessionStore,
+            authGateway,
+            oauthTokenGateway,
+            configuration.accountId(),
+            configuration.auth()
+        );
+        if (configuration.auth().mode() == AuthMode.CLIENT_CREDENTIALS) {
+            restTemplate.getInterceptors().add(new OAuth401RetryInterceptor(tokenManager));
+        }
+        apiClient.setBearerToken(() -> bearerTokenForRequest(sessionStore, tokenManager, configuration));
+
         CollaborationRequestsApi collaborationRequestsApi = new CollaborationRequestsApi(apiClient);
         CaseNotesApi caseNotesApi = new CaseNotesApi(apiClient);
         CaseAttachmentsApi caseAttachmentsApi = new CaseAttachmentsApi(apiClient);
         CaseResponsesApi caseResponsesApi = new CaseResponsesApi(apiClient);
         WebhooksApi webhooksApi = new WebhooksApi(apiClient);
+        WebhooksV1Api webhooksV1Api = new WebhooksV1Api(apiClient);
         EntitySearchApi entitySearchApi = new EntitySearchApi(apiClient);
         FormRequestApi formRequestApi = new FormRequestApi(apiClient);
 
@@ -102,7 +126,6 @@ public final class TsaNetApiRuntime {
         AttachmentForwardResultStorageService attachmentForwardResultStorageService =
             new AttachmentForwardResultStorageService(attachmentForwardResultRepository);
 
-        ConnectApiAuthGateway authGateway = new ConnectApiAuthGateway(identityApi);
         ConnectApiCollaborationGateway collaborationGateway = new ConnectApiCollaborationGateway(
             collaborationRequestsApi,
             sessionStore,
@@ -127,6 +150,7 @@ public final class TsaNetApiRuntime {
             userContextStorageService
         );
         ConnectApiWebhooksGateway webhooksGateway = new ConnectApiWebhooksGateway(
+            webhooksV1Api,
             webhooksApi,
             sessionStore,
             webhookSubscriptionStorageService
@@ -146,6 +170,7 @@ public final class TsaNetApiRuntime {
         return new DefaultTsaNetApiSession(
             configuration,
             sessionStore,
+            tokenManager,
             authGateway,
             collaborationGateway,
             formGateway,
@@ -166,6 +191,20 @@ public final class TsaNetApiRuntime {
             attachmentConfigStorageService,
             attachmentForwardResultStorageService
         );
+    }
+
+    private static String bearerTokenForRequest(
+        ConnectApiSessionStore sessionStore,
+        TokenManager tokenManager,
+        TsaNetApiConfiguration configuration
+    ) {
+        if (!sessionStore.getBearerToken().isPresent()) {
+            return null;
+        }
+        if (configuration.auth().mode() == AuthMode.CLIENT_CREDENTIALS) {
+            return tokenManager.ensureValidAccessToken();
+        }
+        return sessionStore.getBearerToken().orElse(null);
     }
 
     private static JdbcTemplate createJdbcTemplate(String sqlitePath) {

--- a/connect-library/src/main/java/com/tsanet/api/session/AccountScopedTsaNetApiSession.java
+++ b/connect-library/src/main/java/com/tsanet/api/session/AccountScopedTsaNetApiSession.java
@@ -4,6 +4,8 @@ import com.tsanet.api.ApplicationUserAccount;
 import com.tsanet.api.ApplicationUserAccountRegistry;
 import com.tsanet.api.TsaNetApiSession;
 import com.tsanet.api.TsaNetApiSessionFactory;
+import com.tsanet.api.auth.AuthMode;
+import com.tsanet.api.auth.PasswordAuthConfig;
 import com.tsanet.api.facade.AttachmentsFacade;
 import com.tsanet.api.facade.AuthFacade;
 import com.tsanet.api.facade.CaseNotesFacade;
@@ -12,6 +14,7 @@ import com.tsanet.api.facade.CollaborationRequestsFacade;
 import com.tsanet.api.facade.PartnersFacade;
 import com.tsanet.api.facade.UserFacade;
 import com.tsanet.api.facade.WebhooksFacade;
+import java.time.Instant;
 import java.util.Objects;
 import java.util.Optional;
 
@@ -81,44 +84,52 @@ public final class AccountScopedTsaNetApiSession implements TsaNetApiSession, Ac
         return requireDelegate().attachments();
     }
 
-    private synchronized void activateAccount(String username, String password) {
-        ApplicationUserAccount account = accountRegistry.requireByUsername(username);
+    private synchronized void activateAccount(ApplicationUserAccount account) {
         if (delegate != null && account.id().equals(activeAccountId)) {
             return;
         }
-        delegate = sessionFactory.openSessionWithSqlitePath(account.sqlitePath(), username, password);
+        delegate = sessionFactory.openSessionForApplicationUser(account);
         activeAccountId = account.id();
         activeSqlitePath = account.sqlitePath();
     }
 
-    void bindAccountForTesting(String username, String password) {
-        activateAccount(username, password);
+    void bindAccountForTesting(String accountId) {
+        activateAccount(accountRegistry.requireById(accountId));
     }
 
     private TsaNetApiSession requireDelegate() {
         TsaNetApiSession current = delegate;
         if (current == null) {
-            throw new IllegalStateException("No account session. Use 'login' first.");
+            throw new IllegalStateException("No account session. Use 'login' or 'authenticate' first.");
         }
         return current;
     }
 
     private final class AccountAuthFacade implements AuthFacade {
         @Override
+        public String authenticate() {
+            ApplicationUserAccount account = accountRegistry.defaultAccount().orElseThrow(
+                () -> new IllegalStateException("No application users configured under tsanet.accounts")
+            );
+            activateAccount(account);
+            return requireDelegate().auth().authenticate();
+        }
+
+        @Override
         public String login(String username, String password) {
-            activateAccount(username, password);
+            ApplicationUserAccount account = accountRegistry.requireByUsername(username);
+            if (account.auth().mode() != AuthMode.CONNECT1_PASSWORD) {
+                throw new IllegalStateException(
+                    "Account '" + account.id() + "' uses client-credentials auth. Use authenticate()."
+                );
+            }
+            activateAccount(account);
             return requireDelegate().auth().login(username, password);
         }
 
         @Override
         public String loginWithConfiguredCredentials() {
-            ApplicationUserAccount account = accountRegistry.defaultAccount().orElseThrow(
-                () -> new IllegalStateException("No application users configured under tsaet.accounts")
-            );
-            String password = account.password() != null && !account.password().isBlank()
-                ? account.password()
-                : throwMissingPassword(account);
-            return login(account.username(), password);
+            return authenticate();
         }
 
         @Override
@@ -135,6 +146,30 @@ public final class AccountScopedTsaNetApiSession implements TsaNetApiSession, Ac
         }
 
         @Override
+        public Optional<String> currentAccountId() {
+            if (delegate == null) {
+                return Optional.empty();
+            }
+            return delegate.auth().currentAccountId();
+        }
+
+        @Override
+        public Optional<AuthMode> authMode() {
+            if (delegate == null) {
+                return Optional.empty();
+            }
+            return delegate.auth().authMode();
+        }
+
+        @Override
+        public Optional<Instant> tokenExpiresAt() {
+            if (delegate == null) {
+                return Optional.empty();
+            }
+            return delegate.auth().tokenExpiresAt();
+        }
+
+        @Override
         public Optional<String> currentBearerToken() {
             if (delegate == null) {
                 return Optional.empty();
@@ -147,10 +182,6 @@ public final class AccountScopedTsaNetApiSession implements TsaNetApiSession, Ac
             if (delegate != null) {
                 delegate.auth().logout();
             }
-        }
-
-        private String throwMissingPassword(ApplicationUserAccount account) {
-            throw new IllegalStateException("Password is required for application user '" + account.id() + "'");
         }
     }
 }

--- a/connect-library/src/main/java/com/tsanet/api/storage/CollaborationRequestRepository.java
+++ b/connect-library/src/main/java/com/tsanet/api/storage/CollaborationRequestRepository.java
@@ -28,8 +28,9 @@ public class CollaborationRequestRepository {
             """
             INSERT INTO collaboration_request (
                 id, status, summary, submit_company_name, submit_company_id,
-                receive_company_name, receive_company_id, token, created_at, updated_at, fetched_at
-            ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+                receive_company_name, receive_company_id, token, created_at, updated_at,
+                test_case, fetched_at
+            ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
             ON CONFLICT(id) DO UPDATE SET
                 status = excluded.status,
                 summary = excluded.summary,
@@ -40,6 +41,7 @@ public class CollaborationRequestRepository {
                 token = excluded.token,
                 created_at = excluded.created_at,
                 updated_at = excluded.updated_at,
+                test_case = excluded.test_case,
                 fetched_at = excluded.fetched_at
             """,
             requests,
@@ -55,7 +57,8 @@ public class CollaborationRequestRepository {
                 ps.setString(8, request.token());
                 ps.setString(9, request.createdAt());
                 ps.setString(10, request.updatedAt());
-                ps.setString(11, fetchedAt);
+                ps.setObject(11, toStoredBoolean(request.testCase()));
+                ps.setString(12, fetchedAt);
             }
         );
     }
@@ -64,7 +67,8 @@ public class CollaborationRequestRepository {
         return jdbcTemplate.query(
             """
             SELECT id, status, summary, submit_company_name, submit_company_id,
-                   receive_company_name, receive_company_id, token, created_at, updated_at
+                   receive_company_name, receive_company_id, token, created_at, updated_at,
+                   test_case
             FROM collaboration_request
             ORDER BY id
             """,
@@ -76,7 +80,8 @@ public class CollaborationRequestRepository {
         return jdbcTemplate.query(
             """
             SELECT id, status, summary, submit_company_name, submit_company_id,
-                   receive_company_name, receive_company_id, token, created_at, updated_at
+                   receive_company_name, receive_company_id, token, created_at, updated_at,
+                   test_case
             FROM collaboration_request
             WHERE submit_company_id = ? OR receive_company_id = ?
             ORDER BY id
@@ -98,7 +103,19 @@ public class CollaborationRequestRepository {
             rs.getObject("receive_company_id", Long.class),
             rs.getString("token"),
             rs.getString("created_at"),
-            rs.getString("updated_at")
+            rs.getString("updated_at"),
+            readStoredBoolean(rs, "test_case")
         );
+    }
+
+    private static Integer toStoredBoolean(Boolean value) {
+        return value == null ? null : (value ? 1 : 0);
+    }
+
+    // The SQLite driver's typed getObject(col, Integer.class) throws on NULL, so read
+    // the JDBC-1 way: primitive get plus wasNull.
+    private static Boolean readStoredBoolean(ResultSet rs, String column) throws SQLException {
+        int raw = rs.getInt(column);
+        return rs.wasNull() ? null : raw != 0;
     }
 }

--- a/connect-library/src/main/java/com/tsanet/api/storage/DatabaseInitializer.java
+++ b/connect-library/src/main/java/com/tsanet/api/storage/DatabaseInitializer.java
@@ -15,6 +15,7 @@ public final class DatabaseInitializer {
             token TEXT NOT NULL UNIQUE,
             created_at TEXT,
             updated_at TEXT,
+            test_case INTEGER,
             fetched_at TEXT NOT NULL
         )
         """;
@@ -151,6 +152,7 @@ public final class DatabaseInitializer {
 
     public static void createSchema(JdbcTemplate jdbcTemplate) {
         jdbcTemplate.execute(COLLABORATION_REQUEST_TABLE);
+        ensureColumn(jdbcTemplate, "collaboration_request", "test_case", "INTEGER");
         jdbcTemplate.execute(CASE_NOTE_TABLE);
         jdbcTemplate.execute(CASE_RESPONSE_TABLE);
         jdbcTemplate.execute(USER_CONTEXT_TABLE);

--- a/connect-library/src/test/java/com/tsanet/api/ApplicationUserAccountConfigMapperTest.java
+++ b/connect-library/src/test/java/com/tsanet/api/ApplicationUserAccountConfigMapperTest.java
@@ -1,0 +1,49 @@
+package com.tsanet.api;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import com.tsanet.api.auth.AuthMode;
+import com.tsanet.api.auth.ClientCredentialsAuthConfig;
+import com.tsanet.api.auth.PasswordAuthConfig;
+import org.junit.jupiter.api.Test;
+
+class ApplicationUserAccountConfigMapperTest {
+    @Test
+    void itBuildsPasswordAccountFromLegacyFields() {
+        ApplicationUserAccount account = ApplicationUserAccountConfigMapper.fromLegacyFields(
+            "acme",
+            "/tmp/acme.db",
+            "api@test.com",
+            "secret"
+        );
+
+        assertThat(account.id()).isEqualTo("acme");
+        assertThat(account.sqlitePath()).isEqualTo("/tmp/acme.db");
+        assertThat(account.auth()).isInstanceOf(PasswordAuthConfig.class);
+        assertThat(account.auth().mode()).isEqualTo(AuthMode.CONNECT1_PASSWORD);
+        assertThat(account.username()).contains("api@test.com");
+    }
+
+    @Test
+    void itBuildsClientCredentialsAccountFromAuthType() {
+        ApplicationUserAccount account = ApplicationUserAccountConfigMapper.fromAuthType(
+            "production",
+            "/tmp/prod.db",
+            "client-credentials",
+            null,
+            null,
+            "tenant",
+            null,
+            "client-id",
+            "client-secret",
+            "api://audience",
+            null
+        );
+
+        assertThat(account.auth()).isInstanceOf(ClientCredentialsAuthConfig.class);
+        assertThat(account.auth().mode()).isEqualTo(AuthMode.CLIENT_CREDENTIALS);
+        ClientCredentialsAuthConfig oauth = (ClientCredentialsAuthConfig) account.auth();
+        assertThat(oauth.resolvedTokenUrl()).contains("tenant");
+        assertThat(oauth.resolvedScope()).isEqualTo("api://audience/.default");
+    }
+}

--- a/connect-library/src/test/java/com/tsanet/api/connectapi/internal/ConnectApiAttachmentsGatewayTest.java
+++ b/connect-library/src/test/java/com/tsanet/api/connectapi/internal/ConnectApiAttachmentsGatewayTest.java
@@ -1,0 +1,60 @@
+package com.tsanet.api.connectapi.internal;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.Mockito.when;
+
+import com.tsanet.api.connectapi.dto.AttachmentConfigDto;
+import com.tsanet.api.generated.api.CaseAttachmentsApi;
+import com.tsanet.api.generated.model.AttachmentConfigDTO;
+import com.tsanet.api.generated.model.CompanyAttachmentConfigDTO;
+import com.tsanet.api.storage.AttachmentConfigRepository;
+import com.tsanet.api.storage.AttachmentConfigStorageService;
+import com.tsanet.api.storage.AttachmentForwardResultRepository;
+import com.tsanet.api.storage.AttachmentForwardResultStorageService;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.jdbc.core.JdbcTemplate;
+
+@ExtendWith({MockitoExtension.class, GatewayTestDatabaseExtension.class})
+class ConnectApiAttachmentsGatewayTest {
+    @Mock
+    private CaseAttachmentsApi caseAttachmentsApi;
+
+    private ConnectApiAttachmentsGateway gateway;
+
+    @BeforeEach
+    void setUp() {
+        JdbcTemplate jdbcTemplate = GatewayTestSupport.inMemoryJdbc("attachments-gateway-test");
+        AttachmentConfigStorageService configStorageService =
+            new AttachmentConfigStorageService(new AttachmentConfigRepository(jdbcTemplate));
+        AttachmentForwardResultStorageService forwardStorageService =
+            new AttachmentForwardResultStorageService(new AttachmentForwardResultRepository(jdbcTemplate));
+        gateway = new ConnectApiAttachmentsGateway(
+            caseAttachmentsApi,
+            GatewayTestSupport.authenticatedSessionStore(),
+            configStorageService,
+            forwardStorageService
+        );
+    }
+
+    @Test
+    void itFetchesAttachmentConfigAndPersistsIt() {
+        CompanyAttachmentConfigDTO submitter = new CompanyAttachmentConfigDTO().companyId(1L);
+        AttachmentConfigDTO apiConfig = new AttachmentConfigDTO().submitter(submitter);
+        when(caseAttachmentsApi.getAttachmentConfig("tok-att")).thenReturn(apiConfig);
+
+        AttachmentConfigDto config = gateway.getAttachmentConfig("tok-att");
+
+        assertThat(config.submitter().companyId()).isEqualTo(1L);
+    }
+
+    @Test
+    void itRejectsInvalidForwardPayload() {
+        assertThatThrownBy(() -> gateway.forwardAttachments("tok-att", "  ", java.util.List.of()))
+            .isInstanceOf(IllegalArgumentException.class);
+    }
+}

--- a/connect-library/src/test/java/com/tsanet/api/connectapi/internal/ConnectApiAuthGatewayTest.java
+++ b/connect-library/src/test/java/com/tsanet/api/connectapi/internal/ConnectApiAuthGatewayTest.java
@@ -1,0 +1,48 @@
+package com.tsanet.api.connectapi.internal;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import com.tsanet.api.generated.api.IdentityApi;
+import com.tsanet.api.generated.model.LoginRequestDTO;
+import com.tsanet.api.generated.model.TokenDTO;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+@ExtendWith(MockitoExtension.class)
+class ConnectApiAuthGatewayTest {
+    @Mock
+    private IdentityApi identityApi;
+
+    @Test
+    void itReturnsAccessTokenFromLoginResponse() {
+        when(identityApi.login(any(LoginRequestDTO.class)))
+            .thenReturn(new TokenDTO().accessToken("jwt-token-123"));
+
+        ConnectApiAuthGateway gateway = new ConnectApiAuthGateway(identityApi);
+
+        assertThat(gateway.login("api@test.com", "secret")).isEqualTo("jwt-token-123");
+
+        ArgumentCaptor<LoginRequestDTO> captor = ArgumentCaptor.forClass(LoginRequestDTO.class);
+        verify(identityApi).login(captor.capture());
+        assertThat(captor.getValue().getUsername()).isEqualTo("api@test.com");
+        assertThat(captor.getValue().getPassword()).isEqualTo("secret");
+    }
+
+    @Test
+    void itRejectsMissingAccessToken() {
+        when(identityApi.login(any(LoginRequestDTO.class))).thenReturn(new TokenDTO());
+
+        ConnectApiAuthGateway gateway = new ConnectApiAuthGateway(identityApi);
+
+        assertThatThrownBy(() -> gateway.login("api@test.com", "secret"))
+            .isInstanceOf(IllegalStateException.class)
+            .hasMessageContaining("accessToken is missing");
+    }
+}

--- a/connect-library/src/test/java/com/tsanet/api/connectapi/internal/ConnectApiCollaborationGatewayTest.java
+++ b/connect-library/src/test/java/com/tsanet/api/connectapi/internal/ConnectApiCollaborationGatewayTest.java
@@ -1,0 +1,92 @@
+package com.tsanet.api.connectapi.internal;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import com.tsanet.api.connectapi.dto.CollaborationRequestStatusDto;
+import com.tsanet.api.generated.api.CollaborationRequestsApi;
+import com.tsanet.api.generated.model.CollaborationRequestDTO;
+import com.tsanet.api.generated.model.CollaborationRequestStatusDTO;
+import com.tsanet.api.storage.CollaborationRequestRepository;
+import com.tsanet.api.storage.CollaborationRequestStorageService;
+import java.util.List;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.jdbc.core.JdbcTemplate;
+
+@ExtendWith({MockitoExtension.class, GatewayTestDatabaseExtension.class})
+class ConnectApiCollaborationGatewayTest {
+    @Mock
+    private CollaborationRequestsApi collaborationRequestsApi;
+
+    private ConnectApiSessionStore sessionStore;
+    private CollaborationRequestStorageService storageService;
+    private ConnectApiCollaborationGateway gateway;
+
+    @BeforeEach
+    void setUp() {
+        sessionStore = GatewayTestSupport.authenticatedSessionStore();
+        JdbcTemplate jdbcTemplate = GatewayTestSupport.inMemoryJdbc("collab-gateway-test");
+        storageService = new CollaborationRequestStorageService(new CollaborationRequestRepository(jdbcTemplate));
+        gateway = new ConnectApiCollaborationGateway(collaborationRequestsApi, sessionStore, storageService);
+    }
+
+    @Test
+    void itRequiresLoginBeforeListingRequests() {
+        sessionStore.clear();
+
+        assertThatThrownBy(gateway::getCollaborationRequests)
+            .isInstanceOf(IllegalStateException.class)
+            .hasMessageContaining("Not logged in");
+    }
+
+    @Test
+    void itMapsListResponseAndPersistsToSqlite() {
+        CollaborationRequestStatusDTO apiDto = GatewayTestSupport.sampleCollaborationRequest("tok-list");
+        when(collaborationRequestsApi.listCollaborationRequests(null, null, null, null, null, false))
+            .thenReturn(List.of(apiDto));
+
+        List<CollaborationRequestStatusDto> requests = gateway.getCollaborationRequests();
+
+        assertThat(requests).singleElement().satisfies(request -> {
+            assertThat(request.id()).isEqualTo(42L);
+            assertThat(request.status()).isEqualTo("OPEN");
+            assertThat(request.summary()).isEqualTo("Need help");
+            assertThat(request.token()).isEqualTo("tok-list");
+        });
+        assertThat(storageService.findAll()).hasSize(1);
+    }
+
+    @Test
+    void itFetchesRequestByToken() {
+        CollaborationRequestStatusDTO apiDto = GatewayTestSupport.sampleCollaborationRequest("tok-abc");
+        when(collaborationRequestsApi.getCollaborationRequestByToken("tok-abc", false)).thenReturn(apiDto);
+
+        CollaborationRequestStatusDto request = gateway.getCollaborationRequestByToken("tok-abc");
+
+        assertThat(request.token()).isEqualTo("tok-abc");
+        assertThat(storageService.findAll()).singleElement().extracting(CollaborationRequestStatusDto::token)
+            .isEqualTo("tok-abc");
+        verify(collaborationRequestsApi).getCollaborationRequestByToken("tok-abc", false);
+    }
+
+    @Test
+    void itCreatesCollaborationRequest() {
+        CollaborationRequestDTO createPayload = new CollaborationRequestDTO();
+        CollaborationRequestStatusDTO created = GatewayTestSupport.sampleCollaborationRequest("tok-new");
+        created.setSummary("Created case");
+        when(collaborationRequestsApi.createCollaborationRequest(createPayload)).thenReturn(created);
+
+        CollaborationRequestStatusDto result = gateway.createCollaborationRequest(createPayload);
+
+        assertThat(result.summary()).isEqualTo("Created case");
+        assertThat(storageService.findAll()).hasSize(1);
+        verify(collaborationRequestsApi).createCollaborationRequest(createPayload);
+    }
+}

--- a/connect-library/src/test/java/com/tsanet/api/connectapi/internal/ConnectApiFormGatewayTest.java
+++ b/connect-library/src/test/java/com/tsanet/api/connectapi/internal/ConnectApiFormGatewayTest.java
@@ -1,0 +1,57 @@
+package com.tsanet.api.connectapi.internal;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import com.tsanet.api.generated.api.FormRequestApi;
+import com.tsanet.api.generated.model.CollaborationRequestDTO;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+@ExtendWith(MockitoExtension.class)
+class ConnectApiFormGatewayTest {
+    @Mock
+    private FormRequestApi formRequestApi;
+
+    @Test
+    void itFetchesFormByCompanyId() {
+        CollaborationRequestDTO form = new CollaborationRequestDTO().documentId(100L);
+        when(formRequestApi.getFormByCompanyId(2L)).thenReturn(form);
+
+        ConnectApiFormGateway gateway = new ConnectApiFormGateway(
+            formRequestApi,
+            GatewayTestSupport.authenticatedSessionStore()
+        );
+
+        assertThat(gateway.getFormByCompanyId(2L).getDocumentId()).isEqualTo(100L);
+        verify(formRequestApi).getFormByCompanyId(2L);
+    }
+
+    @Test
+    void itRequiresLogin() {
+        ConnectApiSessionStore sessionStore = new ConnectApiSessionStore();
+        ConnectApiFormGateway gateway = new ConnectApiFormGateway(formRequestApi, sessionStore);
+
+        assertThatThrownBy(() -> gateway.getFormByDepartmentId(3L))
+            .isInstanceOf(IllegalStateException.class)
+            .hasMessageContaining("Not logged in");
+    }
+
+    @Test
+    void itRejectsEmptyFormResponse() {
+        when(formRequestApi.getFormByDocumentId(9L)).thenReturn(null);
+
+        ConnectApiFormGateway gateway = new ConnectApiFormGateway(
+            formRequestApi,
+            GatewayTestSupport.authenticatedSessionStore()
+        );
+
+        assertThatThrownBy(() -> gateway.getFormByDocumentId(9L))
+            .isInstanceOf(IllegalStateException.class)
+            .hasMessageContaining("document id=9");
+    }
+}

--- a/connect-library/src/test/java/com/tsanet/api/connectapi/internal/ConnectApiNotesGatewayTest.java
+++ b/connect-library/src/test/java/com/tsanet/api/connectapi/internal/ConnectApiNotesGatewayTest.java
@@ -1,0 +1,97 @@
+package com.tsanet.api.connectapi.internal;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import com.tsanet.api.connectapi.dto.CaseNoteDto;
+import com.tsanet.api.generated.api.CaseNotesApi;
+import com.tsanet.api.generated.model.CaseNoteDTO;
+import com.tsanet.api.generated.model.CaseNoteTemplateDTO;
+import com.tsanet.api.generated.model.NotePriority;
+import com.tsanet.api.storage.CaseNoteRepository;
+import com.tsanet.api.storage.CaseNoteStorageService;
+import java.util.Collections;
+import java.util.List;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.jdbc.core.JdbcTemplate;
+
+@ExtendWith({MockitoExtension.class, GatewayTestDatabaseExtension.class})
+class ConnectApiNotesGatewayTest {
+    @Mock
+    private CaseNotesApi caseNotesApi;
+
+    private ConnectApiSessionStore sessionStore;
+    private CaseNoteStorageService storageService;
+    private ConnectApiNotesGateway gateway;
+
+    @BeforeEach
+    void setUp() {
+        sessionStore = GatewayTestSupport.authenticatedSessionStore();
+        JdbcTemplate jdbcTemplate = GatewayTestSupport.inMemoryJdbc("notes-gateway-test");
+        storageService = new CaseNoteStorageService(new CaseNoteRepository(jdbcTemplate));
+        gateway = new ConnectApiNotesGateway(caseNotesApi, sessionStore, storageService);
+    }
+
+    @Test
+    void itMapsNotesAndPersistsThem() {
+        CaseNoteDTO apiNote = new CaseNoteDTO()
+            .id(7L)
+            .summary("Update")
+            .description("Details")
+            .priority(NotePriority.MEDIUM)
+            .token("note-token-7");
+        when(caseNotesApi.getNotes("tok-1", null, null, false)).thenReturn(List.of(apiNote));
+
+        List<CaseNoteDto> notes = gateway.getNotes("tok-1");
+
+        assertThat(notes).singleElement().satisfies(note -> {
+            assertThat(note.id()).isEqualTo(7L);
+            assertThat(note.caseToken()).isEqualTo("tok-1");
+            assertThat(note.summary()).isEqualTo("Update");
+            assertThat(note.priority()).isEqualTo("MEDIUM");
+        });
+    }
+
+    @Test
+    void itCreatesNoteAndRefreshesCache() {
+        CaseNoteDTO created = new CaseNoteDTO()
+            .id(99L)
+            .summary("New note")
+            .description("Body")
+            .priority(NotePriority.HIGH)
+            .token("note-token-99");
+        when(caseNotesApi.createNote(eq("tok-2"), any(CaseNoteTemplateDTO.class))).thenReturn(created);
+        when(caseNotesApi.getNotes("tok-2", null, null, false)).thenReturn(List.of(created));
+
+        CaseNoteDto note = gateway.createNote("tok-2", "New note", "Body", "HIGH");
+
+        assertThat(note.id()).isEqualTo(99L);
+
+        ArgumentCaptor<CaseNoteTemplateDTO> captor = ArgumentCaptor.forClass(CaseNoteTemplateDTO.class);
+        verify(caseNotesApi).createNote(eq("tok-2"), captor.capture());
+        assertThat(captor.getValue().getSummary()).isEqualTo("New note");
+        assertThat(captor.getValue().getPriority()).isEqualTo(NotePriority.HIGH);
+    }
+
+    @Test
+    void itRejectsInvalidNoteInput() {
+        assertThatThrownBy(() -> gateway.createNote("tok-2", "  ", "Body", "HIGH"))
+            .isInstanceOf(IllegalArgumentException.class);
+    }
+
+    @Test
+    void itReturnsEmptyListWhenApiReturnsNull() {
+        when(caseNotesApi.getNotes("tok-empty", null, null, false)).thenReturn(null);
+
+        assertThat(gateway.getNotes("tok-empty")).isEqualTo(Collections.emptyList());
+    }
+}

--- a/connect-library/src/test/java/com/tsanet/api/connectapi/internal/ConnectApiPartnersGatewayTest.java
+++ b/connect-library/src/test/java/com/tsanet/api/connectapi/internal/ConnectApiPartnersGatewayTest.java
@@ -1,0 +1,82 @@
+package com.tsanet.api.connectapi.internal;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.Mockito.when;
+
+import com.tsanet.api.connectapi.dto.PartnerSelectionDto;
+import com.tsanet.api.generated.api.EntitySearchApi;
+import com.tsanet.api.generated.model.PartnerSelectionDTO;
+import com.tsanet.api.storage.PartnerSelectionRepository;
+import com.tsanet.api.storage.PartnerSelectionStorageService;
+import java.util.List;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.jdbc.core.JdbcTemplate;
+
+@ExtendWith({MockitoExtension.class, GatewayTestDatabaseExtension.class})
+class ConnectApiPartnersGatewayTest {
+    @Mock
+    private EntitySearchApi entitySearchApi;
+
+    private ConnectApiPartnersGateway gateway;
+
+    @BeforeEach
+    void setUp() {
+        JdbcTemplate jdbcTemplate = GatewayTestSupport.inMemoryJdbc("partners-gateway-test");
+        PartnerSelectionStorageService storageService =
+            new PartnerSelectionStorageService(new PartnerSelectionRepository(jdbcTemplate));
+        gateway = new ConnectApiPartnersGateway(
+            entitySearchApi,
+            GatewayTestSupport.authenticatedSessionStore(),
+            storageService
+        );
+    }
+
+    @Test
+    void itSearchesPartnersByKeywordAndPersistsResults() {
+        PartnerSelectionDTO apiPartner = new PartnerSelectionDTO()
+            .label("Beta Corp / Support")
+            .companyName("Beta Corp")
+            .companyId(2L)
+            .documentId(100L);
+        when(entitySearchApi.searchPartners("beta")).thenReturn(List.of(apiPartner));
+
+        List<PartnerSelectionDto> partners = gateway.searchPartners(" beta ");
+
+        assertThat(partners).singleElement().satisfies(partner -> {
+            assertThat(partner.searchTerm()).isEqualTo("beta");
+            assertThat(partner.label()).isEqualTo("Beta Corp / Support");
+            assertThat(partner.companyId()).isEqualTo(2L);
+        });
+    }
+
+    @Test
+    void itRejectsBlankKeywordSearch() {
+        assertThatThrownBy(() -> gateway.searchPartners("   "))
+            .isInstanceOf(IllegalArgumentException.class);
+    }
+
+    @Test
+    void itSearchesPartnersSemantically() {
+        PartnerSelectionDTO apiPartner = new PartnerSelectionDTO()
+            .label("Acme")
+            .companyName("Acme Corp")
+            .companyId(1L)
+            .documentId(101L);
+        when(entitySearchApi.searchPartnersSemanticSearch("network issue", 5)).thenReturn(List.of(apiPartner));
+
+        List<PartnerSelectionDto> partners = gateway.searchPartnersSemantic("network issue", 5);
+
+        assertThat(partners).singleElement().extracting(PartnerSelectionDto::companyId).isEqualTo(1L);
+    }
+
+    @Test
+    void itRejectsInvalidSemanticLimit() {
+        assertThatThrownBy(() -> gateway.searchPartnersSemantic("network issue", 0))
+            .isInstanceOf(IllegalArgumentException.class);
+    }
+}

--- a/connect-library/src/test/java/com/tsanet/api/connectapi/internal/ConnectApiResponsesGatewayTest.java
+++ b/connect-library/src/test/java/com/tsanet/api/connectapi/internal/ConnectApiResponsesGatewayTest.java
@@ -1,0 +1,124 @@
+package com.tsanet.api.connectapi.internal;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import com.tsanet.api.connectapi.dto.CaseResponseDto;
+import com.tsanet.api.connectapi.dto.CollaborationRequestStatusDto;
+import com.tsanet.api.generated.api.CaseResponsesApi;
+import com.tsanet.api.generated.api.CollaborationRequestsApi;
+import com.tsanet.api.generated.model.CaseApprovalDTO;
+import com.tsanet.api.generated.model.CaseResponseDTO;
+import com.tsanet.api.generated.model.CaseResponseType;
+import com.tsanet.api.generated.model.CaseStatus;
+import com.tsanet.api.generated.model.CollaborationRequestStatusDTO;
+import com.tsanet.api.storage.CaseResponseRepository;
+import com.tsanet.api.storage.CaseResponseStorageService;
+import com.tsanet.api.storage.CollaborationRequestRepository;
+import com.tsanet.api.storage.CollaborationRequestStorageService;
+import java.time.OffsetDateTime;
+import java.util.List;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.jdbc.core.JdbcTemplate;
+
+@ExtendWith({MockitoExtension.class, GatewayTestDatabaseExtension.class})
+class ConnectApiResponsesGatewayTest {
+    @Mock
+    private CollaborationRequestsApi collaborationRequestsApi;
+    @Mock
+    private CaseResponsesApi caseResponsesApi;
+
+    private CaseResponseStorageService responseStorageService;
+    private CollaborationRequestStorageService collaborationStorageService;
+    private ConnectApiResponsesGateway gateway;
+
+    @BeforeEach
+    void setUp() {
+        JdbcTemplate jdbcTemplate = GatewayTestSupport.inMemoryJdbc("responses-gateway-test");
+        responseStorageService = new CaseResponseStorageService(new CaseResponseRepository(jdbcTemplate));
+        collaborationStorageService = new CollaborationRequestStorageService(new CollaborationRequestRepository(jdbcTemplate));
+        gateway = new ConnectApiResponsesGateway(
+            collaborationRequestsApi,
+            caseResponsesApi,
+            GatewayTestSupport.authenticatedSessionStore(),
+            responseStorageService,
+            collaborationStorageService
+        );
+    }
+
+    @Test
+    void itReadsResponsesFromCollaborationRequestPayload() {
+        CaseResponseDTO apiResponse = new CaseResponseDTO()
+            .id(3L)
+            .type(CaseResponseType.APPROVAL)
+            .caseNumber("CASE-1")
+            .engineerName("Engineer")
+            .createdAt(OffsetDateTime.parse("2026-01-03T10:00:00Z"));
+        CollaborationRequestStatusDTO request = GatewayTestSupport.sampleCollaborationRequest("tok-resp");
+        request.setCaseResponses(List.of(apiResponse));
+        when(collaborationRequestsApi.getCollaborationRequestByToken("tok-resp", false)).thenReturn(request);
+
+        List<CaseResponseDto> responses = gateway.getResponses("tok-resp");
+
+        assertThat(responses).singleElement().satisfies(response -> {
+            assertThat(response.id()).isEqualTo(3L);
+            assertThat(response.caseToken()).isEqualTo("tok-resp");
+            assertThat(response.type()).isEqualTo("APPROVAL");
+        });
+        assertThat(responseStorageService.findByCaseToken("tok-resp")).hasSize(1);
+    }
+
+    @Test
+    void itApprovesCollaborationRequestAndRefreshesCache() {
+        CollaborationRequestStatusDTO approved = GatewayTestSupport.sampleCollaborationRequest("tok-approve");
+        approved.setStatus(CaseStatus.ACCEPTED);
+        when(caseResponsesApi.approveCollaborationRequest(eq("tok-approve"), any(CaseApprovalDTO.class)))
+            .thenReturn(approved);
+        when(collaborationRequestsApi.getCollaborationRequestByToken("tok-approve", false)).thenReturn(approved);
+
+        CollaborationRequestStatusDto result = gateway.approveCollaborationRequest(
+            "tok-approve",
+            "CASE-9",
+            "Engineer",
+            "eng@test.com",
+            "+123",
+            "Next steps"
+        );
+
+        assertThat(result.status()).isEqualTo("ACCEPTED");
+        assertThat(collaborationStorageService.findAll()).hasSize(1);
+
+        ArgumentCaptor<CaseApprovalDTO> captor = ArgumentCaptor.forClass(CaseApprovalDTO.class);
+        verify(caseResponsesApi).approveCollaborationRequest(eq("tok-approve"), captor.capture());
+        assertThat(captor.getValue().getCaseNumber()).isEqualTo("CASE-9");
+        assertThat(captor.getValue().getNextSteps()).isEqualTo("Next steps");
+    }
+
+    @Test
+    void itRejectsInvalidRejectionPayload() {
+        assertThatThrownBy(() -> gateway.rejectCollaborationRequest("tok", " ", "a@b.com", null, "reason"))
+            .isInstanceOf(IllegalArgumentException.class);
+    }
+
+    @Test
+    void itClosesCollaborationRequest() {
+        CollaborationRequestStatusDTO closed = GatewayTestSupport.sampleCollaborationRequest("tok-close");
+        closed.setStatus(CaseStatus.CLOSED);
+        when(caseResponsesApi.closeCollaborationRequest("tok-close")).thenReturn(closed);
+        when(collaborationRequestsApi.getCollaborationRequestByToken("tok-close", false)).thenReturn(closed);
+
+        CollaborationRequestStatusDto result = gateway.closeCollaborationRequest("tok-close");
+
+        assertThat(result.status()).isEqualTo("CLOSED");
+        verify(caseResponsesApi).closeCollaborationRequest("tok-close");
+    }
+}

--- a/connect-library/src/test/java/com/tsanet/api/connectapi/internal/ConnectApiSessionStoreTest.java
+++ b/connect-library/src/test/java/com/tsanet/api/connectapi/internal/ConnectApiSessionStoreTest.java
@@ -1,0 +1,44 @@
+package com.tsanet.api.connectapi.internal;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import com.tsanet.api.auth.AuthMode;
+import java.time.Instant;
+import org.junit.jupiter.api.Test;
+
+class ConnectApiSessionStoreTest {
+    @Test
+    void itTracksPasswordSessionWithoutExpiry() {
+        ConnectApiSessionStore store = new ConnectApiSessionStore();
+        store.savePassword("api@test.com", "token");
+
+        assertThat(store.isAuthorized()).isTrue();
+        assertThat(store.getUsername()).contains("api@test.com");
+        assertThat(store.getAuthMode()).contains(AuthMode.CONNECT1_PASSWORD);
+        assertThat(store.getExpiresAt()).isEmpty();
+        assertThat(store.isExpired(Instant.now())).isFalse();
+    }
+
+    @Test
+    void itMarksOAuthTokenExpiredWithinSkewWindow() {
+        ConnectApiSessionStore store = new ConnectApiSessionStore();
+        Instant expiresAt = Instant.parse("2026-01-01T12:00:00Z");
+        store.saveOAuth("production", "oauth-token", expiresAt);
+
+        assertThat(store.getAuthMode()).contains(AuthMode.CLIENT_CREDENTIALS);
+        assertThat(store.getAccountId()).contains("production");
+        assertThat(store.isExpired(expiresAt.minusSeconds(TokenManager.EXPIRY_SKEW.getSeconds() - 1))).isTrue();
+        assertThat(store.isExpired(expiresAt.minusSeconds(TokenManager.EXPIRY_SKEW.getSeconds() + 30))).isFalse();
+    }
+
+    @Test
+    void itClearsAuthorizationOnLogout() {
+        ConnectApiSessionStore store = new ConnectApiSessionStore();
+        store.saveOAuth("production", "oauth-token", Instant.parse("2026-01-01T12:00:00Z"));
+
+        store.clear();
+
+        assertThat(store.isAuthorized()).isFalse();
+        assertThat(store.getBearerToken()).isEmpty();
+    }
+}

--- a/connect-library/src/test/java/com/tsanet/api/connectapi/internal/ConnectApiUserGatewayTest.java
+++ b/connect-library/src/test/java/com/tsanet/api/connectapi/internal/ConnectApiUserGatewayTest.java
@@ -1,0 +1,56 @@
+package com.tsanet.api.connectapi.internal;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import com.tsanet.api.connectapi.dto.UserContextDto;
+import com.tsanet.api.generated.api.IdentityApi;
+import com.tsanet.api.generated.model.CompanyDTO;
+import com.tsanet.api.generated.model.UserContextDTO;
+import com.tsanet.api.generated.model.UserDTO;
+import com.tsanet.api.storage.UserContextRepository;
+import com.tsanet.api.storage.UserContextStorageService;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.jdbc.core.JdbcTemplate;
+
+@ExtendWith({MockitoExtension.class, GatewayTestDatabaseExtension.class})
+class ConnectApiUserGatewayTest {
+    @Mock
+    private IdentityApi identityApi;
+
+    private UserContextStorageService storageService;
+    private ConnectApiUserGateway gateway;
+
+    @BeforeEach
+    void setUp() {
+        JdbcTemplate jdbcTemplate = GatewayTestSupport.inMemoryJdbc("user-gateway-test");
+        storageService = new UserContextStorageService(new UserContextRepository(jdbcTemplate));
+        gateway = new ConnectApiUserGateway(
+            identityApi,
+            GatewayTestSupport.authenticatedSessionStore(),
+            storageService
+        );
+    }
+
+    @Test
+    void itMapsCurrentUserAndPersistsContext() {
+        UserContextDTO apiUser = new UserContextDTO()
+            .company(new CompanyDTO().id(10L).name("Acme"))
+            .user(new UserDTO().id(5L).username("api@test.com").email("api@test.com").firstName("Api").lastName("User"));
+        when(identityApi.getCurrentUser()).thenReturn(apiUser);
+
+        UserContextDto user = gateway.getCurrentUser();
+
+        assertThat(user.companyId()).isEqualTo(10L);
+        assertThat(user.companyName()).isEqualTo("Acme");
+        assertThat(user.userId()).isEqualTo(5L);
+        assertThat(user.username()).isEqualTo("api@test.com");
+        assertThat(storageService.findAll()).singleElement().isEqualTo(user);
+        verify(identityApi).getCurrentUser();
+    }
+}

--- a/connect-library/src/test/java/com/tsanet/api/connectapi/internal/ConnectApiWebhooksGatewayTest.java
+++ b/connect-library/src/test/java/com/tsanet/api/connectapi/internal/ConnectApiWebhooksGatewayTest.java
@@ -1,0 +1,132 @@
+package com.tsanet.api.connectapi.internal;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import com.tsanet.api.connectapi.dto.WebhookDeliveryDto;
+import com.tsanet.api.connectapi.dto.WebhookSubscriptionDto;
+import com.tsanet.api.connectapi.dto.WebhookSubscriptionResponseDto;
+import com.tsanet.api.generated.api.WebhooksApi;
+import com.tsanet.api.generated.api.WebhooksV1Api;
+import com.tsanet.api.generated.model.CreateWebhookSubscriptionRequestDTO;
+import com.tsanet.api.generated.model.WebhookDeliveryLogDTO;
+import com.tsanet.api.generated.model.WebhookDeliveryLogPageDTO;
+import com.tsanet.api.generated.model.WebhookEventType;
+import com.tsanet.api.generated.model.WebhookSubscriptionDTO;
+import com.tsanet.api.generated.model.WebhookSubscriptionResponseDTO;
+import com.tsanet.api.storage.WebhookSubscriptionRepository;
+import com.tsanet.api.storage.WebhookSubscriptionStorageService;
+import java.time.OffsetDateTime;
+import java.util.List;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.jdbc.core.JdbcTemplate;
+
+@ExtendWith({MockitoExtension.class, GatewayTestDatabaseExtension.class})
+class ConnectApiWebhooksGatewayTest {
+    @Mock
+    private WebhooksV1Api webhooksV1Api;
+    @Mock
+    private WebhooksApi webhooksApi;
+
+    private WebhookSubscriptionStorageService storageService;
+    private ConnectApiWebhooksGateway gateway;
+
+    @BeforeEach
+    void setUp() {
+        JdbcTemplate jdbcTemplate = GatewayTestSupport.inMemoryJdbc("webhooks-gateway-test");
+        storageService = new WebhookSubscriptionStorageService(new WebhookSubscriptionRepository(jdbcTemplate));
+        gateway = new ConnectApiWebhooksGateway(
+            webhooksV1Api,
+            webhooksApi,
+            GatewayTestSupport.authenticatedSessionStore(),
+            storageService
+        );
+    }
+
+    @Test
+    void itListsWebhookSubscriptionsAndPersistsThem() {
+        WebhookSubscriptionDTO apiSubscription = new WebhookSubscriptionDTO()
+            .id(1L)
+            .callbackUrl("https://example.com/hook")
+            .eventTypes(List.of(WebhookEventType.COLLABORATION_REQUEST_CREATED))
+            .active(true);
+        when(webhooksV1Api.listWebhookSubscriptions()).thenReturn(List.of(apiSubscription));
+
+        List<WebhookSubscriptionDto> subscriptions = gateway.listWebhookSubscriptions();
+
+        assertThat(subscriptions).singleElement().satisfies(subscription -> {
+            assertThat(subscription.id()).isEqualTo(1L);
+            assertThat(subscription.callbackUrl()).isEqualTo("https://example.com/hook");
+            assertThat(subscription.eventTypes()).isEqualTo("COLLABORATION_REQUEST_CREATED");
+        });
+        assertThat(storageService.findAll()).hasSize(1);
+    }
+
+    @Test
+    void itCreatesWebhookSubscriptionAndStoresSecret() {
+        WebhookSubscriptionResponseDTO created = new WebhookSubscriptionResponseDTO()
+            .id(5L)
+            .callbackUrl("https://example.com/new")
+            .secret("hmac-secret")
+            .active(true);
+        when(webhooksV1Api.createWebhookSubscription(any(CreateWebhookSubscriptionRequestDTO.class))).thenReturn(created);
+        when(webhooksV1Api.listWebhookSubscriptions()).thenReturn(List.of());
+
+        WebhookSubscriptionResponseDto response = gateway.createWebhookSubscription(
+            "https://example.com/new",
+            List.of("collaboration-request.created")
+        );
+
+        assertThat(response.id()).isEqualTo(5L);
+        assertThat(response.secret()).isEqualTo("hmac-secret");
+
+        ArgumentCaptor<CreateWebhookSubscriptionRequestDTO> captor =
+            ArgumentCaptor.forClass(CreateWebhookSubscriptionRequestDTO.class);
+        verify(webhooksV1Api).createWebhookSubscription(captor.capture());
+        assertThat(captor.getValue().getCallbackUrl().toString()).isEqualTo("https://example.com/new");
+    }
+
+    @Test
+    void itMapsWebhookDeliveryLogs() {
+        WebhookDeliveryLogDTO delivery = new WebhookDeliveryLogDTO()
+            .id(10L)
+            .cloudEventId("evt-123")
+            .eventType("collaboration-request.created")
+            .httpStatus(200)
+            .attemptNumber(1)
+            .success(true)
+            .createdAt(OffsetDateTime.parse("2026-01-04T10:00:00Z"));
+        WebhookDeliveryLogPageDTO page = new WebhookDeliveryLogPageDTO()
+            .content(List.of(delivery))
+            .totalElements(1L)
+            .totalPages(1)
+            .size(20)
+            .number(0);
+        when(webhooksApi.getWebhookDeliveries(5L, 0, 20)).thenReturn(page);
+
+        List<WebhookDeliveryDto> deliveries = gateway.listWebhookDeliveries(5L, 0, 20).content();
+
+        assertThat(deliveries).singleElement().satisfies(item -> {
+            assertThat(item.id()).isEqualTo(10L);
+            assertThat(item.cloudEventId()).isEqualTo("evt-123");
+            assertThat(item.success()).isTrue();
+        });
+    }
+
+    @Test
+    void itDeletesWebhookSubscriptionAndRefreshesCache() {
+        when(webhooksV1Api.listWebhookSubscriptions()).thenReturn(List.of());
+
+        gateway.deleteWebhookSubscription(7L);
+
+        verify(webhooksApi).deleteWebhookSubscription(7L);
+        verify(webhooksV1Api).listWebhookSubscriptions();
+    }
+}

--- a/connect-library/src/test/java/com/tsanet/api/connectapi/internal/GatewayTestDatabaseExtension.java
+++ b/connect-library/src/test/java/com/tsanet/api/connectapi/internal/GatewayTestDatabaseExtension.java
@@ -1,0 +1,11 @@
+package com.tsanet.api.connectapi.internal;
+
+import org.junit.jupiter.api.extension.AfterEachCallback;
+import org.junit.jupiter.api.extension.ExtensionContext;
+
+final class GatewayTestDatabaseExtension implements AfterEachCallback {
+    @Override
+    public void afterEach(ExtensionContext context) {
+        GatewayTestSupport.cleanupCreatedDatabases();
+    }
+}

--- a/connect-library/src/test/java/com/tsanet/api/connectapi/internal/GatewayTestSupport.java
+++ b/connect-library/src/test/java/com/tsanet/api/connectapi/internal/GatewayTestSupport.java
@@ -1,0 +1,79 @@
+package com.tsanet.api.connectapi.internal;
+
+import com.tsanet.api.generated.model.CaseStatus;
+import com.tsanet.api.generated.model.CollaborationRequestStatusDTO;
+import com.tsanet.api.storage.DatabaseInitializer;
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.time.OffsetDateTime;
+import java.util.ArrayList;
+import java.util.List;
+import org.springframework.jdbc.core.JdbcTemplate;
+import org.sqlite.SQLiteDataSource;
+
+final class GatewayTestSupport {
+    private static final Path TEST_DB_DIR = Path.of("target", "gateway-test-dbs");
+    private static final ThreadLocal<List<Path>> CREATED_DATABASES = ThreadLocal.withInitial(ArrayList::new);
+
+    private GatewayTestSupport() {
+    }
+
+    static ConnectApiSessionStore authenticatedSessionStore() {
+        ConnectApiSessionStore sessionStore = new ConnectApiSessionStore();
+        sessionStore.savePassword("api@test.com", "test-token");
+        return sessionStore;
+    }
+
+    static JdbcTemplate inMemoryJdbc(String dbName) {
+        try {
+            Files.createDirectories(TEST_DB_DIR);
+            Path dbPath = TEST_DB_DIR.resolve(dbName + "-" + System.nanoTime() + ".db").toAbsolutePath().normalize();
+            CREATED_DATABASES.get().add(dbPath);
+
+            SQLiteDataSource dataSource = new SQLiteDataSource();
+            dataSource.setUrl("jdbc:sqlite:" + dbPath);
+            JdbcTemplate jdbcTemplate = new JdbcTemplate(dataSource);
+            DatabaseInitializer.createSchema(jdbcTemplate);
+            return jdbcTemplate;
+        } catch (IOException ex) {
+            throw new IllegalStateException("Failed to initialize test SQLite database", ex);
+        }
+    }
+
+    static void cleanupCreatedDatabases() {
+        for (Path dbPath : CREATED_DATABASES.get()) {
+            deleteSqliteFiles(dbPath);
+        }
+        CREATED_DATABASES.get().clear();
+    }
+
+    private static void deleteSqliteFiles(Path dbPath) {
+        deleteIfExists(dbPath);
+        deleteIfExists(Path.of(dbPath + "-journal"));
+        deleteIfExists(Path.of(dbPath + "-wal"));
+        deleteIfExists(Path.of(dbPath + "-shm"));
+    }
+
+    private static void deleteIfExists(Path path) {
+        try {
+            Files.deleteIfExists(path);
+        } catch (IOException ignored) {
+        }
+    }
+
+    static CollaborationRequestStatusDTO sampleCollaborationRequest(String token) {
+        CollaborationRequestStatusDTO dto = new CollaborationRequestStatusDTO();
+        dto.setId(42L);
+        dto.setStatus(CaseStatus.OPEN);
+        dto.setSummary("Need help");
+        dto.setSubmitCompanyName("Acme");
+        dto.setSubmitCompanyId(1L);
+        dto.setReceiveCompanyName("Beta");
+        dto.setReceiveCompanyId(2L);
+        dto.setToken(token);
+        dto.setCreatedAt(OffsetDateTime.parse("2026-01-01T10:00:00Z"));
+        dto.setUpdatedAt(OffsetDateTime.parse("2026-01-02T10:00:00Z"));
+        return dto;
+    }
+}

--- a/connect-library/src/test/java/com/tsanet/api/connectapi/internal/OAuthTokenGatewayTest.java
+++ b/connect-library/src/test/java/com/tsanet/api/connectapi/internal/OAuthTokenGatewayTest.java
@@ -1,0 +1,42 @@
+package com.tsanet.api.connectapi.internal;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import com.tsanet.api.auth.ClientCredentialsAuthConfig;
+import com.tsanet.api.auth.OAuthAccessToken;
+import java.time.Clock;
+import java.time.Instant;
+import java.time.ZoneOffset;
+import org.junit.jupiter.api.Test;
+import org.springframework.http.HttpMethod;
+import org.springframework.http.MediaType;
+import org.springframework.test.web.client.MockRestServiceServer;
+import org.springframework.web.client.RestTemplate;
+
+import static org.springframework.test.web.client.match.MockRestRequestMatchers.method;
+import static org.springframework.test.web.client.match.MockRestRequestMatchers.requestTo;
+import static org.springframework.test.web.client.response.MockRestResponseCreators.withSuccess;
+
+class OAuthTokenGatewayTest {
+    @Test
+    void itFetchesClientCredentialsToken() {
+        RestTemplate restTemplate = new RestTemplate();
+        MockRestServiceServer server = MockRestServiceServer.createServer(restTemplate);
+        server.expect(requestTo("https://login.microsoftonline.com/tenant/oauth2/v2.0/token"))
+            .andExpect(method(HttpMethod.POST))
+            .andRespond(withSuccess(
+                "{\"access_token\":\"token-123\",\"expires_in\":7200}",
+                MediaType.APPLICATION_JSON
+            ));
+
+        OAuthTokenGateway gateway = new OAuthTokenGateway(restTemplate);
+        OAuthAccessToken token = gateway.fetchClientCredentialsToken(
+            new ClientCredentialsAuthConfig("tenant", null, "client-id", "client-secret", "api://audience", null)
+        );
+
+        assertThat(token.accessToken()).isEqualTo("token-123");
+        assertThat(token.expiresInSeconds()).isEqualTo(7200);
+        server.verify();
+    }
+}

--- a/connect-library/src/test/java/com/tsanet/api/connectapi/internal/TokenManagerTest.java
+++ b/connect-library/src/test/java/com/tsanet/api/connectapi/internal/TokenManagerTest.java
@@ -1,0 +1,118 @@
+package com.tsanet.api.connectapi.internal;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import com.tsanet.api.auth.AuthMode;
+import com.tsanet.api.auth.ClientCredentialsAuthConfig;
+import com.tsanet.api.auth.OAuthAccessToken;
+import com.tsanet.api.auth.PasswordAuthConfig;
+import java.time.Clock;
+import java.time.Instant;
+import java.time.ZoneOffset;
+import org.junit.jupiter.api.Test;
+
+class TokenManagerTest {
+    private static final Instant NOW = Instant.parse("2026-01-01T12:00:00Z");
+    private static final Clock CLOCK = Clock.fixed(NOW, ZoneOffset.UTC);
+
+    @Test
+    void itAuthenticatesWithConfiguredPassword() {
+        ConnectApiSessionStore sessionStore = new ConnectApiSessionStore();
+        ConnectApiAuthGateway authGateway = mock(ConnectApiAuthGateway.class);
+        when(authGateway.login("user@test.com", "secret")).thenReturn("password-token");
+
+        TokenManager tokenManager = new TokenManager(
+            sessionStore,
+            authGateway,
+            mock(OAuthTokenGateway.class),
+            "default",
+            new PasswordAuthConfig("user@test.com", "secret"),
+            CLOCK
+        );
+
+        assertThat(tokenManager.authenticate()).isEqualTo("password-token");
+        assertThat(sessionStore.getAuthMode()).contains(AuthMode.CONNECT1_PASSWORD);
+        assertThat(tokenManager.authMode()).isEqualTo(AuthMode.CONNECT1_PASSWORD);
+    }
+
+    @Test
+    void itRefreshesExpiredOAuthTokenBeforeUse() {
+        ConnectApiSessionStore sessionStore = new ConnectApiSessionStore();
+        sessionStore.saveOAuth("production", "expired-token", NOW.minusSeconds(30));
+
+        OAuthTokenGateway oauthTokenGateway = mock(OAuthTokenGateway.class);
+        ClientCredentialsAuthConfig config = new ClientCredentialsAuthConfig(
+            "tenant",
+            null,
+            "client-id",
+            "client-secret",
+            "api://audience",
+            null
+        );
+        when(oauthTokenGateway.fetchClientCredentialsToken(config))
+            .thenReturn(new OAuthAccessToken("fresh-token", 3600));
+
+        TokenManager tokenManager = new TokenManager(
+            sessionStore,
+            mock(ConnectApiAuthGateway.class),
+            oauthTokenGateway,
+            "production",
+            config,
+            CLOCK
+        );
+
+        assertThat(tokenManager.ensureValidAccessToken()).isEqualTo("fresh-token");
+        assertThat(sessionStore.getBearerToken()).contains("fresh-token");
+        verify(oauthTokenGateway).fetchClientCredentialsToken(config);
+    }
+
+    @Test
+    void itKeepsValidOAuthTokenWithoutRefreshing() {
+        ConnectApiSessionStore sessionStore = new ConnectApiSessionStore();
+        sessionStore.saveOAuth("production", "valid-token", NOW.plusSeconds(600));
+
+        OAuthTokenGateway oauthTokenGateway = mock(OAuthTokenGateway.class);
+        ClientCredentialsAuthConfig config = new ClientCredentialsAuthConfig(
+            "tenant",
+            null,
+            "client-id",
+            "client-secret",
+            "api://audience",
+            null
+        );
+
+        TokenManager tokenManager = new TokenManager(
+            sessionStore,
+            mock(ConnectApiAuthGateway.class),
+            oauthTokenGateway,
+            "production",
+            config,
+            CLOCK
+        );
+
+        assertThat(tokenManager.ensureValidAccessToken()).isEqualTo("valid-token");
+        verify(oauthTokenGateway, never()).fetchClientCredentialsToken(any());
+    }
+
+    @Test
+    void itRejectsRefreshForPasswordAuth() {
+        TokenManager tokenManager = new TokenManager(
+            new ConnectApiSessionStore(),
+            mock(ConnectApiAuthGateway.class),
+            mock(OAuthTokenGateway.class),
+            "default",
+            new PasswordAuthConfig("user@test.com", "secret"),
+            CLOCK
+        );
+
+        assertThatThrownBy(tokenManager::refreshAccessToken)
+            .isInstanceOf(IllegalStateException.class)
+            .hasMessageContaining("client-credentials");
+    }
+}

--- a/connect-library/src/test/java/com/tsanet/api/internal/DefaultTsaNetApiSessionCreateRequestTest.java
+++ b/connect-library/src/test/java/com/tsanet/api/internal/DefaultTsaNetApiSessionCreateRequestTest.java
@@ -1,0 +1,121 @@
+package com.tsanet.api.internal;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyLong;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import com.tsanet.api.TsaNetApiConfiguration;
+import com.tsanet.api.connectapi.dto.CollaborationRequestStatusDto;
+import com.tsanet.api.connectapi.internal.ConnectApiAttachmentsGateway;
+import com.tsanet.api.connectapi.internal.ConnectApiAuthGateway;
+import com.tsanet.api.connectapi.internal.ConnectApiCollaborationGateway;
+import com.tsanet.api.connectapi.internal.ConnectApiFormGateway;
+import com.tsanet.api.connectapi.internal.ConnectApiNotesGateway;
+import com.tsanet.api.connectapi.internal.ConnectApiPartnersGateway;
+import com.tsanet.api.connectapi.internal.ConnectApiResponsesGateway;
+import com.tsanet.api.connectapi.internal.ConnectApiSessionStore;
+import com.tsanet.api.connectapi.internal.ConnectApiUserGateway;
+import com.tsanet.api.connectapi.internal.ConnectApiWebhooksGateway;
+import com.tsanet.api.connectapi.internal.TokenManager;
+import com.tsanet.api.generated.model.CollaborationRequestDTO;
+import com.tsanet.api.storage.AttachmentConfigStorageService;
+import com.tsanet.api.storage.AttachmentForwardResultStorageService;
+import com.tsanet.api.storage.CaseNoteStorageService;
+import com.tsanet.api.storage.CaseResponseStorageService;
+import com.tsanet.api.storage.CollaborationRequestFormStorageService;
+import com.tsanet.api.storage.CollaborationRequestStorageService;
+import com.tsanet.api.storage.PartnerSelectionStorageService;
+import com.tsanet.api.storage.UserContextStorageService;
+import com.tsanet.api.storage.WebhookInboundEventStorageService;
+import com.tsanet.api.storage.WebhookSubscriptionStorageService;
+import com.tsanet.api.connectapi.dto.CollaborationRequestFormTemplateDto;
+import java.util.Collections;
+import java.util.Map;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.mockito.ArgumentCaptor;
+
+/**
+ * The write-side test flag must reach the wire exactly as passed. Asserted on the
+ * form handed to the collaboration gateway because that IS the outgoing request
+ * body; the read-side name differs (testCase), which is why asserting the request
+ * object here is the strongest check available without a live round trip.
+ */
+class DefaultTsaNetApiSessionCreateRequestTest {
+
+    private ConnectApiCollaborationGateway collaborationGateway;
+    private ConnectApiFormGateway formGateway;
+    private DefaultTsaNetApiSession session;
+
+    @BeforeEach
+    void setUp() {
+        collaborationGateway = mock(ConnectApiCollaborationGateway.class);
+        formGateway = mock(ConnectApiFormGateway.class);
+        session = new DefaultTsaNetApiSession(
+            mock(TsaNetApiConfiguration.class),
+            mock(ConnectApiSessionStore.class),
+            mock(TokenManager.class),
+            mock(ConnectApiAuthGateway.class),
+            collaborationGateway,
+            formGateway,
+            mock(ConnectApiNotesGateway.class),
+            mock(ConnectApiResponsesGateway.class),
+            mock(ConnectApiUserGateway.class),
+            mock(ConnectApiWebhooksGateway.class),
+            mock(ConnectApiPartnersGateway.class),
+            mock(ConnectApiAttachmentsGateway.class),
+            mock(CollaborationRequestStorageService.class),
+            mock(CollaborationRequestFormStorageService.class),
+            mock(CaseNoteStorageService.class),
+            mock(CaseResponseStorageService.class),
+            mock(UserContextStorageService.class),
+            mock(WebhookSubscriptionStorageService.class),
+            mock(WebhookInboundEventStorageService.class),
+            mock(PartnerSelectionStorageService.class),
+            mock(AttachmentConfigStorageService.class),
+            mock(AttachmentForwardResultStorageService.class)
+        );
+
+        CollaborationRequestDTO form = new CollaborationRequestDTO();
+        form.setDocumentId(77L);
+        form.setCustomFields(Collections.emptyList());
+        when(formGateway.getFormByDocumentId(anyLong())).thenReturn(form);
+        when(collaborationGateway.createCollaborationRequest(any())).thenReturn(
+            new CollaborationRequestStatusDto(1L, "OPEN", "s", "A", 1L, "B", 2L, "tok", null, null)
+        );
+    }
+
+    private CollaborationRequestFormTemplateDto template() {
+        return new CollaborationRequestFormTemplateDto(77L, 5L, null, Collections.emptyList());
+    }
+
+    @Test
+    void itSendsFalseWhenAProductionConsumerPassesFalse() {
+        session.createRequest(template(), "CASE-1", "s", "d", Map.of(), false);
+
+        assertThat(capturedForm().getTestSubmission()).isFalse();
+    }
+
+    @Test
+    void itSendsTrueWhenPassedTrue() {
+        session.createRequest(template(), "CASE-1", "s", "d", Map.of(), true);
+
+        assertThat(capturedForm().getTestSubmission()).isTrue();
+    }
+
+    @Test
+    void theDeprecatedOverloadKeepsTheOldAlwaysTestBehavior() {
+        session.createRequest(template(), "CASE-1", "s", "d", Map.of());
+
+        assertThat(capturedForm().getTestSubmission()).isTrue();
+    }
+
+    private CollaborationRequestDTO capturedForm() {
+        ArgumentCaptor<CollaborationRequestDTO> captor = ArgumentCaptor.forClass(CollaborationRequestDTO.class);
+        verify(collaborationGateway).createCollaborationRequest(captor.capture());
+        return captor.getValue();
+    }
+}

--- a/connect-library/src/test/java/com/tsanet/api/session/AccountScopedTsaNetApiSessionTest.java
+++ b/connect-library/src/test/java/com/tsanet/api/session/AccountScopedTsaNetApiSessionTest.java
@@ -28,8 +28,8 @@ class AccountScopedTsaNetApiSessionTest {
         Path betaDb = tempDir.resolve("beta.db");
         ApplicationUserAccountRegistry registry = ApplicationUserAccountRegistry.of(
             List.of(
-                new ApplicationUserAccount("alpha", "alpha@test.com", "secret", alphaDb.toString()),
-                new ApplicationUserAccount("beta", "beta@test.com", "secret", betaDb.toString())
+                ApplicationUserAccount.passwordAccount("alpha", alphaDb.toString(), "alpha@test.com", "secret"),
+                ApplicationUserAccount.passwordAccount("beta", betaDb.toString(), "beta@test.com", "secret")
             )
         );
         TsaNetApiSessionFactory factory = TsaNetApi.sessionFactory(
@@ -40,7 +40,7 @@ class AccountScopedTsaNetApiSessionTest {
         seedRepository(alphaDb.toString(), 1L, "Alpha request");
         seedRepository(betaDb.toString(), 2L, "Beta request");
 
-        session.bindAccountForTesting("alpha@test.com", "secret");
+        session.bindAccountForTesting("alpha");
         assertThat(session.activeAccountLabel()).contains("alpha");
         assertThat(session.activeSqlitePath()).contains(alphaDb.toString());
         assertThat(session.collaborationRequests().listStoredRequests())
@@ -48,7 +48,7 @@ class AccountScopedTsaNetApiSessionTest {
             .extracting(CollaborationRequestStatusDto::summary)
             .isEqualTo("Alpha request");
 
-        session.bindAccountForTesting("beta@test.com", "secret");
+        session.bindAccountForTesting("beta");
         assertThat(session.activeAccountLabel()).contains("beta");
         assertThat(session.collaborationRequests().listStoredRequests())
             .singleElement()

--- a/connect-library/src/test/java/com/tsanet/api/storage/CollaborationRequestRepositoryTest.java
+++ b/connect-library/src/test/java/com/tsanet/api/storage/CollaborationRequestRepositoryTest.java
@@ -60,4 +60,71 @@ class CollaborationRequestRepositoryTest {
             .extracting(CollaborationRequestStatusDto::status, CollaborationRequestStatusDto::summary)
             .containsExactly("CLOSED", "New");
     }
+
+    @Test
+    void itRoundTripsTestCaseThroughTheCache() {
+        repository.saveAll(
+            List.of(
+                new CollaborationRequestStatusDto(1L, "OPEN", "Real", "Acme", 1L, "Beta", 2L, "tok1", null, null, false),
+                new CollaborationRequestStatusDto(2L, "OPEN", "Test", "Acme", 1L, "Beta", 2L, "tok2", null, null, true)
+            )
+        );
+
+        assertThat(repository.findAll())
+            .extracting(CollaborationRequestStatusDto::id, CollaborationRequestStatusDto::testCase)
+            .containsExactly(
+                org.assertj.core.groups.Tuple.tuple(1L, Boolean.FALSE),
+                org.assertj.core.groups.Tuple.tuple(2L, Boolean.TRUE)
+            );
+    }
+
+    /**
+     * The DDL below is a FROZEN copy of collaboration_request as it existed before the
+     * test_case column, on purpose: deriving it from current constants would make this
+     * test pass by construction. It proves the two claims an upgrade rests on:
+     * createSchema adds the column to a pre-existing database (CREATE TABLE IF NOT
+     * EXISTS alone is a no-op there), and the upsert's UPDATE arm populates test_case
+     * on a refreshed pre-upgrade row rather than leaving it null forever.
+     */
+    @Test
+    void itUpgradesAPreExistingDatabaseAndBackfillsTestCaseOnRefresh() {
+        SQLiteDataSource dataSource = new SQLiteDataSource();
+        dataSource.setUrl("jdbc:sqlite:file:target/test-collaboration-request-upgrade-" + System.nanoTime() + ".db");
+        JdbcTemplate jdbcTemplate = new JdbcTemplate(dataSource);
+        jdbcTemplate.execute("""
+            CREATE TABLE IF NOT EXISTS collaboration_request (
+                id INTEGER PRIMARY KEY,
+                status TEXT,
+                summary TEXT,
+                submit_company_name TEXT,
+                submit_company_id INTEGER,
+                receive_company_name TEXT,
+                receive_company_id INTEGER,
+                token TEXT NOT NULL UNIQUE,
+                created_at TEXT,
+                updated_at TEXT,
+                fetched_at TEXT NOT NULL
+            )
+            """);
+        jdbcTemplate.update(
+            "INSERT INTO collaboration_request (id, status, summary, submit_company_name, submit_company_id,"
+                + " receive_company_name, receive_company_id, token, created_at, updated_at, fetched_at)"
+                + " VALUES (1, 'OPEN', 'Old row', 'Acme', 1, 'Beta', 2, 'tok1', NULL, NULL, 'x'),"
+                + " (2, 'OPEN', 'Untouched old row', 'Acme', 1, 'Beta', 2, 'tok2', NULL, NULL, 'x')"
+        );
+
+        DatabaseInitializer.createSchema(jdbcTemplate);
+        CollaborationRequestRepository upgraded = new CollaborationRequestRepository(jdbcTemplate);
+
+        upgraded.saveAll(
+            List.of(new CollaborationRequestStatusDto(1L, "OPEN", "Old row", "Acme", 1L, "Beta", 2L, "tok1", null, null, true))
+        );
+
+        assertThat(upgraded.findAll())
+            .extracting(CollaborationRequestStatusDto::id, CollaborationRequestStatusDto::testCase)
+            .containsExactly(
+                org.assertj.core.groups.Tuple.tuple(1L, Boolean.TRUE),
+                org.assertj.core.groups.Tuple.tuple(2L, null)
+            );
+    }
 }

--- a/pom.xml
+++ b/pom.xml
@@ -30,5 +30,23 @@
         <jackson.databind.nullable.version>0.2.6</jackson.databind.nullable.version>
         <connect.openapi.spec>${maven.multiModuleProjectDirectory}/../Connect-API-Code/connect-core-api/src/main/resources/openapi.yaml</connect.openapi.spec>
         <crash.jvm.opens>--add-opens java.base/java.lang=ALL-UNNAMED --add-opens java.base/java.lang.reflect=ALL-UNNAMED</crash.jvm.opens>
+        <!-- Deploy is disarmed by default so a bare local `mvn deploy` with configured
+             credentials cannot accidentally publish (the SNAPSHOT gate lives in the
+             workflow, which is the only place that arms this with
+             -Dmaven.deploy.skip=false). Same toggle pattern as Connect_Gateway. -->
+        <maven.deploy.skip>true</maven.deploy.skip>
     </properties>
+
+    <!-- Where `mvn deploy` publishes. The workflow deploys the root pom (this file is
+         connect-library's parent, so consumers need it resolvable) plus connect-library
+         only, via reactor selection (-pl .,connect-library); the app and demo modules
+         are never published. The server id `github` is wired to credentials by the
+         publish workflow's setup-java step. -->
+    <distributionManagement>
+        <repository>
+            <id>github</id>
+            <name>GitHub Packages - tsanetgit/Connect_SDK</name>
+            <url>https://maven.pkg.github.com/tsanetgit/Connect_SDK</url>
+        </repository>
+    </distributionManagement>
 </project>


### PR DESCRIPTION
Brings the \`oauth\` integration branch into main. Contents:

- **OAuth basic implementation** (Slava, 2026-07-30): client-credentials auth mode alongside password auth. \`AuthMode\`, \`ClientCredentialsAuthConfig\`, \`OAuthTokenGateway\`, \`TokenManager\`, \`OAuth401RetryInterceptor\`, and the session/registry plumbing to select auth per account.
  - The same commit (\`0f57fac\`) also migrates the webhook surface to the newer spec: \`WebhookDeliveryDto.integrationId\` (Long) becomes \`cloudEventId\` (String) and the gateway calls \`WebhooksV1Api\` for list/create. This is the change that lets the branch compile against the sibling \`beta\` spec; main at \`332e5c7\` does not (see the README branch notes from \`tsanetgit/Connect_SDK#42\`).
- Five PRs squash-merged onto the branch since (2026-08-10):
  - \`tsanetgit/Connect_SDK#39\`: declare jackson-datatype-jsr310 so the client is self-sufficient outside Boot
  - \`tsanetgit/Connect_SDK#40\`: surface testCase through the facade DTO and cache (\`tsanetgit/Connect_SDK#38\`)
  - \`tsanetgit/Connect_SDK#41\`: make the test flag a per-call parameter on the facade create API (\`tsanetgit/Connect_SDK#37\`)
  - \`tsanetgit/Connect_SDK#42\`: README: document the sibling-spec build requirement and branch state
  - \`tsanetgit/Connect_SDK#43\`: publish connect-library to GitHub Packages on release
- Incidental tidying carried by the branch: \`tsaet\` to \`tsanet\` typo fixes in three log/error strings, and two stale comments removed in \`ConnectApiWebhooksGateway\`.

No overlap with main's \`tsanetgit/Connect_SDK#35\` (credential removal + security-audit CI): the branch touches neither \`application.yml\` nor the audit tooling, so nothing removed there comes back.

Build receipt for the head (\`f747bc6\`), sibling \`Connect-API-Code\` on \`beta\` (\`0691e1f\`), JDK 21: \`mvn install\` BUILD SUCCESS, 122 tests (connect-library 86, demo 6, app 30), 0 failures.

Merging as a merge commit to keep the individual commit trail.

🤖 Generated with [Claude Code](https://claude.com/claude-code)