### PR TITLE
Add connect-sdk-deploy: a Claude skill for member SDK and demo deployment

### DIFF
--- a/skills/connect-sdk-deploy/SKILL.md
+++ b/skills/connect-sdk-deploy/SKILL.md
@@ -1,0 +1,127 @@
+---
+name: connect-sdk-deploy
+description: >
+  Help TSANet members (and anyone assisting them) deploy the TSANet Connect SDK and the
+  SDK demo from tsanetgit/Connect_SDK. Covers adding connect-library to a member's own
+  Java / Maven / Spring Boot tooling via GitHub Packages, building the SDK from source,
+  running the demo-ui web demo or the console app locally, and hosting the demo in a
+  container for stakeholders. Use this skill whenever someone mentions the Connect SDK,
+  connect-library, the SDK demo or demo-ui, Java integration with the TSANet Connect API,
+  consuming TSANet Maven artifacts, or deploying, hosting, or showing the demo, even if
+  they never name the repository. For Connect REST API semantics (endpoints, case
+  lifecycle rules) defer to the tsanet-connect skill; this skill owns getting the SDK and
+  demo built, configured, and running.
+---
+
+# Deploying the Connect SDK and SDK demo
+
+This skill gets a TSANet member from zero to a working Connect SDK integration or a
+running SDK demo. The source of truth is the `tsanetgit/Connect_SDK` repository itself:
+its root `README.md`, `docs/RUNBOOK.md`, `docs/USER_GUIDE.md`, and
+`connect-library/README.md`. When you have a checkout available, read those files before
+answering; this skill tells you what matters, where the traps are, and what has changed
+recently, but the repo docs win on any conflict.
+
+Facts below were verified against `main` on 2026-08-18. If months have passed, re-verify
+the release version, branch names, and module list against the live repository.
+
+## Repository map
+
+| Module | What it is | Runnable? |
+|---|---|---|
+| `connect-library` | The Java client for the TSANet Connect API. Facade API over generated OpenAPI clients, with a local SQLite cache. This is "the SDK". | Library only |
+| `TSANet-integration-app` | Console reference app exposing the library as CLI commands (`login`, `requests`, `notes add`, `webhooks create`, ...) | Spring Boot jar |
+| `TSANet-integration-demo` | Scripted demo scenarios over the library | Spring Boot jar |
+| `demo-ui` | The branded web demo: dashboard, partner search, dynamic process forms, full case lifecycle from the browser. This is "the SDK demo" most people mean. | Spring Boot jar, port 8090 |
+| `attachment-receiver` | Attachment receive endpoint with pluggable storage (S3, Azure Files). Early stage; no standalone docs yet. | Spring Boot jar |
+
+## Access model (read this first, it shapes everything)
+
+- `tsanetgit/Connect_SDK` is **public**.
+- The build generates client code from the Connect OpenAPI specification, which lives in
+  `tsanetgit/Connect-API-Code`. That repository is **private**. A clone of Connect_SDK
+  alone does not build.
+- The released library is published to **GitHub Packages**, which requires a GitHub
+  personal access token with `read:packages` for downloads, even though the package is
+  public. Any GitHub account works; no tsanetgit org membership needed.
+
+So there are two very different situations:
+
+1. **Member consuming the SDK** (the common case): no source build needed. Pull
+   `com.tsanet:connect-library` from GitHub Packages with any GitHub account.
+   See `references/consume-artifact.md`.
+2. **Anyone building from source** (required for the demo apps, or for unreleased
+   changes): needs read access to the private `tsanetgit/Connect-API-Code` repository.
+   Members who need this should ask their TSANet contact for access, or ask TSANet to
+   hand them a built jar or container image instead.
+
+## Choose the path
+
+**"We want to call the Connect API from our own Java service"** →
+`references/consume-artifact.md`. Maven coordinates, the GitHub Packages token dance,
+auth configuration (OAuth client-credentials and password modes), and working code for
+the common operations.
+
+**"We want to run or host the demo"** → `references/demo-deploy.md`. Local build and
+run, entering member credentials, the ngrok option for a one-off screen share, the
+Docker image, and hosting with the mandatory auth gate.
+
+**"The build or the app is misbehaving"** → `references/troubleshooting.md`. Symptom
+to cause to fix, including the classic ones (wrong sibling branch, the 500-on-bad-login
+error mode, GitHub Packages 401s).
+
+## Building from source (the short version)
+
+Prerequisites: JDK 21, Maven, and read access to `tsanetgit/Connect-API-Code`.
+
+1. Clone both repositories side by side. The spec sibling **must** be named
+   `Connect-API-Code` and **must** have the `beta` branch checked out. The generated
+   symbols depend on which specification the sibling provides, so the branch matters:
+   `develop` currently breaks the build (V2 webhook APIs).
+
+   ```bash
+   git clone https://github.com/tsanetgit/Connect_SDK.git
+   git clone https://github.com/tsanetgit/Connect-API-Code.git
+   cd Connect-API-Code && git checkout beta && cd ..
+   ```
+
+2. Build from the Connect_SDK root on `main`:
+
+   ```bash
+   mvn install                          # everything, with tests
+   mvn -pl connect-library -am install  # library only
+   ```
+
+Module poms stay at `0.0.1-SNAPSHOT` by design; the release workflow stamps real
+versions. Do not build from the historical `oauth` branch: it merged to `main` in
+`tsanetgit/Connect_SDK#44` and remains only as history.
+
+## Cross-cutting API gotchas
+
+These bite regardless of path, and none of them are visible in the OpenAPI schema:
+
+- **Bad credentials return HTTP 500, not 401.** The Connect API's legacy error mode
+  answers a wrong username or password with
+  `500 "Error processing request"`. Sending `Accept: application/problem+json` opts
+  into structured RFC 7807 errors. Do not let a member burn an afternoon debugging
+  their network for what is a typo in a password.
+- **Test-mode asymmetry.** You *write* the `testSubmission` flag when creating a case
+  but *read* it back as `testCase`. The library's create API takes an explicit
+  per-call `testSubmission` flag with no silent default; older always-test method
+  signatures are deprecated shims scheduled for removal in 0.2.0.
+- **Engineer emails must be on the member's registered domain.** The platform rejects
+  collaboration requests whose engineer email is off the member company's registered
+  domain. This is a business rule, not a schema rule, and the error is not
+  self-explanatory.
+- **A successful `/me` proves authentication, not authorization.** Business endpoints
+  require the API role on the account; `/v1/me` does not. A green "who am I" check
+  can coexist with 403s on every case operation. Verify with a real case list, not
+  with `/me`.
+
+## Credential hygiene
+
+Member credentials, tokens, and tenant IDs never go in git, in the workflow files, or
+in anything shared. Keep real values in an untracked local file or environment
+variables, and use placeholders like `<MEMBER_USERNAME>` in anything written down.
+The demo persists credentials to `~/.tsanet-demo-ui/` (mode 600) on purpose; that
+directory stays on the machine that entered them.

--- a/skills/connect-sdk-deploy/evals/evals.json
+++ b/skills/connect-sdk-deploy/evals/evals.json
@@ -1,0 +1,50 @@
+{
+  "skill_name": "connect-sdk-deploy",
+  "evals": [
+    {
+      "id": 0,
+      "eval_name": "local-demo",
+      "prompt": "We're a TSANet member on the BETA environment and I want to run the Connect SDK demo locally on my MacBook (Apple Silicon, Homebrew tooling) so our support team can click through a case lifecycle. Write me the exact step-by-step plan, commands included, plus anything that usually trips people up. Save it as demo-local-plan.md",
+      "expected_output": "A runbook-style plan: sibling clone of the private Connect-API-Code repo on the beta branch, JDK 21 JAVA_HOME setup, the two Maven build commands, running the demo-ui jar on localhost:8090, entering member credentials in Settings, and the known traps (500-on-bad-login badge, wrong sibling branch).",
+      "files": [],
+      "assertions": [
+        "Instructs cloning tsanetgit/Connect-API-Code as a sibling directory and checking out the beta branch",
+        "Notes that Connect-API-Code is private / requires access from TSANet",
+        "Specifies JDK 21 with explicit JAVA_HOME setup for Homebrew keg-only openjdk@21",
+        "Builds connect-library and demo-ui with Maven and runs the demo-ui jar",
+        "States the app listens on localhost:8090 and credentials are entered in the Settings tab",
+        "Explains that a bad login shows as 'Connect API returned 500', not a 401"
+      ]
+    },
+    {
+      "id": 1,
+      "eval_name": "spring-boot",
+      "prompt": "Our platform team wants to call the TSANet Connect API from our existing Spring Boot service using TSANet's official Java SDK. Produce the setup guide for us: how we get the dependency, how auth works for a production application account (we're a Microsoft Entra shop), and code that lists collaboration requests and approves an inbound one. Save it as sdk-integration-guide.md",
+      "expected_output": "A guide covering GitHub Packages consumption (repo URL, read:packages PAT, settings.xml server id matching), the client-credentials auth mode configured via tsanet.accounts in application.yml with the secret from an environment variable, and facade code for listRequests plus approveRequest.",
+      "files": [],
+      "assertions": [
+        "Gives the GitHub Packages repository URL maven.pkg.github.com/tsanetgit/Connect_SDK and says a PAT with read:packages is required even for public artifacts",
+        "Shows a settings.xml server entry whose id matches the pom repository id",
+        "Configures client-credentials auth (tenant-id, client-id, client-secret, audience) with the secret sourced from an environment variable, not a literal",
+        "Uses the session facade API (authenticate/login, collaborationRequests().listRequests(), caseResponses().approveRequest(...))",
+        "Does not hardcode a version without pointing at the releases page as the source of the current one",
+        "Surfaces at least one platform business rule (engineer email on registered domain, testSubmission/testCase asymmetry, or 500 legacy error mode)"
+      ]
+    },
+    {
+      "id": 2,
+      "eval_name": "hosted-demo",
+      "prompt": "I need the TSANet Connect SDK demo reachable by a few colleagues for about a week for an evaluation. We have Docker locally and a container host in the cloud. Give me the deployment steps and the security must-dos. Save it as hosted-demo-plan.md",
+      "expected_output": "A hosted deployment plan: jar built outside Docker, amd64 platform flag, the mandatory TSANET_DEMO_AUTH_USER/PASSWORD gate, /healthz for health checks, ephemeral credential storage requiring re-entry after redeploys, and pause/scale-to-zero guidance rather than deleting the service.",
+      "files": [],
+      "assertions": [
+        "States the jar must be built outside Docker because the image is runtime-only (codegen needs the spec sibling)",
+        "Uses --platform linux/amd64 for the image build",
+        "Requires setting TSANET_DEMO_AUTH_USER and TSANET_DEMO_AUTH_PASSWORD and warns the app is open when the password is unset",
+        "Mentions /healthz as the open health-check endpoint",
+        "Warns that container storage is ephemeral so member credentials must be re-entered after each deploy/restart",
+        "Advises pausing/scaling to zero between uses rather than deleting the service, or flags App Runner's closure to new customers"
+      ]
+    }
+  ]
+}

--- a/skills/connect-sdk-deploy/references/consume-artifact.md
+++ b/skills/connect-sdk-deploy/references/consume-artifact.md
@@ -1,0 +1,183 @@
+# Consuming connect-library from GitHub Packages
+
+The path for a member embedding the SDK in their own Java tooling. No source build, no
+access to the private spec repository.
+
+## Coordinates
+
+`com.tsanet:connect-library`, published to
+`https://maven.pkg.github.com/tsanetgit/Connect_SDK`.
+
+Always point people at the **latest release** for the current version number:
+<https://github.com/tsanetgit/Connect_SDK/releases/latest>. Do not hardcode a version
+into docs you write for them; quote the coordinates pattern and let the release page
+supply the number.
+
+## One-time token setup
+
+GitHub Packages requires authentication for Maven downloads even on public packages.
+Any GitHub account works; the token needs only the `read:packages` scope.
+
+`~/.m2/settings.xml`:
+
+```xml
+<settings>
+  <servers>
+    <server>
+      <id>github</id>
+      <username><GITHUB_USERNAME></username>
+      <password><PAT_WITH_READ_PACKAGES></password>
+    </server>
+  </servers>
+</settings>
+```
+
+Consumer `pom.xml`:
+
+```xml
+<repositories>
+  <repository>
+    <id>github</id>
+    <url>https://maven.pkg.github.com/tsanetgit/Connect_SDK</url>
+  </repository>
+</repositories>
+
+<dependency>
+  <groupId>com.tsanet</groupId>
+  <artifactId>connect-library</artifactId>
+  <version><LATEST_RELEASE_VERSION></version>
+</dependency>
+```
+
+The `<id>github</id>` in the pom must match the `<id>` in settings.xml, or Maven will
+not send credentials and you get an opaque 401. The parent pom
+(`tsanet-client-parent`) is published alongside the library and resolves from the same
+repository.
+
+The library works outside Spring Boot: `jackson-datatype-jsr310` is a declared
+dependency as of 0.1.0, so plain-Java embedding does not fail on time serialization.
+
+## Opening a session
+
+```java
+import com.tsanet.api.TsaNetApi;
+import com.tsanet.api.TsaNetApiConfiguration;
+import com.tsanet.api.TsaNetApiSession;
+
+TsaNetApiSession session = TsaNetApi.initialize(
+    TsaNetApiConfiguration.of(
+        "<CONNECT_API_BASE_URL>",                 // TSANet provides per environment
+        System.getProperty("user.home") + "/.tsanet/data.db",  // local SQLite cache
+        "<MEMBER_USERNAME>",
+        "<MEMBER_PASSWORD>"
+    )
+);
+session.auth().login("<MEMBER_USERNAME>", "<MEMBER_PASSWORD>");
+```
+
+Facades hang off the session: `auth()`, `collaborationRequests()`, `caseNotes()`,
+`caseResponses()`, `users()`, `webhooks()`, `partners()`, `attachments()`. Remote calls
+before a successful login throw `IllegalStateException: Not logged in`.
+
+Every remote read and successful write upserts into the SQLite cache;
+`listStored*` methods read the cache without touching the network. `logout()` clears
+the in-memory token only, never the cache.
+
+## Auth modes
+
+Two modes, selected by configuration:
+
+- **`connect1-password`**: username and password, the mode shown above. Typical for
+  evaluation and non-production accounts.
+- **`client-credentials`**: OAuth 2.0 machine-to-machine via Microsoft Entra, the mode
+  for production application accounts. The library refreshes tokens proactively before
+  expiry. TSANet provisions the tenant, client ID, and audience values with the
+  application account.
+
+Client-credentials, programmatic:
+
+```java
+import com.tsanet.api.ApplicationUserAccount;
+import com.tsanet.api.ApplicationUserAccountConfigMapper;
+
+ApplicationUserAccount account = ApplicationUserAccountConfigMapper.clientCredentialsAccount(
+    "production",
+    System.getProperty("user.home") + "/.tsanet/production.db",
+    "<ENTRA_TENANT_ID>",
+    null,
+    "<ENTRA_CLIENT_ID>",
+    System.getenv("TSANET_CLIENT_SECRET"),
+    "<API_AUDIENCE>",       // e.g. api://... value provided by TSANet
+    null
+);
+
+TsaNetApiSession session = TsaNetApi.sessionFactory(
+    TsaNetApiConnectionSettings.of("<CONNECT_API_BASE_URL>", account.sqlitePath())
+).openSessionForApplicationUser(account);
+
+session.auth().authenticate();
+```
+
+Spring Boot, in `application.yml`:
+
+```yaml
+tsanet:
+  accounts:
+    - id: production
+      sqlite-path: "${user.home}/.tsanet/production.db"
+      auth:
+        type: client-credentials
+        tenant-id: "<ENTRA_TENANT_ID>"
+        client-id: "<ENTRA_CLIENT_ID>"
+        client-secret: "${TSANET_CLIENT_SECRET}"
+        audience: "<API_AUDIENCE>"
+    - id: evaluation
+      sqlite-path: "${user.home}/.tsanet/eval.db"
+      auth:
+        type: connect1-password
+        username: "<MEMBER_USERNAME>"
+        password: "<MEMBER_PASSWORD>"
+```
+
+Secrets always arrive via environment variables, never literals in the yml.
+
+## Multiple accounts or environments
+
+Use the session factory so each account gets an isolated SQLite file and bearer token:
+
+```java
+TsaNetApiSessionFactory factory = TsaNetApi.sessionFactory(
+    TsaNetApiConnectionSettings.of("<CONNECT_API_BASE_URL>", "/path/to/data.db")
+);
+TsaNetApiSession a = factory.openSession("acme", "<USER_A>", "<PASSWORD_A>");
+TsaNetApiSession b = factory.openSessionForAccount("<USER_B_EMAIL>", "<PASSWORD_B>");
+```
+
+Session labels map to per-label database files (`data-acme.db`, ...), so two
+environments or two member companies never share a cache.
+
+## The operations members actually start with
+
+```java
+session.users().getCurrentUser();                       // who am I
+session.collaborationRequests().syncAllDetails();       // pull everything into SQLite
+var partners = session.partners().searchPartners("<PARTNER_NAME>");
+session.collaborationRequests().createRequest(
+    partners.get(0).companyId(), "<YOUR_CASE_NUMBER>",
+    "Problem summary", "Detailed description");
+session.caseResponses().approveRequest(token, "<CASE_NUMBER>", "<ENGINEER_NAME>",
+    "<ENGINEER_EMAIL_ON_REGISTERED_DOMAIN>", "<PHONE>", "Next steps");
+```
+
+The full facade reference, the CLI command table, and lifecycle validation examples
+live in `connect-library/README.md` in the repository. Read it when the member's
+question goes past setup and into API usage. Remember the lifecycle rules are the
+business contract: reject requires `INFORMATION` status, notes are refused on closed
+cases, and so on. For those semantics defer to TSANet's Connect documentation or the
+tsanet-connect skill rather than inferring from method signatures.
+
+## Upgrading
+
+Watch the release notes on each release. Known deprecation: the always-test create
+signatures (pre-0.1.0 behavior) are shims scheduled for removal in 0.2.0; migrate
+callers to the explicit per-call `testSubmission` flag.

--- a/skills/connect-sdk-deploy/references/demo-deploy.md
+++ b/skills/connect-sdk-deploy/references/demo-deploy.md
@@ -1,0 +1,140 @@
+# Running and hosting the SDK demo
+
+The demo (`demo-ui`) tells the member integration story end to end in a browser:
+authenticate, find a partner, fill the partner's process form, submit a collaboration
+request, and work the case lifecycle from both sides. It exists to show what the SDK
+gives a member out of the box.
+
+Authoritative repo docs: `docs/RUNBOOK.md` (build, start, credentials, tunnel,
+shutdown) and `docs/USER_GUIDE.md` (how to drive the app). Read them from the checkout
+when available. This reference compresses them and adds context they assume.
+
+## What you need before starting
+
+- JDK 21 (Homebrew's `openjdk@21` is keg-only; export `JAVA_HOME` explicitly)
+- A source checkout with the private spec sibling (see SKILL.md "Building from
+  source"): the demo is not published as an artifact, so someone with
+  `tsanetgit/Connect-API-Code` access must build it, or supply the jar or image
+- Member credentials for the environment you will demo against. For a bidirectional
+  demo (both sides of a case), two member companies partnered with published process
+  forms, each able to search and submit to the other
+
+## Local run
+
+```bash
+export JAVA_HOME=<JAVA_21_HOME>
+export PATH="$JAVA_HOME/bin:$PATH"
+cd <CONNECT_SDK_CHECKOUT>
+mvn -q -pl connect-library -am install -DskipTests
+mvn -q -pl demo-ui -am package -DskipTests
+java -jar demo-ui/target/demo-ui-0.0.1-SNAPSHOT.jar
+```
+
+The server listens on **http://localhost:8090**. Ctrl+C stops it, or
+`pkill -f demo-ui-0.0.1-SNAPSHOT.jar`.
+
+## Credentials and the header badge
+
+1. Open the app, go to **Settings**. There is one card per environment; enter the
+   member username and password on the environment you were issued, **Save
+   Credentials**, then **Make Active**.
+2. The header badge is the connection truth:
+   - **Green "Company — email"**: authenticated; that is the live `/api/me` answer
+   - **Amber "Not configured"**: nothing saved yet
+   - **Amber "Auth failed: Connect API returned 500 — Error processing request"**: the
+     environment rejected the credentials. The API's legacy error mode returns 500 for
+     bad logins, so this almost always means a wrong username or password, not an
+     outage.
+
+Credentials persist per environment to `~/.tsanet-demo-ui/` (mode 600, never in git),
+with an isolated SQLite cache per environment, so restarts skip this step. Settings →
+**Clear** wipes an environment. The active environment persists across restarts.
+
+## First session with real credentials: verification sweep
+
+Two areas were built against assumptions and deserve one live confirmation. Walk them
+once and note anything odd:
+
+1. **New Collaboration** → search a partner → open the process form. Do dropdowns show
+   one option per line, and does every field type render as a sensible input?
+2. Open any **case detail**. Do the lifecycle action buttons match what the case state
+   actually allows?
+
+Rendering anomalies are typically one-line field-type mapping fixes; report them to
+TSANet rather than working around them.
+
+## Sharing options, weakest to strongest
+
+### One call: ngrok tunnel
+
+```bash
+ngrok http 8090
+```
+
+Share the printed `https://` URL. Free-tier caveats: visitors click through an
+interstitial page, and the URL changes on every restart. Kill the tunnel when the call
+ends; never leave it up unattended, because the local app has no auth gate.
+
+### Standing deployment: container
+
+The root `Dockerfile` builds a **runtime-only** image: it packages a jar you already
+built (the codegen needs the spec sibling, which the Docker build context lacks).
+Build the jar first, then:
+
+```bash
+docker build --platform linux/amd64 -t connect-sdk-demo .
+docker run --rm -p 8090:8090 \
+  -e TSANET_DEMO_AUTH_USER=<PICK_A_USER> \
+  -e TSANET_DEMO_AUTH_PASSWORD=<PICK_A_PASSWORD> \
+  connect-sdk-demo
+```
+
+`--platform linux/amd64` matters when building on Apple silicon for an amd64 host.
+The image runs as a non-root user and stores per-environment credentials and SQLite
+caches under `TSANET_DEMO_DATA_DIR` (defaults to `/tmp/tsanet-demo`), which is
+**ephemeral by design**: after every container restart or redeploy, re-enter the
+member credentials in Settings.
+
+### The auth gate is not optional when hosted
+
+The app runs **open** when `TSANET_DEMO_AUTH_PASSWORD` is unset; that is only
+acceptable on localhost. Any deployment reachable by others MUST set
+`TSANET_DEMO_AUTH_USER` and `TSANET_DEMO_AUTH_PASSWORD`, which puts a browser
+password prompt in front of everything. `/healthz` stays open for platform health
+checks. Remember what sits behind the gate: a UI that holds live member credentials
+and can create real collaboration cases against partner companies.
+
+## Hosting notes
+
+Any container host that can run an amd64 image with one exposed port and a health
+check on `/healthz` works: AWS App Runner, ECS, Azure Container Apps, Cloud Run, or a
+plain VM with Docker.
+
+Operational pattern that has worked well: keep the service **paused or scaled to
+zero between demos** (no compute billing, nothing exposed), resume a few minutes
+before, pause after. Two cautions from experience:
+
+- Do not delete and recreate a service to turn it off; public URLs are minted per
+  service, and every share link dies. Pause is the off switch.
+- AWS App Runner specifically stopped accepting new customers on 2026-04-30. Existing
+  services keep running, but for a new deployment pick a different host (on AWS, ECS
+  Express Mode fed by the same image is the natural successor).
+
+Redeploy loop for an image-based host: rebuild the jar, rebuild and push the image,
+trigger the host's deploy, then re-enter member credentials (ephemeral filesystem).
+
+## The console app, if a browser is overkill
+
+`TSANet-integration-app` packages the same library behind CLI commands, useful for
+scripted walkthroughs or terminal-only environments:
+
+```bash
+mvn -q -pl TSANet-integration-app -am package -DskipTests
+java -jar TSANet-integration-app/target/TSANet-integration-app-0.0.1-SNAPSHOT.jar
+```
+
+Then interactively: `api-login <MEMBER_USERNAME> <MEMBER_PASSWORD>`, `requests`,
+`partners --search <NAME>`, `create-request ...`, `notes add ...`, `sync`. The full
+command table is in `connect-library/README.md`. The app's webhook bridge listens on
+port 8090 by default (`tsanet.webhook.port`), so do not run it alongside demo-ui
+without changing one of the ports.

--- a/skills/connect-sdk-deploy/references/troubleshooting.md
+++ b/skills/connect-sdk-deploy/references/troubleshooting.md
@@ -1,0 +1,82 @@
+# Troubleshooting
+
+Symptom-first. Each entry: what you see, what it actually means, what to do.
+
+## Build
+
+**`cannot find symbol ... WebhooksApi` (or other generated classes missing)**
+The spec sibling is on the wrong branch. The build generates the client from
+`../Connect-API-Code/connect-core-api/src/main/resources/openapi.yaml`, and the
+generated symbols track that branch. Fix:
+`cd ../Connect-API-Code && git checkout beta`, then rebuild. The `develop` branch
+currently breaks the build (V2 webhook APIs).
+
+**Build fails immediately, complains it cannot read the OpenAPI spec**
+There is no sibling checkout. Clone `tsanetgit/Connect-API-Code` (private; needs
+access) beside the SDK checkout, directory named exactly `Connect-API-Code`, branch
+`beta`. A Connect_SDK clone alone does not build; if the person cannot get spec
+access, route them to the published artifact or hand them a built jar.
+
+**Maven returns 401 downloading connect-library from GitHub Packages**
+GitHub Packages authenticates every Maven download, public or not. Checklist:
+a token with `read:packages`; a `<server>` entry in `~/.m2/settings.xml` whose
+`<id>` exactly matches the repository `<id>` in the pom (conventionally `github`);
+the repository URL `https://maven.pkg.github.com/tsanetgit/Connect_SDK`.
+
+**JDK mismatch errors (release version, class file version)**
+The build wants JDK 21. On macOS with Homebrew, `openjdk@21` is keg-only: export
+`JAVA_HOME` to it and prepend `$JAVA_HOME/bin` to `PATH` before building or running.
+
+## Runtime, demo
+
+**Badge says: Auth failed: Connect API returned 500 — Error processing request**
+Almost always wrong credentials. The Connect API's legacy error mode answers bad
+logins with 500, not 401. Re-enter the username and password before suspecting the
+platform.
+
+**Everything authenticates but the dashboard is empty or case actions 403**
+Authentication is not authorization. `/me` succeeds for any valid account, while
+business endpoints require the API role. Have TSANet confirm the account is
+API-enabled, and verify with a real case list rather than the badge.
+
+**Collaboration request rejected on submit, complaint about the engineer email**
+Platform business rule: the engineer email must be on the member company's
+registered domain. Personal or off-domain addresses are rejected. Not in the API
+schema; do not look for it there.
+
+**Credentials keep disappearing on the hosted demo**
+By design. The container filesystem is ephemeral (`TSANET_DEMO_DATA_DIR`, default
+`/tmp/tsanet-demo`), so every redeploy, restart, or resume wipes saved credentials.
+Re-enter them in Settings after each cycle. Locally, credentials persist in
+`~/.tsanet-demo-ui/` until cleared.
+
+**Hosted demo loads with no password prompt**
+`TSANET_DEMO_AUTH_PASSWORD` is unset, so the gate is off and the demo is open to
+anyone with the URL. Set `TSANET_DEMO_AUTH_USER` and `TSANET_DEMO_AUTH_PASSWORD` in
+the host's configuration and redeploy immediately.
+
+**Container exits or crashes on an amd64 host but ran fine locally on a Mac**
+The image was built for arm64. Rebuild with `--platform linux/amd64`.
+
+**Port 8090 already in use**
+demo-ui and the console app's webhook bridge both default to 8090. Run one at a
+time, or move the bridge (`tsanet.webhook.port`).
+
+## Interpreting API errors generally
+
+The API has two error personalities. By default (legacy mode) failures collapse into
+`500 Error processing request`. Sending `Accept: application/problem+json` opts into
+RFC 7807 structured errors with a usable `detail`. When debugging anything
+API-side, turn that on first; it converts guessing into reading.
+
+Test-mode note for anyone wiring their own client: you *write* `testSubmission` on
+create but *read* the flag back as `testCase`. Filtering on the write-side name
+silently treats every test case as real.
+
+## When it is not in this file
+
+Read the repo docs (`README.md`, `docs/RUNBOOK.md`, `docs/USER_GUIDE.md`,
+`connect-library/README.md`) from the member's checkout; they are the source of
+truth and updated with the code. If the behavior contradicts those docs, gather the
+exact request, response, and app version, and raise it with TSANet rather than
+patching around it.


### PR DESCRIPTION
A Claude Code skill under `skills/connect-sdk-deploy/` that assists TSANet members (and anyone helping them) with deploying the Connect SDK and the SDK demo. Follows the precedent of `tsanet-gateway-adapter` living in `tsanetgit/Connect_Gateway`.

## What it carries

- **SKILL.md**: repository map, the access model (public SDK repo, private spec sibling, GitHub Packages token requirement), the three deployment paths, the from-source build, and the cross-cutting API gotchas (500-on-bad-login, `testSubmission`/`testCase` asymmetry, registered-domain email rule, `/me` vs authorization).
- **references/consume-artifact.md**: the member path. GitHub Packages consumption, settings.xml shape, both auth modes with code and `application.yml`, session factory, first operations.
- **references/demo-deploy.md**: local run, credentials and badge, verification sweep, ngrok, the runtime-only Docker image, the mandatory hosted auth gate, hosting notes including the App Runner new-customer closure.
- **references/troubleshooting.md**: symptom-first fixes for the recurring traps.
- **evals/evals.json**: three test scenarios with assertions, for future skill iterations.

## Grounding

Every fact verified against this repository on 2026-08-18: root README, `docs/RUNBOOK.md`, `docs/USER_GUIDE.md`, `connect-library/README.md`, the v0.1.0 release notes, and the publish workflow discussion in `tsanetgit/Connect_SDK#43`. Placeholders only; no live identifiers, hostnames, tenant IDs, or credentials.

## Validation

Three member scenarios (local demo run, Spring Boot integration, hosted demo) were executed by a fresh agent session with the skill and a baseline session without it, graded against 18 assertions:

| | Pass rate | Mean time | Mean tokens |
|---|---|---|---|
| With skill | 18/18 | 150s | 88.8k |
| Baseline | 17/18 | 192s | 91.5k |

The baseline ran on a machine with full local clones (including the private spec repo), so it is a strong baseline; the skill's edge there was speed, fewer tool calls, and durable-docs discipline (the baseline hardcoded the release version, the skill run pointed at releases/latest). On a machine without the clones the gap widens.

## Open questions for review

1. Distribution: keep repo-only, or also surface through the Developer Hub for members?
2. After merge, symlink into `~/.claude/skills/` on the ops machine (same pattern as the gateway skill)?

🤖 Generated with [Claude Code](https://claude.com/claude-code)