### PR TITLE
connect-sdk-deploy skill: refresh to v1.0.0 (Jackson 3, 0.2.0 retention, receiver adapters)

### DIFF
--- a/skills/connect-sdk-deploy/SKILL.md
+++ b/skills/connect-sdk-deploy/SKILL.md
@@ -22,7 +22,7 @@ its root `README.md`, `docs/RUNBOOK.md`, `docs/USER_GUIDE.md`, and
 answering; this skill tells you what matters, where the traps are, and what has changed
 recently, but the repo docs win on any conflict.
 
-Facts below were verified against `main` on 2026-08-18. If months have passed, re-verify
+Facts below were verified against `main` on 2026-09-02 (release v1.0.0). If months have passed, re-verify
 the release version, branch names, and module list against the live repository.
 
 ## Repository map
@@ -33,7 +33,7 @@ the release version, branch names, and module list against the live repository.
 | `TSANet-integration-app` | Console reference app exposing the library as CLI commands (`login`, `requests`, `notes add`, `webhooks create`, ...) | Spring Boot jar |
 | `TSANet-integration-demo` | Scripted demo scenarios over the library | Spring Boot jar |
 | `demo-ui` | The branded web demo: dashboard, partner search, dynamic process forms, full case lifecycle from the browser. This is "the SDK demo" most people mean. | Spring Boot jar, port 8090 |
-| `attachment-receiver` | Attachment receive endpoint with pluggable storage (S3, Azure Files). Early stage; no standalone docs yet. | Spring Boot jar |
+| `attachment-receiver` | The storage half of receiving pushed files: a streaming storage SPI with AWS S3, Azure Files, and Google Cloud Storage adapters, an encrypted per-tenant config store, and a go-live verifier. The HTTPS endpoint that accepts the push is not built yet; no standalone docs yet. | Spring Boot jar |
 
 ## Access model (read this first, it shapes everything)
 
@@ -77,7 +77,8 @@ Prerequisites: JDK 21, Maven, and read access to `tsanetgit/Connect-API-Code`.
 1. Clone both repositories side by side. The spec sibling **must** be named
    `Connect-API-Code` and **must** have the `beta` branch checked out. The generated
    symbols depend on which specification the sibling provides, so the branch matters:
-   `develop` currently breaks the build (V2 webhook APIs).
+   `beta` is the branch CI builds and certifies against; other branches are
+   unsupported and have broken the build before.
 
    ```bash
    git clone https://github.com/tsanetgit/Connect_SDK.git
@@ -108,7 +109,8 @@ These bite regardless of path, and none of them are visible in the OpenAPI schem
 - **Test-mode asymmetry.** You *write* the `testSubmission` flag when creating a case
   but *read* it back as `testCase`. The library's create API takes an explicit
   per-call `testSubmission` flag with no silent default; older always-test method
-  signatures are deprecated shims scheduled for removal in 0.2.0.
+  signatures remain as deprecated shims (still present in 1.0.0) and will be removed
+  at a later release boundary.
 - **Engineer emails must be on the member's registered domain.** The platform rejects
   collaboration requests whose engineer email is off the member company's registered
   domain. This is a business rule, not a schema rule, and the error is not

--- a/skills/connect-sdk-deploy/references/consume-artifact.md
+++ b/skills/connect-sdk-deploy/references/consume-artifact.md
@@ -54,8 +54,12 @@ not send credentials and you get an opaque 401. The parent pom
 (`tsanet-client-parent`) is published alongside the library and resolves from the same
 repository.
 
-The library works outside Spring Boot: `jackson-datatype-jsr310` is a declared
-dependency as of 0.1.0, so plain-Java embedding does not fail on time serialization.
+Three versions are published: 0.1.0, 0.2.0, and 1.0.0. **1.0.0 requires Jackson 3**
+(`tools.jackson.core:jackson-databind`) and is built on the Spring Boot 4.1 line; a
+service still on Jackson 2 or Spring Boot 3 should take 0.2.0, which has the same
+facade surface on the older runtime. The library works outside Spring Boot; from 1.0.0
+`java.time` support comes from Jackson 3's databind itself, so no `jsr310` module is
+declared or needed.
 
 ## Opening a session
 
@@ -164,7 +168,8 @@ session.collaborationRequests().syncAllDetails();       // pull everything into 
 var partners = session.partners().searchPartners("<PARTNER_NAME>");
 session.collaborationRequests().createRequest(
     partners.get(0).companyId(), "<YOUR_CASE_NUMBER>",
-    "Problem summary", "Detailed description");
+    "Problem summary", "Detailed description",
+    true);   // testSubmission: explicit per call; false pages a real partner engineer
 session.caseResponses().approveRequest(token, "<CASE_NUMBER>", "<ENGINEER_NAME>",
     "<ENGINEER_EMAIL_ON_REGISTERED_DOMAIN>", "<PHONE>", "Next steps");
 ```
@@ -178,6 +183,19 @@ tsanet-connect skill rather than inferring from method signatures.
 
 ## Upgrading
 
-Watch the release notes on each release. Known deprecation: the always-test create
-signatures (pre-0.1.0 behavior) are shims scheduled for removal in 0.2.0; migrate
-callers to the explicit per-call `testSubmission` flag.
+Watch the release notes on each release.
+
+- **0.2.0** added `CacheRetention.sweep(JdbcTemplate, Duration, Instant)`: age-based
+  eviction of closed and rejected cases from the SQLite cache. Open cases are never
+  evicted; attachment forward results are never touched. Nothing runs it for you;
+  call it from your own schedule if the cache should not grow forever.
+- **1.0.0** moved to Spring Boot 4.1 and Jackson 3. Facade signatures are unchanged.
+  Breaking for consumers: Jackson 3 is required; Jackson 3 parse exceptions are
+  unchecked, so a `catch (IOException)` around a mapper call compiles but stops
+  catching malformed JSON; `FAIL_ON_NULL_FOR_PRIMITIVES` is on by default in your own
+  mappers (the library's cache reader keeps the old behavior); the `JsonNullable`
+  accessors on `CaseApprovalUpdateDTO` and `CollaborationRequestSubmitterUpdateDTO`
+  are gone (plain accessors unchanged).
+- Known deprecation: the always-test create signatures (pre-0.1.0 behavior) are still
+  present in 1.0.0 as `@Deprecated(forRemoval = true)` shims; migrate callers to the
+  explicit per-call `testSubmission` flag before they are removed.

--- a/skills/connect-sdk-deploy/references/troubleshooting.md
+++ b/skills/connect-sdk-deploy/references/troubleshooting.md
@@ -8,8 +8,8 @@ Symptom-first. Each entry: what you see, what it actually means, what to do.
 The spec sibling is on the wrong branch. The build generates the client from
 `../Connect-API-Code/connect-core-api/src/main/resources/openapi.yaml`, and the
 generated symbols track that branch. Fix:
-`cd ../Connect-API-Code && git checkout beta`, then rebuild. The `develop` branch
-currently breaks the build (V2 webhook APIs).
+`cd ../Connect-API-Code && git checkout beta`, then rebuild. `beta` is the branch
+CI certifies; other branches are unsupported.
 
 **Build fails immediately, complains it cannot read the OpenAPI spec**
 There is no sibling checkout. Clone `tsanetgit/Connect-API-Code` (private; needs
@@ -22,6 +22,13 @@ GitHub Packages authenticates every Maven download, public or not. Checklist:
 a token with `read:packages`; a `<server>` entry in `~/.m2/settings.xml` whose
 `<id>` exactly matches the repository `<id>` in the pom (conventionally `github`);
 the repository URL `https://maven.pkg.github.com/tsanetgit/Connect_SDK`.
+
+**Upgraded to connect-library 1.0.0 and the consumer no longer compiles or fails at
+startup on Jackson classes**
+1.0.0 depends on Jackson 3 (`tools.jackson.core`), not Jackson 2
+(`com.fasterxml.jackson.core`). The consumer must be on Jackson 3 / Spring Boot 4.1,
+or stay on 0.2.0. Annotations kept their `com.fasterxml.jackson.annotation` package,
+so annotated DTOs are not the problem; mapper and exception types are.
 
 **JDK mismatch errors (release version, class file version)**
 The build wants JDK 21. On macOS with Homebrew, `openjdk@21` is keg-only: export


### PR DESCRIPTION
Refreshes `skills/connect-sdk-deploy` so its facts match `main` at `bd06c45` (re-verified 2026-09-02). The skill's previous verification date was 2026-08-18, before v0.2.0, v1.0.0 and the GCS adapter (`tsanetgit/Connect_SDK#68`). Docs only: `SKILL.md`, `references/consume-artifact.md`, `references/troubleshooting.md`. `demo-deploy.md` and `evals/evals.json` untouched (jar names, port and console commands re-checked; the evals reference none of the changed text).

## What was wrong, and the receipt for each fix

| Claim in the skill | Reality on `main` | Receipt |
|---|---|---|
| Always-test `createRequest` shims "scheduled for removal in 0.2.0" | Still present in 1.0.0 | `grep -c 'forRemoval = true' connect-library/.../CollaborationRequestsFacade.java` = 2; v0.2.0 notes say the removal was punted |
| The consume-artifact example called the 4-arg `createRequest` | That is the deprecated shim; it silently test-flags the case | Facade source: the non-deprecated form takes `boolean testSubmission`. Example now passes it explicitly |
| `jackson-datatype-jsr310` "is a declared dependency as of 0.1.0" | 1.0.0 declares `tools.jackson.core:jackson-databind`, no jsr310 | `connect-library/pom.xml` lines 30-36 |
| Nothing about the runtime line | 1.0.0 is Spring Boot 4.1.1 / Jackson 3; three versions published | root pom parent 4.1.1; `gh api orgs/tsanetgit/packages/maven/com.tsanet.connect-library/versions` = 1.0.0, 0.2.0, 0.1.0 |
| Receiver: "pluggable storage (S3, Azure Files)" | S3, Azure Files, GCS adapters; encrypted tenant config; go-live verifier; no HTTP ingest | `find attachment-receiver/src/main` (storage/s3, azure, gcs; config/EncryptedFileTenantConfigStore; verify/GoLiveVerifier); `grep -rl RestController attachment-receiver/src/main` = none |
| "`develop` currently breaks the build (V2 webhook APIs)" | connect-library compiles against the develop spec | `mvn -q -pl connect-library -am compile -Dconnect.openapi.spec=<develop openapi.yaml>` exit 0, 85 generated sources regenerated; both branches expose the same `/v1/webhooks*` and `/v2/webhooks` paths |
| No mention of 0.2.0 retention | `CacheRetention.sweep(JdbcTemplate, Duration, Instant)` exists; nothing in `src/main` calls it | `grep -rn 'CacheRetention\.' */src/main` = only the class itself |

Prose claims added in the Upgrading section (unchecked parse exceptions, `FAIL_ON_NULL_FOR_PRIMITIVES`, the two `JsonNullable` DTOs, annotations package unchanged) come from the v1.0.0 release notes and were spot-checked: `CollaborationRequestFormRepository.java:24` disables `FAIL_ON_NULL_FOR_PRIMITIVES` for the cache reader; the two generated DTOs exist with zero `JsonNullable` occurrences; the pom comment at line 31-33 records the annotations coordinates.

## Pre-PR gate and blast radius

- `scripts/qa-review.py --local`: exit 0, `LOOKS GOOD`. The reviewer flagged that it did not independently re-run the pom/shim checks; the receipts above are those checks.
- `scripts/pre-pr-artifacts.py`: no detector triggered (docs-only). PROMPT lines: no guard, check, abstraction, schema or failure path introduced. "Every behavioural claim cites the line that makes it true": see the receipt column above.
- Old-term sweep after editing: `grep -rnE 'scheduled for removal in 0\.2\.0|currently breaks|S3, Azure Files\)'` over the skill = clean.
- `scripts/security-audit.py`: 0 fail, 2 warn (pre-existing), 5 pass.

Advisor consulted twice (orientation and pre-done). The pre-done pass asked whether six library-specific claims were verified rather than inferred; all six were, per the receipts above.

## Follow-up not in this PR

The hub page `connectors/connect-sdk.html` in `tsanetgit/tsanet-developer-hub` was updated to the same facts today (commit `a1de20e`). The skill's "Loading it" instructions there are unchanged and still correct.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
