### PR TITLE
attachment-receiver: module skeleton and the AttachmentStorage SPI

### DIFF
--- a/attachment-receiver/pom.xml
+++ b/attachment-receiver/pom.xml
@@ -1,0 +1,28 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+
+    <parent>
+        <groupId>com.tsanet</groupId>
+        <artifactId>tsanet-client-parent</artifactId>
+        <version>0.0.1-SNAPSHOT</version>
+    </parent>
+
+    <artifactId>attachment-receiver</artifactId>
+    <name>attachment-receiver</name>
+    <description>
+        Receive side of TSANet Connect case attachments: the AttachmentStorage SPI and its
+        storage adapters. The normalized HTTPS ingest endpoint is a separate, gated concern
+        (tsanetgit/Connect-API-Code#140) and nothing in this module may assume its wire shape.
+    </description>
+
+    <dependencies>
+        <dependency>
+            <groupId>org.junit.jupiter</groupId>
+            <artifactId>junit-jupiter</artifactId>
+            <scope>test</scope>
+        </dependency>
+    </dependencies>
+</project>

--- a/attachment-receiver/src/main/java/com/tsanet/receiver/storage/AttachmentStorage.java
+++ b/attachment-receiver/src/main/java/com/tsanet/receiver/storage/AttachmentStorage.java
@@ -1,0 +1,70 @@
+package com.tsanet.receiver.storage;
+
+import java.io.InputStream;
+
+/**
+ * Where received attachment bytes go: one implementation per storage backend (AWS S3,
+ * Azure Files, in-memory for tests). Implementations are exercised by the shared
+ * {@code AttachmentStorageContractTest}; an adapter is not done until it passes it.
+ *
+ * <p>This SPI deliberately knows nothing about how bytes arrive. The normalized HTTPS
+ * ingest endpoint is gated on tsanetgit/Connect-API-Code#140 and its wire shape must not
+ * leak in here: no HTTP types, no auth, no path conventions.
+ *
+ * <p>Rules that bind every implementation:
+ * <ul>
+ *   <li><b>Streaming:</b> {@link #store} consumes the stream incrementally. It must not
+ *       buffer the whole file in memory; the platform backend already does that on its
+ *       side and the receiver must not repeat the mistake.</li>
+ *   <li><b>Stream ownership:</b> the caller closes the stream. {@code store} must not.</li>
+ *   <li><b>No partial visibility:</b> when {@code store} throws, a subsequent
+ *       {@link #exists exists(caseNumber, fileName)} must return {@code false}. A failed
+ *       write aborts and cleans up; it never leaves a half-written object visible.</li>
+ *   <li><b>Same-name behavior is implementation-defined for now.</b> Whether a second
+ *       store of the same (caseNumber, fileName) overwrites, versions, or rejects is an
+ *       open contract question (tsanetgit/Connect-API-Code#140, question 2). Callers must
+ *       not build a check-then-store policy on {@link #exists} — that is a race; when the
+ *       answer lands, the policy moves into {@code store} itself (conditional write).</li>
+ *   <li><b>{@code fileName} is remote-controlled input.</b> The platform backend appends
+ *       the sender's filename to the push URL with no encoding, so it may contain path
+ *       separators or traversal sequences. Adapters treat it as an opaque token, never as
+ *       a path to interpret.</li>
+ * </ul>
+ */
+public interface AttachmentStorage {
+
+    /**
+     * Streams one attachment's bytes to the backend.
+     *
+     * @param attachment what is being stored; {@link IncomingAttachment#contentLength()}
+     *                   may be {@code -1} when the byte count is unknown up front
+     * @param content    the bytes; read incrementally, never closed by this method
+     * @return the backend key the bytes landed under and the count actually written
+     * @throws AttachmentStorageException on any failure, including a stream that fails
+     *                                    mid-read; the failed object must not be visible
+     */
+    StoredAttachment store(IncomingAttachment attachment, InputStream content)
+            throws AttachmentStorageException;
+
+    /**
+     * Whether an object for this (caseNumber, fileName) is currently visible.
+     *
+     * <p>An indeterminate check must throw, never answer {@code false}: on a real backend
+     * this is a network call, and reporting an outage as "object absent" would make the
+     * no-partial-visibility guarantee unverifiable exactly when it matters.
+     *
+     * @throws AttachmentStorageException when the backend cannot answer
+     */
+    boolean exists(String caseNumber, String fileName) throws AttachmentStorageException;
+
+    /**
+     * Go-live probe: proves the configured backend is reachable and writable by writing,
+     * reading back, and deleting a sentinel object. Run on configuration save and on
+     * demand; a passing probe is the precondition for registering a receive config.
+     *
+     * @throws AttachmentStorageException with a message specific enough to distinguish
+     *                                    wrong-credential from wrong-target from
+     *                                    no-permission
+     */
+    void verifyAccess() throws AttachmentStorageException;
+}

--- a/attachment-receiver/src/main/java/com/tsanet/receiver/storage/AttachmentStorageException.java
+++ b/attachment-receiver/src/main/java/com/tsanet/receiver/storage/AttachmentStorageException.java
@@ -1,0 +1,17 @@
+package com.tsanet.receiver.storage;
+
+/**
+ * A storage operation failed. Checked on purpose: the ingest path must map every storage
+ * failure to a non-2xx response (the platform backend treats any 2xx as delivered, so a
+ * swallowed failure here reads as success to the sender and the file is silently lost).
+ */
+public class AttachmentStorageException extends Exception {
+
+    public AttachmentStorageException(String message) {
+        super(message);
+    }
+
+    public AttachmentStorageException(String message, Throwable cause) {
+        super(message, cause);
+    }
+}

--- a/attachment-receiver/src/main/java/com/tsanet/receiver/storage/IncomingAttachment.java
+++ b/attachment-receiver/src/main/java/com/tsanet/receiver/storage/IncomingAttachment.java
@@ -1,0 +1,36 @@
+package com.tsanet.receiver.storage;
+
+import java.util.Objects;
+
+/**
+ * What the receiver knows about one attachment before storing it. The case number is the
+ * only case-correlation metadata the push contract carries, so it is required; everything
+ * else degrades gracefully.
+ *
+ * @param caseNumber    the collaboration case number the file belongs to; never blank
+ * @param fileName      the file's name as pushed; never blank
+ * @param contentType   the declared media type, or {@code null} when not declared
+ * @param contentLength the declared byte count, or {@code -1} when unknown (a chunked
+ *                      push has no length up front; adapters must handle both)
+ */
+public record IncomingAttachment(String caseNumber, String fileName, String contentType,
+                                 long contentLength) {
+
+    public IncomingAttachment {
+        if (Objects.requireNonNull(caseNumber, "caseNumber").isBlank()) {
+            throw new IllegalArgumentException("caseNumber must not be blank");
+        }
+        if (Objects.requireNonNull(fileName, "fileName").isBlank()) {
+            throw new IllegalArgumentException("fileName must not be blank");
+        }
+        if (contentLength < -1) {
+            throw new IllegalArgumentException(
+                    "contentLength must be a byte count or -1 for unknown, got " + contentLength);
+        }
+    }
+
+    /** Whether the byte count was declared up front. */
+    public boolean lengthKnown() {
+        return contentLength >= 0;
+    }
+}

--- a/attachment-receiver/src/main/java/com/tsanet/receiver/storage/StoredAttachment.java
+++ b/attachment-receiver/src/main/java/com/tsanet/receiver/storage/StoredAttachment.java
@@ -1,0 +1,23 @@
+package com.tsanet.receiver.storage;
+
+import java.util.Objects;
+
+/**
+ * Proof of a completed store: where the bytes landed and how many were written.
+ *
+ * @param storageKey   the backend's key for the object; never blank, layout is the
+ *                     adapter's concern
+ * @param bytesWritten the count actually streamed to the backend; always the real count,
+ *                     even when the incoming length was unknown
+ */
+public record StoredAttachment(String storageKey, long bytesWritten) {
+
+    public StoredAttachment {
+        if (Objects.requireNonNull(storageKey, "storageKey").isBlank()) {
+            throw new IllegalArgumentException("storageKey must not be blank");
+        }
+        if (bytesWritten < 0) {
+            throw new IllegalArgumentException("bytesWritten must be >= 0, got " + bytesWritten);
+        }
+    }
+}

--- a/attachment-receiver/src/test/java/com/tsanet/receiver/storage/AttachmentStorageContractTest.java
+++ b/attachment-receiver/src/test/java/com/tsanet/receiver/storage/AttachmentStorageContractTest.java
@@ -1,0 +1,114 @@
+package com.tsanet.receiver.storage;
+
+import org.junit.jupiter.api.Test;
+
+import java.io.ByteArrayInputStream;
+import java.io.FilterInputStream;
+import java.io.IOException;
+import java.io.InputStream;
+import java.nio.charset.StandardCharsets;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+/**
+ * The contract every {@link AttachmentStorage} adapter must pass; an adapter binds itself
+ * by extending this class and implementing {@link #newStorage()}. Deliberately absent:
+ * any assertion about storing the same (caseNumber, fileName) twice — that policy is an
+ * open contract question (tsanetgit/Connect-API-Code#140, question 2) and pinning it here
+ * would encode an answer we do not have.
+ */
+public abstract class AttachmentStorageContractTest {
+
+    /** A fresh, empty storage instance per test. */
+    protected abstract AttachmentStorage newStorage() throws Exception;
+
+    private static final byte[] CONTENT = "attachment bytes for the contract test".getBytes(StandardCharsets.UTF_8);
+
+    private static IncomingAttachment knownLength() {
+        return new IncomingAttachment("01234567", "diag.log", "text/plain", CONTENT.length);
+    }
+
+    @Test
+    void storeThenExists() throws Exception {
+        AttachmentStorage storage = newStorage();
+        StoredAttachment stored = storage.store(knownLength(), new ByteArrayInputStream(CONTENT));
+        assertFalse(stored.storageKey().isBlank(), "storageKey must identify the object");
+        assertTrue(storage.exists("01234567", "diag.log"), "stored object must be visible");
+    }
+
+    @Test
+    void bytesWrittenMatchesStreamedLength() throws Exception {
+        AttachmentStorage storage = newStorage();
+        StoredAttachment stored = storage.store(knownLength(), new ByteArrayInputStream(CONTENT));
+        assertEquals(CONTENT.length, stored.bytesWritten());
+    }
+
+    @Test
+    void unknownLengthStreamStores() throws Exception {
+        AttachmentStorage storage = newStorage();
+        IncomingAttachment unknown = new IncomingAttachment("01234567", "chunked.bin", null, -1);
+        StoredAttachment stored = storage.store(unknown, new ByteArrayInputStream(CONTENT));
+        assertEquals(CONTENT.length, stored.bytesWritten(),
+                "bytesWritten must be the real count even when the incoming length was unknown");
+        assertTrue(storage.exists("01234567", "chunked.bin"));
+    }
+
+    @Test
+    void existsIsFalseForUnknownFile() throws Exception {
+        AttachmentStorage storage = newStorage();
+        assertFalse(storage.exists("01234567", "never-stored.txt"));
+    }
+
+    @Test
+    void storeDoesNotCloseTheCallersStream() throws Exception {
+        AttachmentStorage storage = newStorage();
+        var tracking = new CloseTrackingStream(new ByteArrayInputStream(CONTENT));
+        storage.store(knownLength(), tracking);
+        assertFalse(tracking.closed, "the caller owns the stream; store must not close it");
+    }
+
+    @Test
+    void failedStoreLeavesNoPartialVisibility() throws Exception {
+        AttachmentStorage storage = newStorage();
+        IncomingAttachment attachment = new IncomingAttachment("01234567", "truncated.dat", null, -1);
+        assertThrows(AttachmentStorageException.class,
+                () -> storage.store(attachment, new MidReadFailingStream()));
+        assertFalse(storage.exists("01234567", "truncated.dat"),
+                "a failed store must abort cleanly, never leave a half-written object visible");
+    }
+
+    @Test
+    void verifyAccessSucceedsOnAHealthyBackend() throws Exception {
+        newStorage().verifyAccess();
+    }
+
+    private static final class CloseTrackingStream extends FilterInputStream {
+        boolean closed;
+
+        CloseTrackingStream(InputStream in) {
+            super(in);
+        }
+
+        @Override
+        public void close() throws IOException {
+            closed = true;
+            super.close();
+        }
+    }
+
+    /** Yields a few bytes, then fails: the wrong-but-well-formed input for a store path. */
+    private static final class MidReadFailingStream extends InputStream {
+        private int served;
+
+        @Override
+        public int read() throws IOException {
+            if (served++ < 4) {
+                return 'x';
+            }
+            throw new IOException("stream failed mid-read (simulated)");
+        }
+    }
+}

--- a/attachment-receiver/src/test/java/com/tsanet/receiver/storage/InMemoryAttachmentStorage.java
+++ b/attachment-receiver/src/test/java/com/tsanet/receiver/storage/InMemoryAttachmentStorage.java
@@ -1,0 +1,57 @@
+package com.tsanet.receiver.storage;
+
+import java.io.ByteArrayOutputStream;
+import java.io.IOException;
+import java.io.InputStream;
+import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
+
+/**
+ * Test double: the reference {@link AttachmentStorage} semantics with no backend. Buffers
+ * in memory, which the SPI forbids for real adapters — acceptable only because this class
+ * exists to make the contract test and future callers testable, never to hold real files.
+ */
+public final class InMemoryAttachmentStorage implements AttachmentStorage {
+
+    private final Map<String, byte[]> objects = new ConcurrentHashMap<>();
+
+    @Override
+    public StoredAttachment store(IncomingAttachment attachment, InputStream content)
+            throws AttachmentStorageException {
+        String key = key(attachment.caseNumber(), attachment.fileName());
+        ByteArrayOutputStream buffer = new ByteArrayOutputStream();
+        byte[] chunk = new byte[8192];
+        try {
+            int read;
+            while ((read = content.read(chunk)) != -1) {
+                buffer.write(chunk, 0, read);
+            }
+        } catch (IOException e) {
+            throw new AttachmentStorageException(
+                    "stream failed mid-read for " + key + "; nothing stored", e);
+        }
+        byte[] bytes = buffer.toByteArray();
+        objects.put(key, bytes);
+        return new StoredAttachment(key, bytes.length);
+    }
+
+    @Override
+    public boolean exists(String caseNumber, String fileName) {
+        return objects.containsKey(key(caseNumber, fileName));
+    }
+
+    @Override
+    public void verifyAccess() {
+        // No backend to probe: the in-memory map is always reachable and writable.
+    }
+
+    /** Visible for callers' assertions in future tests, not part of the SPI. */
+    public byte[] contentOf(String caseNumber, String fileName) {
+        byte[] bytes = objects.get(key(caseNumber, fileName));
+        return bytes == null ? null : bytes.clone();
+    }
+
+    private static String key(String caseNumber, String fileName) {
+        return caseNumber + "/" + fileName;
+    }
+}

--- a/attachment-receiver/src/test/java/com/tsanet/receiver/storage/InMemoryAttachmentStorageTest.java
+++ b/attachment-receiver/src/test/java/com/tsanet/receiver/storage/InMemoryAttachmentStorageTest.java
@@ -1,0 +1,10 @@
+package com.tsanet.receiver.storage;
+
+/** Binds the in-memory double to the contract every adapter must pass. */
+class InMemoryAttachmentStorageTest extends AttachmentStorageContractTest {
+
+    @Override
+    protected AttachmentStorage newStorage() {
+        return new InMemoryAttachmentStorage();
+    }
+}

--- a/pom.xml
+++ b/pom.xml
@@ -22,6 +22,7 @@
         <module>connect-library</module>
         <module>TSANet-integration-demo</module>
         <module>TSANet-integration-app</module>
+        <module>attachment-receiver</module>
     </modules>
 
     <properties>


### PR DESCRIPTION
Closes #47, the first sub-issue of the P4 attachment-receive epic #46.

## What this adds

- New Maven module `attachment-receiver` (registered in the parent reactor; the only change to an existing file is that one `<module>` line).
- The `AttachmentStorage` SPI (`com.tsanet.receiver.storage`, distinct from `connect-library`'s existing SQLite `storage` package): `store` (streaming), `exists` (throwing), `verifyAccess` (go-live probe), with value types `IncomingAttachment` / `StoredAttachment` and checked `AttachmentStorageException`.
- `AttachmentStorageContractTest`, the abstract acceptance bar every adapter (#48 S3, #49 Azure Files) must extend, plus the `InMemoryAttachmentStorage` reference double bound to it.
- Nothing wire-shaped: the ingest endpoint is gated on tsanetgit/Connect-API-Code#140 and no HTTP concept appears in this module.

## Binding rules the SPI encodes (and where each is enforced)

| Claim in the javadoc | Line that makes it true |
|---|---|
| Caller owns the stream; store must not close it | `AttachmentStorageContractTest.storeDoesNotCloseTheCallersStream` |
| A failed store leaves no visible partial object | `AttachmentStorageContractTest.failedStoreLeavesNoPartialVisibility` (see disposition 1) |
| `contentLength` may be `-1` (unknown up front) | `AttachmentStorageContractTest.unknownLengthStreamStores` |
| An indeterminate `exists` throws, never answers false | `exists` signature: `throws AttachmentStorageException` |
| Same-name behavior deliberately unspecified (Connect-API-Code#140 Q2) | No same-name assertion in the contract test, by design |
| `fileName` is remote-controlled; adapters treat it as opaque | SPI javadoc rule; enforcement lands with #52 (hardening) |

## Verification

- `mvn test -pl attachment-receiver`: 7 tests, 0 failures (surefire: `tests="7" errors="0" skipped="0" failures="0"`).
- Probe-the-test: injected two violations into the double (partial visibility before read; closing the caller's stream) — exactly the two guarding tests went red, restored to green.
- Full reactor: `mvn -DskipTests package` BUILD SUCCESS with the new module in the build order.
- JUnit version is parent-managed: `mvn dependency:list` resolves `org.junit.jupiter:junit-jupiter:jar:5.10.3` with no version in this module's pom.

## Advisor (2 calls)

Design call shaped the SPI (store javadoc must not promise `exists()`-based same-name policy — TOCTOU, S3/Azure need conditional writes; `-1` length convention pinned now; stream ownership + no-partial-visibility encoded as tests). Pre-done call raised one blocker, applied: `exists` gained its failure channel so a backend outage can never read as "object absent."

## Pre-PR gate: CONCERNS, dispositions

1. **The no-partial-visibility test passes the in-memory double by construction** — the double never commits before the read finishes, so the rollback path is unexercised, and an incrementally-committing adapter (S3 multipart) could leave a partial object and still pass. Correct observation; not closable generically in a unit contract test. Disposition: carried to #48 and #49 as an explicit acceptance criterion (abort-after-partial-commit exercised against the real backend); comments posted on both issues.
2. **JUnit dependencyManagement unverified by the gate.** Verified here: see the `dependency:list` receipt above.

## Blast radius (generated, `scripts/pre-pr-artifacts.py --base origin/main`)

Detector lines: no positional contracts, no vocabulary changes, no old-term sweeps triggered — this is an additive module; the receive side had no prior form to sweep (receipt: `git grep -n "AttachmentStorage" -- ':!attachment-receiver'` on the branch returns nothing).

PROMPT lines answered:

- **Guard vs representation:** the record compact constructors are constructor invariants on new value types; the records themselves are the representation choice (typed value objects instead of loose strings/longs).
- **Newly reachable failure → receiving handler:** `AttachmentStorageException` today reaches only test code; its designed consumer is the gated ingest endpoint (#51), whose contract is to map every storage failure to a non-2xx so the platform reports `FORWARD_FAILED` instead of a false success. That mapping is #51's acceptance, not this PR's.
- **Abstraction introduced → old-form grep:** the decision "where do received bytes go" had no prior deciders anywhere in the repo (grep receipt above; the receive side did not exist).
- **Schema/contract shape:** the parent reactor grew from 3 to 4 modules; pre-existing state (3 modules) shown working by the full-reactor BUILD SUCCESS above.
- **Prose claims:** every javadoc claim is mapped to its enforcing line in the table above; the one claim a unit test cannot fully enforce is disposition 1.

Third-or-later-fix line: not applicable, new code.
