### PR TITLE
attachment-receiver: tenant config model and go-live verification

### DIFF
--- a/attachment-receiver/pom.xml
+++ b/attachment-receiver/pom.xml
@@ -1,0 +1,28 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+
+    <parent>
+        <groupId>com.tsanet</groupId>
+        <artifactId>tsanet-client-parent</artifactId>
+        <version>0.0.1-SNAPSHOT</version>
+    </parent>
+
+    <artifactId>attachment-receiver</artifactId>
+    <name>attachment-receiver</name>
+    <description>
+        Receive side of TSANet Connect case attachments: the AttachmentStorage SPI and its
+        storage adapters. The normalized HTTPS ingest endpoint is a separate, gated concern
+        (tsanetgit/Connect-API-Code#140) and nothing in this module may assume its wire shape.
+    </description>
+
+    <dependencies>
+        <dependency>
+            <groupId>org.junit.jupiter</groupId>
+            <artifactId>junit-jupiter</artifactId>
+            <scope>test</scope>
+        </dependency>
+    </dependencies>
+</project>

--- a/attachment-receiver/src/main/java/com/tsanet/receiver/config/EncryptedFileTenantConfigStore.java
+++ b/attachment-receiver/src/main/java/com/tsanet/receiver/config/EncryptedFileTenantConfigStore.java
@@ -1,0 +1,206 @@
+package com.tsanet.receiver.config;
+
+import javax.crypto.Cipher;
+import javax.crypto.SecretKey;
+import javax.crypto.spec.GCMParameterSpec;
+import javax.crypto.spec.SecretKeySpec;
+import java.io.ByteArrayInputStream;
+import java.io.ByteArrayOutputStream;
+import java.io.IOException;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.StandardCopyOption;
+import java.security.GeneralSecurityException;
+import java.security.SecureRandom;
+import java.util.ArrayList;
+import java.util.Base64;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import java.util.Properties;
+import java.util.stream.Stream;
+
+/**
+ * File-per-tenant store, AES-256-GCM at rest. {@code <pathSegment>.tenant} under one
+ * directory; the file body is a random 12-byte IV followed by the ciphertext. The
+ * tenant's path segment is bound into the ciphertext as GCM additional authenticated
+ * data, so two tenants' files cannot be swapped on disk and still decrypt. Writes go to
+ * a temp file first and land by atomic move: a crash mid-save can never leave a torn
+ * file that reads as tampering later.
+ */
+public final class EncryptedFileTenantConfigStore implements TenantConfigStore {
+
+    private static final String FILE_SUFFIX = ".tenant";
+    private static final int IV_BYTES = 12;
+    private static final int TAG_BITS = 128;
+    private static final int KEY_BYTES = 32;
+
+    private final Path directory;
+    private final SecretKey key;
+    private final SecureRandom random = new SecureRandom();
+
+    public EncryptedFileTenantConfigStore(Path directory, SecretKey key) throws TenantConfigException {
+        this.directory = directory;
+        this.key = key;
+        try {
+            Files.createDirectories(directory);
+        } catch (IOException e) {
+            throw new TenantConfigException("cannot create config directory " + directory, e);
+        }
+    }
+
+    /**
+     * The deployment-reality key path: a base64 value from an environment variable or
+     * secret mount. Fails at startup, loudly, on anything but exactly 32 decoded bytes —
+     * a truncated key discovered at first tenant read is a debugging trap.
+     */
+    public static SecretKey keyFromBase64(String base64) {
+        byte[] decoded = Base64.getDecoder().decode(base64);
+        if (decoded.length != KEY_BYTES) {
+            throw new IllegalArgumentException(
+                    "AES-256 key must decode to exactly " + KEY_BYTES + " bytes, got " + decoded.length);
+        }
+        return new SecretKeySpec(decoded, "AES");
+    }
+
+    @Override
+    public Optional<TenantConfig> byPathSegment(String pathSegment) throws TenantConfigException {
+        if (pathSegment == null || !TenantConfig.PATH_SEGMENT.matcher(pathSegment).matches()) {
+            throw new IllegalArgumentException(
+                    "not a valid routing token: '" + pathSegment + "'");
+        }
+        Path file = directory.resolve(pathSegment + FILE_SUFFIX);
+        if (!Files.exists(file)) {
+            return Optional.empty();
+        }
+        return Optional.of(read(file, pathSegment));
+    }
+
+    @Override
+    public List<TenantConfig> all() throws TenantConfigException {
+        List<TenantConfig> configs = new ArrayList<>();
+        try (Stream<Path> files = Files.list(directory)) {
+            for (Path file : files.filter(f -> f.getFileName().toString().endsWith(FILE_SUFFIX)).toList()) {
+                String name = file.getFileName().toString();
+                String segment = name.substring(0, name.length() - FILE_SUFFIX.length());
+                configs.add(read(file, segment));
+            }
+        } catch (IOException e) {
+            throw new TenantConfigException("cannot list config directory " + directory, e);
+        }
+        return List.copyOf(configs);
+    }
+
+    @Override
+    public void save(TenantConfig config) throws TenantConfigException {
+        byte[] plaintext = serialize(config);
+        byte[] iv = new byte[IV_BYTES];
+        random.nextBytes(iv);
+        byte[] ciphertext;
+        try {
+            Cipher cipher = Cipher.getInstance("AES/GCM/NoPadding");
+            cipher.init(Cipher.ENCRYPT_MODE, key, new GCMParameterSpec(TAG_BITS, iv));
+            cipher.updateAAD(config.pathSegment().getBytes(StandardCharsets.UTF_8));
+            ciphertext = cipher.doFinal(plaintext);
+        } catch (GeneralSecurityException e) {
+            throw new TenantConfigException("encrypt failed for tenant " + config.pathSegment(), e);
+        }
+        Path target = directory.resolve(config.pathSegment() + FILE_SUFFIX);
+        Path temp = null;
+        try {
+            temp = Files.createTempFile(directory, config.pathSegment(), ".tmp");
+            ByteArrayOutputStream body = new ByteArrayOutputStream();
+            body.write(iv);
+            body.write(ciphertext);
+            Files.write(temp, body.toByteArray());
+            Files.move(temp, target, StandardCopyOption.ATOMIC_MOVE, StandardCopyOption.REPLACE_EXISTING);
+            temp = null;
+        } catch (IOException e) {
+            throw new TenantConfigException("cannot write config for tenant " + config.pathSegment(), e);
+        } finally {
+            if (temp != null) {
+                try {
+                    Files.deleteIfExists(temp);
+                } catch (IOException ignored) {
+                    // Best-effort cleanup of a ciphertext-only temp file.
+                }
+            }
+        }
+    }
+
+    private TenantConfig read(Path file, String pathSegment) throws TenantConfigException {
+        byte[] body;
+        try {
+            body = Files.readAllBytes(file);
+        } catch (IOException e) {
+            throw new TenantConfigException("cannot read config for tenant " + pathSegment, e);
+        }
+        if (body.length <= IV_BYTES) {
+            throw new TenantConfigException("config for tenant " + pathSegment + " is truncated");
+        }
+        byte[] plaintext;
+        try {
+            Cipher cipher = Cipher.getInstance("AES/GCM/NoPadding");
+            cipher.init(Cipher.DECRYPT_MODE, key,
+                    new GCMParameterSpec(TAG_BITS, body, 0, IV_BYTES));
+            cipher.updateAAD(pathSegment.getBytes(StandardCharsets.UTF_8));
+            plaintext = cipher.doFinal(body, IV_BYTES, body.length - IV_BYTES);
+        } catch (GeneralSecurityException e) {
+            throw new TenantConfigException("config for tenant " + pathSegment
+                    + " failed its integrity check (tampering, a swapped file, or the wrong key)", e);
+        }
+        TenantConfig config = deserialize(plaintext, pathSegment);
+        if (!config.pathSegment().equals(pathSegment)) {
+            throw new TenantConfigException("config file for tenant " + pathSegment
+                    + " contains configuration for tenant " + config.pathSegment());
+        }
+        return config;
+    }
+
+    private static byte[] serialize(TenantConfig config) throws TenantConfigException {
+        Properties props = new Properties();
+        props.setProperty("pathSegment", config.pathSegment());
+        props.setProperty("pushPassword", config.pushPassword());
+        props.setProperty("storageBackend", config.storageBackend());
+        config.storageProperties().forEach((k, v) -> props.setProperty("storage." + k, v));
+        config.crmProperties().forEach((k, v) -> props.setProperty("crm." + k, v));
+        ByteArrayOutputStream out = new ByteArrayOutputStream();
+        try {
+            props.store(out, null);
+        } catch (IOException e) {
+            throw new TenantConfigException("serialize failed for tenant " + config.pathSegment(), e);
+        }
+        return out.toByteArray();
+    }
+
+    private static TenantConfig deserialize(byte[] plaintext, String pathSegment)
+            throws TenantConfigException {
+        Properties props = new Properties();
+        try {
+            props.load(new ByteArrayInputStream(plaintext));
+        } catch (IOException e) {
+            throw new TenantConfigException("parse failed for tenant " + pathSegment, e);
+        }
+        Map<String, String> storage = new HashMap<>();
+        Map<String, String> crm = new HashMap<>();
+        for (String name : props.stringPropertyNames()) {
+            if (name.startsWith("storage.")) {
+                storage.put(name.substring("storage.".length()), props.getProperty(name));
+            } else if (name.startsWith("crm.")) {
+                crm.put(name.substring("crm.".length()), props.getProperty(name));
+            }
+        }
+        try {
+            return new TenantConfig(
+                    props.getProperty("pathSegment"),
+                    props.getProperty("pushPassword"),
+                    props.getProperty("storageBackend"),
+                    storage, crm);
+        } catch (RuntimeException e) {
+            throw new TenantConfigException(
+                    "config for tenant " + pathSegment + " decrypted but is not valid: " + e.getMessage(), e);
+        }
+    }
+}

--- a/attachment-receiver/src/main/java/com/tsanet/receiver/config/TenantConfig.java
+++ b/attachment-receiver/src/main/java/com/tsanet/receiver/config/TenantConfig.java
@@ -1,0 +1,63 @@
+package com.tsanet.receiver.config;
+
+import java.util.Map;
+import java.util.Objects;
+import java.util.regex.Pattern;
+
+/**
+ * One member's receive configuration. The same shape serves both hosting modes: a
+ * member-deployed receiver has a store holding one of these; the TSANet-hosted
+ * multi-tenant receiver holds one per member.
+ *
+ * @param pathSegment       the member's routing token, used both as the tenant's URL path
+ *                          segment and as its file name in the encrypted store; allowlisted
+ *                          to {@code [a-z0-9][a-z0-9-]{0,63}} so it is safe as either
+ * @param pushPassword      the password the platform backend presents on every push
+ * @param storageBackend    which {@code AttachmentStorage} adapter this tenant uses, by
+ *                          string id (e.g. {@code "s3"}); a string rather than an enum so
+ *                          adapters can register without touching this record
+ * @param storageProperties adapter-specific settings and credentials
+ * @param crmProperties     delivery-adapter settings and credentials; empty means no CRM
+ *                          delivery is configured and files stop at storage
+ */
+public record TenantConfig(String pathSegment, String pushPassword, String storageBackend,
+                           Map<String, String> storageProperties,
+                           Map<String, String> crmProperties) {
+
+    /** URL-path-segment and filename-safe by construction: no dots, slashes, or case. */
+    public static final Pattern PATH_SEGMENT = Pattern.compile("[a-z0-9][a-z0-9-]{0,63}");
+
+    public TenantConfig {
+        Objects.requireNonNull(pathSegment, "pathSegment");
+        if (!PATH_SEGMENT.matcher(pathSegment).matches()) {
+            throw new IllegalArgumentException(
+                    "pathSegment must match " + PATH_SEGMENT + ", got '" + pathSegment + "'");
+        }
+        if (Objects.requireNonNull(pushPassword, "pushPassword").isBlank()) {
+            throw new IllegalArgumentException("pushPassword must not be blank");
+        }
+        if (Objects.requireNonNull(storageBackend, "storageBackend").isBlank()) {
+            throw new IllegalArgumentException("storageBackend must not be blank");
+        }
+        storageProperties = Map.copyOf(Objects.requireNonNull(storageProperties, "storageProperties"));
+        crmProperties = Map.copyOf(Objects.requireNonNull(crmProperties, "crmProperties"));
+    }
+
+    /** Whether this tenant wants received files delivered into a CRM after storage. */
+    public boolean hasCrmDelivery() {
+        return !crmProperties.isEmpty();
+    }
+
+    /**
+     * Redacted on purpose: the password and both property maps' values are credentials.
+     * Only structure (keys) is printable, so a config reaching a log line leaks nothing.
+     */
+    @Override
+    public String toString() {
+        return "TenantConfig[pathSegment=" + pathSegment
+                + ", storageBackend=" + storageBackend
+                + ", storageProperties=" + storageProperties.keySet()
+                + ", crmProperties=" + crmProperties.keySet()
+                + ", pushPassword=<redacted>]";
+    }
+}

--- a/attachment-receiver/src/main/java/com/tsanet/receiver/config/TenantConfigException.java
+++ b/attachment-receiver/src/main/java/com/tsanet/receiver/config/TenantConfigException.java
@@ -1,0 +1,17 @@
+package com.tsanet.receiver.config;
+
+/**
+ * A tenant configuration could not be stored or loaded. Checked for the same reason as
+ * {@code AttachmentStorageException}: a swallowed config failure upstream would let a
+ * push proceed against a tenant whose configuration is unreadable.
+ */
+public class TenantConfigException extends Exception {
+
+    public TenantConfigException(String message) {
+        super(message);
+    }
+
+    public TenantConfigException(String message, Throwable cause) {
+        super(message, cause);
+    }
+}

--- a/attachment-receiver/src/main/java/com/tsanet/receiver/config/TenantConfigStore.java
+++ b/attachment-receiver/src/main/java/com/tsanet/receiver/config/TenantConfigStore.java
@@ -1,0 +1,29 @@
+package com.tsanet.receiver.config;
+
+import java.util.List;
+import java.util.Optional;
+
+/**
+ * Where tenant configurations live. A member-deployed receiver has one tenant; the
+ * TSANet-hosted receiver has many. Implementations hold credentials, so at-rest
+ * encryption is part of the store's contract, not the caller's problem.
+ */
+public interface TenantConfigStore {
+
+    /**
+     * The tenant routed by this path segment, or empty when none is configured.
+     *
+     * @throws IllegalArgumentException  when the segment is not a valid routing token
+     *                                   (defense on the read path: a raw request value
+     *                                   must not be able to address arbitrary files)
+     * @throws TenantConfigException     when the tenant exists but cannot be loaded
+     *                                   (corruption, tampering, wrong key)
+     */
+    Optional<TenantConfig> byPathSegment(String pathSegment) throws TenantConfigException;
+
+    /** Every configured tenant. */
+    List<TenantConfig> all() throws TenantConfigException;
+
+    /** Creates or replaces the tenant's configuration, atomically. */
+    void save(TenantConfig config) throws TenantConfigException;
+}

--- a/attachment-receiver/src/main/java/com/tsanet/receiver/storage/AttachmentStorage.java
+++ b/attachment-receiver/src/main/java/com/tsanet/receiver/storage/AttachmentStorage.java
@@ -1,0 +1,70 @@
+package com.tsanet.receiver.storage;
+
+import java.io.InputStream;
+
+/**
+ * Where received attachment bytes go: one implementation per storage backend (AWS S3,
+ * Azure Files, in-memory for tests). Implementations are exercised by the shared
+ * {@code AttachmentStorageContractTest}; an adapter is not done until it passes it.
+ *
+ * <p>This SPI deliberately knows nothing about how bytes arrive. The normalized HTTPS
+ * ingest endpoint is gated on tsanetgit/Connect-API-Code#140 and its wire shape must not
+ * leak in here: no HTTP types, no auth, no path conventions.
+ *
+ * <p>Rules that bind every implementation:
+ * <ul>
+ *   <li><b>Streaming:</b> {@link #store} consumes the stream incrementally. It must not
+ *       buffer the whole file in memory; the platform backend already does that on its
+ *       side and the receiver must not repeat the mistake.</li>
+ *   <li><b>Stream ownership:</b> the caller closes the stream. {@code store} must not.</li>
+ *   <li><b>No partial visibility:</b> when {@code store} throws, a subsequent
+ *       {@link #exists exists(caseNumber, fileName)} must return {@code false}. A failed
+ *       write aborts and cleans up; it never leaves a half-written object visible.</li>
+ *   <li><b>Same-name behavior is implementation-defined for now.</b> Whether a second
+ *       store of the same (caseNumber, fileName) overwrites, versions, or rejects is an
+ *       open contract question (tsanetgit/Connect-API-Code#140, question 2). Callers must
+ *       not build a check-then-store policy on {@link #exists} — that is a race; when the
+ *       answer lands, the policy moves into {@code store} itself (conditional write).</li>
+ *   <li><b>{@code fileName} is remote-controlled input.</b> The platform backend appends
+ *       the sender's filename to the push URL with no encoding, so it may contain path
+ *       separators or traversal sequences. Adapters treat it as an opaque token, never as
+ *       a path to interpret.</li>
+ * </ul>
+ */
+public interface AttachmentStorage {
+
+    /**
+     * Streams one attachment's bytes to the backend.
+     *
+     * @param attachment what is being stored; {@link IncomingAttachment#contentLength()}
+     *                   may be {@code -1} when the byte count is unknown up front
+     * @param content    the bytes; read incrementally, never closed by this method
+     * @return the backend key the bytes landed under and the count actually written
+     * @throws AttachmentStorageException on any failure, including a stream that fails
+     *                                    mid-read; the failed object must not be visible
+     */
+    StoredAttachment store(IncomingAttachment attachment, InputStream content)
+            throws AttachmentStorageException;
+
+    /**
+     * Whether an object for this (caseNumber, fileName) is currently visible.
+     *
+     * <p>An indeterminate check must throw, never answer {@code false}: on a real backend
+     * this is a network call, and reporting an outage as "object absent" would make the
+     * no-partial-visibility guarantee unverifiable exactly when it matters.
+     *
+     * @throws AttachmentStorageException when the backend cannot answer
+     */
+    boolean exists(String caseNumber, String fileName) throws AttachmentStorageException;
+
+    /**
+     * Go-live probe: proves the configured backend is reachable and writable by writing,
+     * reading back, and deleting a sentinel object. Run on configuration save and on
+     * demand; a passing probe is the precondition for registering a receive config.
+     *
+     * @throws AttachmentStorageException with a message specific enough to distinguish
+     *                                    wrong-credential from wrong-target from
+     *                                    no-permission
+     */
+    void verifyAccess() throws AttachmentStorageException;
+}

--- a/attachment-receiver/src/main/java/com/tsanet/receiver/storage/AttachmentStorageException.java
+++ b/attachment-receiver/src/main/java/com/tsanet/receiver/storage/AttachmentStorageException.java
@@ -1,0 +1,17 @@
+package com.tsanet.receiver.storage;
+
+/**
+ * A storage operation failed. Checked on purpose: the ingest path must map every storage
+ * failure to a non-2xx response (the platform backend treats any 2xx as delivered, so a
+ * swallowed failure here reads as success to the sender and the file is silently lost).
+ */
+public class AttachmentStorageException extends Exception {
+
+    public AttachmentStorageException(String message) {
+        super(message);
+    }
+
+    public AttachmentStorageException(String message, Throwable cause) {
+        super(message, cause);
+    }
+}

--- a/attachment-receiver/src/main/java/com/tsanet/receiver/storage/IncomingAttachment.java
+++ b/attachment-receiver/src/main/java/com/tsanet/receiver/storage/IncomingAttachment.java
@@ -1,0 +1,36 @@
+package com.tsanet.receiver.storage;
+
+import java.util.Objects;
+
+/**
+ * What the receiver knows about one attachment before storing it. The case number is the
+ * only case-correlation metadata the push contract carries, so it is required; everything
+ * else degrades gracefully.
+ *
+ * @param caseNumber    the collaboration case number the file belongs to; never blank
+ * @param fileName      the file's name as pushed; never blank
+ * @param contentType   the declared media type, or {@code null} when not declared
+ * @param contentLength the declared byte count, or {@code -1} when unknown (a chunked
+ *                      push has no length up front; adapters must handle both)
+ */
+public record IncomingAttachment(String caseNumber, String fileName, String contentType,
+                                 long contentLength) {
+
+    public IncomingAttachment {
+        if (Objects.requireNonNull(caseNumber, "caseNumber").isBlank()) {
+            throw new IllegalArgumentException("caseNumber must not be blank");
+        }
+        if (Objects.requireNonNull(fileName, "fileName").isBlank()) {
+            throw new IllegalArgumentException("fileName must not be blank");
+        }
+        if (contentLength < -1) {
+            throw new IllegalArgumentException(
+                    "contentLength must be a byte count or -1 for unknown, got " + contentLength);
+        }
+    }
+
+    /** Whether the byte count was declared up front. */
+    public boolean lengthKnown() {
+        return contentLength >= 0;
+    }
+}

--- a/attachment-receiver/src/main/java/com/tsanet/receiver/storage/StoredAttachment.java
+++ b/attachment-receiver/src/main/java/com/tsanet/receiver/storage/StoredAttachment.java
@@ -1,0 +1,23 @@
+package com.tsanet.receiver.storage;
+
+import java.util.Objects;
+
+/**
+ * Proof of a completed store: where the bytes landed and how many were written.
+ *
+ * @param storageKey   the backend's key for the object; never blank, layout is the
+ *                     adapter's concern
+ * @param bytesWritten the count actually streamed to the backend; always the real count,
+ *                     even when the incoming length was unknown
+ */
+public record StoredAttachment(String storageKey, long bytesWritten) {
+
+    public StoredAttachment {
+        if (Objects.requireNonNull(storageKey, "storageKey").isBlank()) {
+            throw new IllegalArgumentException("storageKey must not be blank");
+        }
+        if (bytesWritten < 0) {
+            throw new IllegalArgumentException("bytesWritten must be >= 0, got " + bytesWritten);
+        }
+    }
+}

--- a/attachment-receiver/src/main/java/com/tsanet/receiver/verify/CrmProbe.java
+++ b/attachment-receiver/src/main/java/com/tsanet/receiver/verify/CrmProbe.java
@@ -1,0 +1,20 @@
+package com.tsanet.receiver.verify;
+
+import java.util.Map;
+
+/**
+ * Dry-run authentication against a tenant's CRM using its configured delivery
+ * credentials. Implementations arrive with the delivery adapters (gateway-side work);
+ * this module only defines the seam so go-live verification has both halves.
+ */
+public interface CrmProbe {
+
+    /**
+     * Proves the credentials in {@code crmProperties} can authenticate, without
+     * performing any delivery.
+     *
+     * @throws Exception on failure, with a message specific enough to distinguish
+     *                   wrong-credential from wrong-target from no-permission
+     */
+    void dryRun(Map<String, String> crmProperties) throws Exception;
+}

--- a/attachment-receiver/src/main/java/com/tsanet/receiver/verify/GoLiveVerifier.java
+++ b/attachment-receiver/src/main/java/com/tsanet/receiver/verify/GoLiveVerifier.java
@@ -1,0 +1,69 @@
+package com.tsanet.receiver.verify;
+
+import com.tsanet.receiver.config.TenantConfig;
+import com.tsanet.receiver.storage.AttachmentStorage;
+import com.tsanet.receiver.verify.VerificationReport.Check;
+import com.tsanet.receiver.verify.VerificationReport.CheckResult;
+import com.tsanet.receiver.verify.VerificationReport.Status;
+
+import java.util.ArrayList;
+import java.util.List;
+
+/**
+ * Runs a tenant's go-live checks: build the configured storage and prove it with the
+ * SPI's write-read-delete probe; dry-run the CRM credentials when delivery is
+ * configured. Run on configuration save and on demand; a passing report is the
+ * precondition for registering the tenant's receive config with the platform.
+ *
+ * <p>Each check is isolated: an unexpected RuntimeException from an adapter lands as
+ * that check's FAIL, never as an aborted report.
+ */
+public final class GoLiveVerifier {
+
+    private final StorageFactory storageFactory;
+    private final CrmProbe crmProbe;
+
+    /** {@code crmProbe} may be null while no delivery adapter is wired in. */
+    public GoLiveVerifier(StorageFactory storageFactory, CrmProbe crmProbe) {
+        this.storageFactory = storageFactory;
+        this.crmProbe = crmProbe;
+    }
+
+    public VerificationReport verify(TenantConfig config) {
+        List<CheckResult> results = new ArrayList<>();
+        results.add(storageCheck(config));
+        results.add(crmCheck(config));
+        return new VerificationReport(results);
+    }
+
+    private CheckResult storageCheck(TenantConfig config) {
+        try {
+            AttachmentStorage storage = storageFactory.create(config);
+            storage.verifyAccess();
+            return new CheckResult(Check.STORAGE, Status.PASS,
+                    "backend '" + config.storageBackend() + "' passed the write-read-delete probe");
+        } catch (Exception e) {
+            return new CheckResult(Check.STORAGE, Status.FAIL, failureMessage(e));
+        }
+    }
+
+    private CheckResult crmCheck(TenantConfig config) {
+        if (!config.hasCrmDelivery()) {
+            return new CheckResult(Check.CRM, Status.SKIPPED, "no CRM delivery configured");
+        }
+        if (crmProbe == null) {
+            return new CheckResult(Check.CRM, Status.FAIL,
+                    "CRM delivery is configured but no probe is available to verify it");
+        }
+        try {
+            crmProbe.dryRun(config.crmProperties());
+            return new CheckResult(Check.CRM, Status.PASS, "CRM credentials authenticated");
+        } catch (Exception e) {
+            return new CheckResult(Check.CRM, Status.FAIL, failureMessage(e));
+        }
+    }
+
+    private static String failureMessage(Exception e) {
+        return e.getMessage() != null ? e.getMessage() : e.getClass().getSimpleName();
+    }
+}

--- a/attachment-receiver/src/main/java/com/tsanet/receiver/verify/StorageFactory.java
+++ b/attachment-receiver/src/main/java/com/tsanet/receiver/verify/StorageFactory.java
@@ -1,0 +1,19 @@
+package com.tsanet.receiver.verify;
+
+import com.tsanet.receiver.config.TenantConfig;
+import com.tsanet.receiver.storage.AttachmentStorage;
+import com.tsanet.receiver.storage.AttachmentStorageException;
+
+/**
+ * Builds the {@link AttachmentStorage} a tenant's configuration selects. Adapters
+ * register here by string id ({@code TenantConfig#storageBackend()}); an unknown id
+ * throws with a message naming it, which the verifier surfaces as a STORAGE failure.
+ *
+ * <p>{@code create} may construct lazily; it does not have to prove connectivity. The
+ * go-live verifier proves connectivity itself by calling
+ * {@link AttachmentStorage#verifyAccess()} on what this returns.
+ */
+public interface StorageFactory {
+
+    AttachmentStorage create(TenantConfig config) throws AttachmentStorageException;
+}

--- a/attachment-receiver/src/main/java/com/tsanet/receiver/verify/VerificationReport.java
+++ b/attachment-receiver/src/main/java/com/tsanet/receiver/verify/VerificationReport.java
@@ -1,0 +1,27 @@
+package com.tsanet.receiver.verify;
+
+import java.util.List;
+
+/**
+ * The outcome of one tenant's go-live verification, one result per check. Failures carry
+ * the underlying message verbatim: the operator reading this decides between
+ * wrong-credential, wrong-target, and no-permission from it.
+ */
+public record VerificationReport(List<CheckResult> checks) {
+
+    public VerificationReport {
+        checks = List.copyOf(checks);
+    }
+
+    public enum Check { STORAGE, CRM }
+
+    public enum Status { PASS, FAIL, SKIPPED }
+
+    public record CheckResult(Check check, Status status, String message) {
+    }
+
+    /** True when nothing failed; a SKIPPED check does not fail a tenant. */
+    public boolean passed() {
+        return checks.stream().noneMatch(c -> c.status() == Status.FAIL);
+    }
+}

--- a/attachment-receiver/src/test/java/com/tsanet/receiver/config/EncryptedFileTenantConfigStoreTest.java
+++ b/attachment-receiver/src/test/java/com/tsanet/receiver/config/EncryptedFileTenantConfigStoreTest.java
@@ -1,0 +1,139 @@
+package com.tsanet.receiver.config;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+
+import javax.crypto.SecretKey;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.security.SecureRandom;
+import java.util.Base64;
+import java.util.Map;
+import java.util.Optional;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+class EncryptedFileTenantConfigStoreTest {
+
+    @TempDir
+    Path dir;
+
+    private EncryptedFileTenantConfigStore store;
+
+    private static String randomKeyBase64() {
+        byte[] key = new byte[32];
+        new SecureRandom().nextBytes(key);
+        return Base64.getEncoder().encodeToString(key);
+    }
+
+    private static TenantConfig acme() {
+        return new TenantConfig("acme", "push-secret-042", "s3",
+                Map.of("bucket", "acme-files"), Map.of("apiToken", "crm-token-042"));
+    }
+
+    @BeforeEach
+    void newStore() throws Exception {
+        store = new EncryptedFileTenantConfigStore(dir,
+                EncryptedFileTenantConfigStore.keyFromBase64(randomKeyBase64()));
+    }
+
+    @Test
+    void roundTripsAConfig() throws Exception {
+        store.save(acme());
+        Optional<TenantConfig> loaded = store.byPathSegment("acme");
+        assertTrue(loaded.isPresent());
+        assertEquals(acme(), loaded.get());
+    }
+
+    @Test
+    void unknownTenantIsEmptyNotAnError() throws Exception {
+        assertTrue(store.byPathSegment("nobody").isEmpty());
+    }
+
+    @Test
+    void ciphertextContainsNoCredentialBytes() throws Exception {
+        store.save(acme());
+        String onDisk = new String(Files.readAllBytes(dir.resolve("acme.tenant")),
+                StandardCharsets.ISO_8859_1);
+        assertFalse(onDisk.contains("push-secret-042"), "password visible on disk");
+        assertFalse(onDisk.contains("crm-token-042"), "crm credential visible on disk");
+        assertFalse(onDisk.contains("acme-files"), "storage property visible on disk");
+    }
+
+    @Test
+    void bitFlipFailsTheIntegrityCheckLoudly() throws Exception {
+        store.save(acme());
+        Path file = dir.resolve("acme.tenant");
+        byte[] body = Files.readAllBytes(file);
+        body[body.length - 1] ^= 0x01;
+        Files.write(file, body);
+        TenantConfigException e = assertThrows(TenantConfigException.class,
+                () -> store.byPathSegment("acme"));
+        assertTrue(e.getMessage().contains("integrity"), "message should name the failure: " + e.getMessage());
+    }
+
+    @Test
+    void swappedTenantFilesDoNotDecrypt() throws Exception {
+        // The AAD binding: renaming globex's file to acme.tenant must fail, not load.
+        store.save(acme());
+        store.save(new TenantConfig("globex", "other-pw", "azure-files", Map.of(), Map.of()));
+        Files.copy(dir.resolve("globex.tenant"), dir.resolve("acme.tenant"),
+                java.nio.file.StandardCopyOption.REPLACE_EXISTING);
+        TenantConfigException e = assertThrows(TenantConfigException.class,
+                () -> store.byPathSegment("acme"),
+                "a swapped config file must fail its integrity check");
+        // The mechanism, not just the outcome: AAD binding fails the DECRYPT ("integrity
+        // check"). If AAD were silently dropped, decrypt would succeed and the later
+        // stored-pathSegment cross-check would throw its distinct message instead.
+        assertTrue(e.getMessage().contains("integrity"),
+                "swap must fail at decryption (AAD), not at the post-decrypt cross-check: "
+                        + e.getMessage());
+    }
+
+    @Test
+    void readPathRejectsNonTokenSegments() {
+        // Defense on the read path: a raw request value must not address arbitrary files.
+        assertThrows(IllegalArgumentException.class, () -> store.byPathSegment("../escape"));
+        assertThrows(IllegalArgumentException.class, () -> store.byPathSegment(null));
+    }
+
+    @Test
+    void wrongKeyFailsLoudlyNotEmptily() throws Exception {
+        store.save(acme());
+        EncryptedFileTenantConfigStore other = new EncryptedFileTenantConfigStore(dir,
+                EncryptedFileTenantConfigStore.keyFromBase64(randomKeyBase64()));
+        assertThrows(TenantConfigException.class, () -> other.byPathSegment("acme"));
+    }
+
+    @Test
+    void listsAllTenants() throws Exception {
+        store.save(acme());
+        store.save(new TenantConfig("globex", "pw2", "azure-files", Map.of(), Map.of()));
+        assertEquals(2, store.all().size());
+    }
+
+    @Test
+    void saveReplacesAtomicallyAndLeavesNoTempFiles() throws Exception {
+        store.save(acme());
+        store.save(new TenantConfig("acme", "rotated-pw", "s3",
+                Map.of("bucket", "acme-files"), Map.of()));
+        assertEquals("rotated-pw", store.byPathSegment("acme").orElseThrow().pushPassword());
+        try (var files = Files.list(dir)) {
+            assertTrue(files.allMatch(f -> f.getFileName().toString().endsWith(".tenant")),
+                    "no temp files may remain after save");
+        }
+    }
+
+    @Test
+    void truncatedKeyFailsAtStartupWithByteCount() {
+        IllegalArgumentException e = assertThrows(IllegalArgumentException.class,
+                () -> EncryptedFileTenantConfigStore.keyFromBase64(
+                        Base64.getEncoder().encodeToString(new byte[16])));
+        assertTrue(e.getMessage().contains("16"), "message should say what it got: " + e.getMessage());
+    }
+}

--- a/attachment-receiver/src/test/java/com/tsanet/receiver/config/TenantConfigTest.java
+++ b/attachment-receiver/src/test/java/com/tsanet/receiver/config/TenantConfigTest.java
@@ -1,0 +1,68 @@
+package com.tsanet.receiver.config;
+
+import org.junit.jupiter.api.Test;
+
+import java.util.Map;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+class TenantConfigTest {
+
+    private static TenantConfig valid() {
+        return new TenantConfig("acme", "push-secret", "s3",
+                Map.of("bucket", "acme-files", "secretKey", "storage-credential-value"),
+                Map.of("apiToken", "crm-credential-value"));
+    }
+
+    @Test
+    void acceptsAValidRoutingToken() {
+        assertEquals("acme", valid().pathSegment());
+    }
+
+    @Test
+    void rejectsRoutingTokensThatAreNotFilenameSafe() {
+        // Allowlist, not blocklist: each of these is dangerous as a path or filename
+        // even though none contains a forward slash. Deliberately absent: Windows
+        // reserved names ("con", "nul") — all-lowercase forms PASS the allowlist; the
+        // receiver deploys on Linux containers and does not defend Windows filesystems.
+        for (String bad : new String[]{"..", "Acme", "a/b", "a\\b", "", "-leading",
+                "a".repeat(65), "dot.dot"}) {
+            assertThrows(IllegalArgumentException.class,
+                    () -> new TenantConfig(bad, "pw", "s3", Map.of(), Map.of()),
+                    "should have rejected: '" + bad + "'");
+        }
+    }
+
+    @Test
+    void rejectsBlankPasswordAndBackend() {
+        assertThrows(IllegalArgumentException.class,
+                () -> new TenantConfig("acme", " ", "s3", Map.of(), Map.of()));
+        assertThrows(IllegalArgumentException.class,
+                () -> new TenantConfig("acme", "pw", " ", Map.of(), Map.of()));
+    }
+
+    @Test
+    void emptyCrmPropertiesMeansNoDelivery() {
+        TenantConfig config = new TenantConfig("acme", "pw", "s3", Map.of(), Map.of());
+        assertFalse(config.hasCrmDelivery());
+        assertTrue(valid().hasCrmDelivery());
+    }
+
+    @Test
+    void toStringRedactsEveryCredential() {
+        String printed = valid().toString();
+        assertFalse(printed.contains("push-secret"), "password leaked into toString");
+        assertFalse(printed.contains("storage-credential-value"), "storage credential leaked into toString");
+        assertFalse(printed.contains("crm-credential-value"), "crm credential leaked into toString");
+        assertTrue(printed.contains("acme"), "structure (tenant, keys) should still print");
+    }
+
+    @Test
+    void propertyMapsAreImmutableCopies() {
+        assertThrows(UnsupportedOperationException.class,
+                () -> valid().storageProperties().put("k", "v"));
+    }
+}

--- a/attachment-receiver/src/test/java/com/tsanet/receiver/storage/AttachmentStorageContractTest.java
+++ b/attachment-receiver/src/test/java/com/tsanet/receiver/storage/AttachmentStorageContractTest.java
@@ -1,0 +1,114 @@
+package com.tsanet.receiver.storage;
+
+import org.junit.jupiter.api.Test;
+
+import java.io.ByteArrayInputStream;
+import java.io.FilterInputStream;
+import java.io.IOException;
+import java.io.InputStream;
+import java.nio.charset.StandardCharsets;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+/**
+ * The contract every {@link AttachmentStorage} adapter must pass; an adapter binds itself
+ * by extending this class and implementing {@link #newStorage()}. Deliberately absent:
+ * any assertion about storing the same (caseNumber, fileName) twice — that policy is an
+ * open contract question (tsanetgit/Connect-API-Code#140, question 2) and pinning it here
+ * would encode an answer we do not have.
+ */
+public abstract class AttachmentStorageContractTest {
+
+    /** A fresh, empty storage instance per test. */
+    protected abstract AttachmentStorage newStorage() throws Exception;
+
+    private static final byte[] CONTENT = "attachment bytes for the contract test".getBytes(StandardCharsets.UTF_8);
+
+    private static IncomingAttachment knownLength() {
+        return new IncomingAttachment("01234567", "diag.log", "text/plain", CONTENT.length);
+    }
+
+    @Test
+    void storeThenExists() throws Exception {
+        AttachmentStorage storage = newStorage();
+        StoredAttachment stored = storage.store(knownLength(), new ByteArrayInputStream(CONTENT));
+        assertFalse(stored.storageKey().isBlank(), "storageKey must identify the object");
+        assertTrue(storage.exists("01234567", "diag.log"), "stored object must be visible");
+    }
+
+    @Test
+    void bytesWrittenMatchesStreamedLength() throws Exception {
+        AttachmentStorage storage = newStorage();
+        StoredAttachment stored = storage.store(knownLength(), new ByteArrayInputStream(CONTENT));
+        assertEquals(CONTENT.length, stored.bytesWritten());
+    }
+
+    @Test
+    void unknownLengthStreamStores() throws Exception {
+        AttachmentStorage storage = newStorage();
+        IncomingAttachment unknown = new IncomingAttachment("01234567", "chunked.bin", null, -1);
+        StoredAttachment stored = storage.store(unknown, new ByteArrayInputStream(CONTENT));
+        assertEquals(CONTENT.length, stored.bytesWritten(),
+                "bytesWritten must be the real count even when the incoming length was unknown");
+        assertTrue(storage.exists("01234567", "chunked.bin"));
+    }
+
+    @Test
+    void existsIsFalseForUnknownFile() throws Exception {
+        AttachmentStorage storage = newStorage();
+        assertFalse(storage.exists("01234567", "never-stored.txt"));
+    }
+
+    @Test
+    void storeDoesNotCloseTheCallersStream() throws Exception {
+        AttachmentStorage storage = newStorage();
+        var tracking = new CloseTrackingStream(new ByteArrayInputStream(CONTENT));
+        storage.store(knownLength(), tracking);
+        assertFalse(tracking.closed, "the caller owns the stream; store must not close it");
+    }
+
+    @Test
+    void failedStoreLeavesNoPartialVisibility() throws Exception {
+        AttachmentStorage storage = newStorage();
+        IncomingAttachment attachment = new IncomingAttachment("01234567", "truncated.dat", null, -1);
+        assertThrows(AttachmentStorageException.class,
+                () -> storage.store(attachment, new MidReadFailingStream()));
+        assertFalse(storage.exists("01234567", "truncated.dat"),
+                "a failed store must abort cleanly, never leave a half-written object visible");
+    }
+
+    @Test
+    void verifyAccessSucceedsOnAHealthyBackend() throws Exception {
+        newStorage().verifyAccess();
+    }
+
+    private static final class CloseTrackingStream extends FilterInputStream {
+        boolean closed;
+
+        CloseTrackingStream(InputStream in) {
+            super(in);
+        }
+
+        @Override
+        public void close() throws IOException {
+            closed = true;
+            super.close();
+        }
+    }
+
+    /** Yields a few bytes, then fails: the wrong-but-well-formed input for a store path. */
+    private static final class MidReadFailingStream extends InputStream {
+        private int served;
+
+        @Override
+        public int read() throws IOException {
+            if (served++ < 4) {
+                return 'x';
+            }
+            throw new IOException("stream failed mid-read (simulated)");
+        }
+    }
+}

--- a/attachment-receiver/src/test/java/com/tsanet/receiver/storage/InMemoryAttachmentStorage.java
+++ b/attachment-receiver/src/test/java/com/tsanet/receiver/storage/InMemoryAttachmentStorage.java
@@ -1,0 +1,57 @@
+package com.tsanet.receiver.storage;
+
+import java.io.ByteArrayOutputStream;
+import java.io.IOException;
+import java.io.InputStream;
+import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
+
+/**
+ * Test double: the reference {@link AttachmentStorage} semantics with no backend. Buffers
+ * in memory, which the SPI forbids for real adapters — acceptable only because this class
+ * exists to make the contract test and future callers testable, never to hold real files.
+ */
+public final class InMemoryAttachmentStorage implements AttachmentStorage {
+
+    private final Map<String, byte[]> objects = new ConcurrentHashMap<>();
+
+    @Override
+    public StoredAttachment store(IncomingAttachment attachment, InputStream content)
+            throws AttachmentStorageException {
+        String key = key(attachment.caseNumber(), attachment.fileName());
+        ByteArrayOutputStream buffer = new ByteArrayOutputStream();
+        byte[] chunk = new byte[8192];
+        try {
+            int read;
+            while ((read = content.read(chunk)) != -1) {
+                buffer.write(chunk, 0, read);
+            }
+        } catch (IOException e) {
+            throw new AttachmentStorageException(
+                    "stream failed mid-read for " + key + "; nothing stored", e);
+        }
+        byte[] bytes = buffer.toByteArray();
+        objects.put(key, bytes);
+        return new StoredAttachment(key, bytes.length);
+    }
+
+    @Override
+    public boolean exists(String caseNumber, String fileName) {
+        return objects.containsKey(key(caseNumber, fileName));
+    }
+
+    @Override
+    public void verifyAccess() {
+        // No backend to probe: the in-memory map is always reachable and writable.
+    }
+
+    /** Visible for callers' assertions in future tests, not part of the SPI. */
+    public byte[] contentOf(String caseNumber, String fileName) {
+        byte[] bytes = objects.get(key(caseNumber, fileName));
+        return bytes == null ? null : bytes.clone();
+    }
+
+    private static String key(String caseNumber, String fileName) {
+        return caseNumber + "/" + fileName;
+    }
+}

--- a/attachment-receiver/src/test/java/com/tsanet/receiver/storage/InMemoryAttachmentStorageTest.java
+++ b/attachment-receiver/src/test/java/com/tsanet/receiver/storage/InMemoryAttachmentStorageTest.java
@@ -1,0 +1,10 @@
+package com.tsanet.receiver.storage;
+
+/** Binds the in-memory double to the contract every adapter must pass. */
+class InMemoryAttachmentStorageTest extends AttachmentStorageContractTest {
+
+    @Override
+    protected AttachmentStorage newStorage() {
+        return new InMemoryAttachmentStorage();
+    }
+}

--- a/attachment-receiver/src/test/java/com/tsanet/receiver/verify/GoLiveVerifierTest.java
+++ b/attachment-receiver/src/test/java/com/tsanet/receiver/verify/GoLiveVerifierTest.java
@@ -1,0 +1,78 @@
+package com.tsanet.receiver.verify;
+
+import com.tsanet.receiver.config.TenantConfig;
+import com.tsanet.receiver.storage.AttachmentStorageException;
+import com.tsanet.receiver.storage.InMemoryAttachmentStorage;
+import com.tsanet.receiver.verify.VerificationReport.Check;
+import com.tsanet.receiver.verify.VerificationReport.CheckResult;
+import com.tsanet.receiver.verify.VerificationReport.Status;
+import org.junit.jupiter.api.Test;
+
+import java.util.Map;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+class GoLiveVerifierTest {
+
+    private static final TenantConfig STORAGE_ONLY =
+            new TenantConfig("acme", "pw", "in-memory", Map.of(), Map.of());
+    private static final TenantConfig WITH_CRM =
+            new TenantConfig("acme", "pw", "in-memory", Map.of(), Map.of("apiToken", "t"));
+
+    private static final StorageFactory WORKING = config -> new InMemoryAttachmentStorage();
+
+    private static CheckResult result(VerificationReport report, Check check) {
+        return report.checks().stream().filter(c -> c.check() == check).findFirst().orElseThrow();
+    }
+
+    @Test
+    void passesStorageAndSkipsCrmWhenUnconfigured() {
+        VerificationReport report = new GoLiveVerifier(WORKING, null).verify(STORAGE_ONLY);
+        assertEquals(Status.PASS, result(report, Check.STORAGE).status());
+        assertEquals(Status.SKIPPED, result(report, Check.CRM).status());
+        assertTrue(report.passed(), "SKIPPED must not fail a tenant");
+    }
+
+    @Test
+    void unknownBackendSurfacesAsAStorageFailureNamingIt() {
+        StorageFactory unknown = config -> {
+            throw new AttachmentStorageException(
+                    "no storage adapter registered for backend '" + config.storageBackend() + "'");
+        };
+        VerificationReport report = new GoLiveVerifier(unknown, null).verify(STORAGE_ONLY);
+        CheckResult storage = result(report, Check.STORAGE);
+        assertEquals(Status.FAIL, storage.status());
+        assertTrue(storage.message().contains("in-memory"),
+                "failure must name the backend id: " + storage.message());
+        assertFalse(report.passed());
+    }
+
+    @Test
+    void configuredCrmWithNoProbeWiredIsALoudFailureNotASkip() {
+        VerificationReport report = new GoLiveVerifier(WORKING, null).verify(WITH_CRM);
+        assertEquals(Status.FAIL, result(report, Check.CRM).status());
+    }
+
+    @Test
+    void bothChecksFailIndependentlyWithTheirOwnMessages() {
+        StorageFactory deadStorage = config -> {
+            throw new RuntimeException("storage: wrong-credential (simulated)");
+        };
+        CrmProbe deadCrm = props -> {
+            throw new RuntimeException("crm: no-permission (simulated)");
+        };
+        VerificationReport report = new GoLiveVerifier(deadStorage, deadCrm).verify(WITH_CRM);
+        assertEquals("storage: wrong-credential (simulated)", result(report, Check.STORAGE).message());
+        assertEquals("crm: no-permission (simulated)", result(report, Check.CRM).message());
+        assertFalse(report.passed());
+    }
+
+    @Test
+    void crmDryRunPassesWhenTheProbeAuthenticates() {
+        VerificationReport report = new GoLiveVerifier(WORKING, props -> { }).verify(WITH_CRM);
+        assertEquals(Status.PASS, result(report, Check.CRM).status());
+        assertTrue(report.passed());
+    }
+}

--- a/pom.xml
+++ b/pom.xml
@@ -22,6 +22,7 @@
         <module>connect-library</module>
         <module>TSANet-integration-demo</module>
         <module>TSANet-integration-app</module>
+        <module>attachment-receiver</module>
     </modules>
 
     <properties>


### PR DESCRIPTION
Closes #50 (epic #46). **Stacked on #54** — base is `feat/attachment-receiver-skeleton`; GitHub retargets to `main` when #54 merges.

## What this adds

- `TenantConfig`: one member's receive configuration, serving both hosting modes (member-deployed = the single-tenant degenerate case). The routing token is **allowlisted** (`[a-z0-9][a-z0-9-]{0,63}`) in the record *and* re-validated on the store's read path, making it safe as a URL path segment and a filename in one move.
- `EncryptedFileTenantConfigStore`: AES-256-GCM file-per-tenant at rest, random IV per write, the routing token bound as GCM AAD (swapped files fail at decrypt), atomic temp-file + `ATOMIC_MOVE` saves, `keyFromBase64` failing at startup on a wrong-length key.
- `GoLiveVerifier` + `VerificationReport`: the Figure-5 checks from the strategy doc — build the configured storage and prove it via the SPI's `verifyAccess()` probe; dry-run CRM credentials when delivery is configured (`CrmProbe` is a seam; implementations arrive with the delivery adapters). Checks fail independently with the underlying message passed through verbatim.
- `StorageFactory`: adapters register by string id; unknown id surfaces as a STORAGE failure naming it.

## Deliberate decisions (stated, not implied)

- **`all()` is fail-fast: one unreadable tenant file fails whole-directory enumeration.** By design for now — an unreadable config is an operational emergency in hosted mode, and silently skipping it would hide exactly the tenant whose files are at risk. If operating experience wants skip-and-collect, that's a follow-up with its own report shape. `byPathSegment` (the per-push path) isolates failures per tenant.
- **Windows reserved names (`con`, `nul`) pass the allowlist.** The receiver deploys on Linux containers; the rejection test says so explicitly rather than implying protection that doesn't exist.
- **Credentials as `String`, not `char[]`:** zeroing is theater here (values transit `Properties` and cipher buffers regardless); the enforced protections are encryption at rest and full redaction of `toString` (password *and* both property maps' values — only keys print).

## Verification

- 28 tests green (surefire: TenantConfigTest 6, EncryptedFileTenantConfigStoreTest 10, GoLiveVerifierTest 5, plus the 7 SPI tests from #54).
- The swap test asserts the **mechanism**, not just the outcome: the failure message must come from the decrypt ("integrity check"), proving the AAD binding acted — if AAD were dropped, the post-decrypt cross-check's distinct message would appear and the test fails.
- Ciphertext probed for credential bytes (password, CRM token, storage property) — none on disk.
- Bit-flip tamper, wrong-key, traversal-on-read (`../escape`), rotation-replaces-atomically, and no-temp-file-residue all covered.

## Advisor (2 calls)

Design call: switched routing-token validation from blocklist to allowlist (dot-dot, backslash, case-collisions), required `toString` redaction with a test, required AAD binding + file-swap test, atomic saves, 32-byte key check with byte count in the message, per-check `Exception` isolation. Pre-done call: strengthened the swap test to assert the AAD mechanism (applied), temp-file cleanup on failed save (applied), honest comment on Windows reserved names (applied), and the `all()` decision stated above.

## Pre-PR gate

Exit 0 ("Merge"). Its one note is the `all()` fail-fast behavior, dispositioned above as a deliberate decision.

## Blast radius (`pre-pr-artifacts.py --base feat/attachment-receiver-skeleton`)

Net-new packages (`config`, `verify`); no existing symbol changed; detector lines all clean. PROMPT lines answered:

- **Guard vs representation:** the allowlist IS the representation change (routing token defined as a grammar, not a sanitized string); the record validators are constructor invariants.
- **Newly reachable failures → handler:** `TenantConfigException` and verification FAILs are consumed today by tests; their designed consumers are the ingest endpoint (#51: unreadable tenant → non-2xx) and the onboarding flow (#53 / gateway #26: a failing report blocks registration). Both are those issues' acceptance, not this PR's.
- **Abstraction introduced:** "which backend stores this tenant's files" had no prior decider (`git grep -n "storageBackend" -- ':!attachment-receiver'` → nothing).
- **Schema/stored shape:** the encrypted file format is introduced here (IV || ciphertext, Properties inside, AAD = token). No pre-existing files can exist; version-marking the format is deferred until a second format exists to distinguish.
- **Prose claims:** every claim in the class javadoc maps to a test named in Verification above; the commit message's "swapped files fail at decrypt" is made true by the mechanism assertion.
