### PR TITLE
attachment-receiver: Azure Blob Storage adapter (container-scoped), alongside Azure Files

### DIFF
--- a/attachment-receiver/pom.xml
+++ b/attachment-receiver/pom.xml
@@ -63,6 +63,10 @@
             <artifactId>azure-storage-file-share</artifactId>
         </dependency>
         <dependency>
+            <groupId>com.azure</groupId>
+            <artifactId>azure-storage-blob</artifactId>
+        </dependency>
+        <dependency>
             <groupId>com.google.cloud</groupId>
             <artifactId>google-cloud-storage</artifactId>
         </dependency>

--- a/attachment-receiver/src/main/java/com/tsanet/receiver/storage/azure/AzureBlobAttachmentStorage.java
+++ b/attachment-receiver/src/main/java/com/tsanet/receiver/storage/azure/AzureBlobAttachmentStorage.java
@@ -1,0 +1,289 @@
+package com.tsanet.receiver.storage.azure;
+
+import com.tsanet.receiver.storage.AttachmentStorage;
+import com.tsanet.receiver.storage.AttachmentStorageException;
+import com.tsanet.receiver.storage.IncomingAttachment;
+import com.tsanet.receiver.storage.StoredAttachment;
+import com.azure.storage.blob.BlobContainerClient;
+import com.azure.storage.blob.models.BlobErrorCode;
+import com.azure.storage.blob.models.BlobStorageException;
+
+import java.io.IOException;
+import java.io.InputStream;
+import java.nio.charset.StandardCharsets;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Base64;
+import java.util.List;
+import java.util.Objects;
+import java.util.UUID;
+
+/**
+ * {@link AttachmentStorage} on one Azure Blob Storage container (block blobs): the
+ * container-scoped sibling of {@link AzureFilesAttachmentStorage}. Blob is the default
+ * Azure option for member self-service; Files stays for members who need a share
+ * (tsanetgit/Connect_SDK#71). The client is injected: account, container and credential
+ * are wiring concerns, not this class's.
+ *
+ * <p>Blob names are {@code [prefix/]encode(caseNumber)/encode(fileName)}, both components
+ * passed through the same {@link AzureFileNames} encoder the Files adapter uses. Blob
+ * Storage is documented as a flat namespace, but the live acceptance run proved that the
+ * request path is normalized on the way in: {@code ../../etc/passwd} landed outside the
+ * case prefix, a trailing dot was stripped, and a backslash became a separator. Store
+ * and exists agreed on every one of them, so the SPI contract held, but a remote-controlled
+ * name escaping the tenant prefix would break multi-tenant isolation in the hosted mode.
+ * Encoding removes the possibility rather than guarding against it: {@code /}, {@code \},
+ * {@code %}, leading and trailing dots are all percent-encoded, so no name can traverse
+ * and no name can start with a dot (which keeps the {@code .verify-} probe namespace
+ * collision-free). {@link #exists} builds names through the same method, so store and
+ * check can never disagree. The encoder's 255-character component cap is stricter than
+ * Blob's 1,024-character name limit; an over-long name fails fast through the SPI's
+ * checked exception.
+ *
+ * <p>Streaming: bytes are read in {@value #BLOCK_SIZE}-byte buffers. A file that ends
+ * inside the first buffer is written with a single {@code Put Blob}, one atomic request.
+ * Anything larger is staged as blocks ({@code Put Block}) and committed with one
+ * {@code Put Block List}. Two Blob Storage facts make the SPI's no-partial-visibility rule
+ * hold structurally:
+ * <ul>
+ *   <li><b>Uncommitted blocks are invisible.</b> A blob that has only received staged
+ *       blocks reads as {@code BlobNotFound}, and the service garbage-collects it seven days
+ *       after the last {@code Put Block}. On any mid-stream failure the upload is
+ *       abandoned, never committed — committing a partial block list would publish a
+ *       truncated object — and there is deliberately no cleanup round-trip that could
+ *       itself fail (the GCS adapter's shape, unlike S3's abort call).</li>
+ *   <li><b>Ambiguous commit, resolved exactly.</b> A {@code Put Block List} that fails
+ *       client-side may have committed server-side. The S3 and GCS adapters resolve that
+ *       by size, which a same-size overwrite or a concurrent writer can fool
+ *       (tsanetgit/Connect_SDK#69). Here the block ids carry a UUID minted for this store
+ *       call, so the resolution is identity, not size: the blob's committed block list
+ *       ({@code Get Block List}) equal to the ids this call staged means this commit
+ *       landed, and nothing else can produce that list. Any other shape throws.</li>
+ * </ul>
+ * Block ids are fixed-length, as the service requires: one UUID per store call plus a
+ * zero-padded index. With {@value #BLOCK_SIZE}-byte blocks the service's 50,000-block
+ * ceiling is about 390 GiB, far above any platform cap. Same-name behavior is overwrite
+ * (proven live for both the single-request and the staged path), consistent with the
+ * other adapters while the policy stays implementation-defined upstream
+ * (tsanetgit/Connect-API-Code#140, question 2).
+ *
+ * <p><b>Go-live probe.</b> {@link #verifyAccess} stages one uncommitted block on a
+ * {@code .verify-<uuid>} name: it needs only write permission and leaves no committed blob,
+ * replacing the other adapters' write-read-delete sentinel (this is the issue's design).
+ * The consequence, stated rather than hidden: <b>the probe validates write only, while
+ * operation needs read as well</b> — {@link #exists} and the ambiguous-commit probe are
+ * {@code Get Blob Properties}. A SAS carrying only {@code cw} passes go-live and fails
+ * {@code exists} at runtime. Required rights are therefore SAS {@code rw} (or {@code rcw})
+ * on the container, or the Storage Blob Data Contributor role for an Entra identity.
+ *
+ * <p>Failure classification reads the service error code before the HTTP status, because
+ * Azure Storage answers {@code AuthenticationFailed} with 403, not 401.
+ */
+public final class AzureBlobAttachmentStorage implements AttachmentStorage {
+
+    /** Stream read granularity and staged block size: 8 MiB (the service allows up to 4,000 MiB). */
+    static final int BLOCK_SIZE = 8 * 1024 * 1024;
+
+    static final String VERIFY_PREFIX = ".verify-";
+
+    private final AzureBlobContainer container;
+    private final String containerName;
+    private final String prefix;
+
+    /** Production entry point: wraps the injected client in the logic-free SDK seam. */
+    public static AzureBlobAttachmentStorage forContainer(BlobContainerClient client, String prefix) {
+        return new AzureBlobAttachmentStorage(new SdkAzureBlobContainer(client),
+                client.getBlobContainerName(), prefix);
+    }
+
+    AzureBlobAttachmentStorage(AzureBlobContainer container, String containerName, String prefix) {
+        this.container = Objects.requireNonNull(container, "container");
+        this.containerName = Objects.requireNonNull(containerName, "containerName");
+        if (containerName.isBlank()) {
+            throw new IllegalArgumentException("containerName must not be blank");
+        }
+        this.prefix = normalize(prefix);
+    }
+
+    @Override
+    public StoredAttachment store(IncomingAttachment attachment, InputStream content)
+            throws AttachmentStorageException {
+        String name = nameOrThrow(attachment.caseNumber(), attachment.fileName());
+        byte[] buffer = new byte[BLOCK_SIZE];
+        int firstLength = fill(content, buffer, name);
+        if (firstLength < BLOCK_SIZE) {
+            // EOF inside the first buffer: one atomic Put Blob, no partial-visibility window.
+            try {
+                container.putBlob(name, attachment.contentType(), Arrays.copyOf(buffer, firstLength));
+            } catch (RuntimeException e) {
+                throw wrap("put blob", name, e);
+            }
+            return new StoredAttachment(name, firstLength);
+        }
+        return staged(attachment, content, name, buffer);
+    }
+
+    private StoredAttachment staged(IncomingAttachment attachment, InputStream content,
+                                    String name, byte[] buffer)
+            throws AttachmentStorageException {
+        String uploadId = UUID.randomUUID().toString();
+        List<String> blockIds = new ArrayList<>();
+        long total = 0;
+        // A stream failure inside fill() propagates as the AttachmentStorageException it
+        // already is (name and phase included); abandoning is the same no-op either way.
+        try {
+            int length = BLOCK_SIZE; // the first buffer arrived full, or we would not be here
+            boolean last = false;
+            while (!last) {
+                if (!blockIds.isEmpty()) {
+                    // The one buffer is reused: stageBlock is synchronous, so the SDK has
+                    // finished with it before the next fill overwrites it.
+                    length = fill(content, buffer, name);
+                    if (length == 0) {
+                        break; // EOF landed exactly on the previous block's boundary.
+                    }
+                }
+                String blockId = blockId(uploadId, blockIds.size());
+                container.stageBlock(name, blockId, buffer, length);
+                blockIds.add(blockId);
+                total += length;
+                last = length < BLOCK_SIZE;
+            }
+        } catch (RuntimeException stageFailure) {
+            // Abandon: nothing was committed, so nothing is visible; the blocks expire.
+            throw wrap("stage block", name, stageFailure);
+        }
+
+        try {
+            container.commitBlockList(name, blockIds, attachment.contentType());
+        } catch (RuntimeException commitFailure) {
+            return resolveAmbiguousCommit(name, blockIds, total, commitFailure);
+        }
+        return new StoredAttachment(name, total);
+    }
+
+    /**
+     * A failed commit is ambiguous: the service may have committed. The committed block
+     * list equal to the ids this call staged means exactly that — no other writer holds
+     * this call's UUID — so report the commit as the success it was. A different list
+     * (a previous blob of the same name, another writer's, or nothing at all) throws.
+     */
+    private StoredAttachment resolveAmbiguousCommit(String name, List<String> blockIds, long total,
+                                                    RuntimeException commitFailure)
+            throws AttachmentStorageException {
+        try {
+            if (blockIds.equals(container.committedBlockIdsOrAbsent(name))) {
+                return new StoredAttachment(name, total);
+            }
+        } catch (RuntimeException probeFailure) {
+            commitFailure.addSuppressed(probeFailure);
+        }
+        throw wrap("commit", name, commitFailure);
+    }
+
+    @Override
+    public boolean exists(String caseNumber, String fileName) throws AttachmentStorageException {
+        String name = nameOrThrow(caseNumber, fileName);
+        try {
+            return container.sizeOrAbsent(name) >= 0;
+        } catch (RuntimeException e) {
+            throw wrap("exists check", name, e);
+        }
+    }
+
+    @Override
+    public void verifyAccess() throws AttachmentStorageException {
+        String probeName = (prefix.isEmpty() ? "" : prefix + "/") + VERIFY_PREFIX + UUID.randomUUID();
+        byte[] probe = "attachment-receiver go-live probe".getBytes(StandardCharsets.UTF_8);
+        try {
+            // One uncommitted block: proves write permission, commits nothing, and the
+            // service reclaims it in seven days. No read, no delete, nothing to clean up.
+            container.stageBlock(probeName, blockId(UUID.randomUUID().toString(), 0), probe, probe.length);
+        } catch (RuntimeException e) {
+            throw new AttachmentStorageException(classify(e), e);
+        }
+    }
+
+    /** Wrong-credential, no-permission, and wrong-target must read differently. */
+    private String classify(RuntimeException e) {
+        if (e instanceof BlobStorageException bse) {
+            BlobErrorCode code = bse.getErrorCode();
+            int status = bse.getStatusCode();
+            if (BlobErrorCode.AUTHENTICATION_FAILED.equals(code)
+                    || BlobErrorCode.INVALID_AUTHENTICATION_INFO.equals(code)
+                    || BlobErrorCode.NO_AUTHENTICATION_INFORMATION.equals(code)) {
+                return "wrong credential: the container rejected the identity (verify write, " + code + ")";
+            }
+            if (BlobErrorCode.AUTHORIZATION_FAILURE.equals(code)
+                    || BlobErrorCode.AUTHORIZATION_PERMISSION_MISMATCH.equals(code)
+                    || BlobErrorCode.INSUFFICIENT_ACCOUNT_PERMISSIONS.equals(code)
+                    || status == 403) {
+                return "no permission: write denied on container '" + containerName + "'"
+                        + (code == null ? "" : " (" + code + ")");
+            }
+            if (BlobErrorCode.CONTAINER_NOT_FOUND.equals(code) || status == 404) {
+                return "wrong target: container '" + containerName
+                        + "' (or its account) does not exist (verify write)";
+            }
+            return "verify write failed on container '" + containerName + "': " + code
+                    + " (HTTP " + status + ")";
+        }
+        return "connectivity: cannot reach the container (verify write): " + e.getMessage();
+    }
+
+    private int fill(InputStream content, byte[] buffer, String name)
+            throws AttachmentStorageException {
+        try {
+            // readNBytes loops over short reads; < buffer.length only ever means EOF.
+            return content.readNBytes(buffer, 0, buffer.length);
+        } catch (IOException e) {
+            throw new AttachmentStorageException(
+                    "stream failed mid-read for " + name + "; nothing committed", e);
+        }
+    }
+
+    /**
+     * Fixed length by construction for every index below 100,000 (36-char UUID, dash,
+     * five digits: 42 bytes before base64, under the service's 64-byte cap), which is
+     * above the service's own 50,000-block ceiling. One UUID per store call, so a retried
+     * store of the same name never commits another attempt's blocks and the ambiguous-commit
+     * resolution can recognize this call's commit by identity.
+     */
+    static String blockId(String uploadId, int index) {
+        return Base64.getEncoder().encodeToString(
+                String.format("%s-%05d", uploadId, index).getBytes(StandardCharsets.US_ASCII));
+    }
+
+    /**
+     * A hostile or oversized name is remote-controlled input; the encoder's
+     * {@link IllegalArgumentException} must surface through the SPI's checked exception,
+     * never as a raw unchecked escape.
+     */
+    private String nameOrThrow(String caseNumber, String fileName) throws AttachmentStorageException {
+        try {
+            String base = AzureFileNames.encode(caseNumber) + "/" + AzureFileNames.encode(fileName);
+            return prefix.isEmpty() ? base : prefix + "/" + base;
+        } catch (IllegalArgumentException e) {
+            throw new AttachmentStorageException("invalid attachment name: " + e.getMessage(), e);
+        }
+    }
+
+    private AttachmentStorageException wrap(String operation, String name, Exception e) {
+        return new AttachmentStorageException(
+                operation + " failed for blob " + containerName + "/" + name + ": " + e.getMessage(), e);
+    }
+
+    private static String normalize(String prefix) {
+        if (prefix == null || prefix.isBlank()) {
+            return "";
+        }
+        String p = prefix;
+        while (p.startsWith("/")) {
+            p = p.substring(1);
+        }
+        while (p.endsWith("/")) {
+            p = p.substring(0, p.length() - 1);
+        }
+        return p;
+    }
+}

--- a/attachment-receiver/src/main/java/com/tsanet/receiver/storage/azure/AzureBlobContainer.java
+++ b/attachment-receiver/src/main/java/com/tsanet/receiver/storage/azure/AzureBlobContainer.java
@@ -1,0 +1,59 @@
+package com.tsanet.receiver.storage.azure;
+
+import java.util.List;
+
+/**
+ * The adapter's seam to one Azure Blob Storage container: a 1:1 wrapper over the SDK
+ * calls {@link AzureBlobAttachmentStorage} uses, and nothing more. Exists for the same
+ * reason {@link AzureShare} does — the SDK's clients are final classes — so offline tests
+ * run against a strict in-memory implementation that enforces the block-blob semantics
+ * the adapter relies on (staged blocks are invisible until committed; a blob that only
+ * ever received uncommitted blocks reads as absent), and {@link SdkAzureBlobContainer}
+ * stays logic-free so the live contract run genuinely covers it. Package-private on
+ * purpose: this is not a second SPI.
+ *
+ * <p>Names are already-joined {@code [prefix/]caseNumber/fileName} strings. Blob names
+ * are opaque to the service, so nothing is encoded on either side of this seam.
+ * Implementations throw their SDK runtime exceptions ({@code BlobStorageException})
+ * through; the adapter owns wrapping and classification.
+ */
+interface AzureBlobContainer {
+
+    /**
+     * Small-file path: {@code Put Blob}, one atomic request. Overwrites an existing blob
+     * of the same name, matching the other adapters while same-name policy stays
+     * implementation-defined upstream (tsanetgit/Connect-API-Code#140, question 2).
+     */
+    void putBlob(String name, String contentType, byte[] bytes);
+
+    /**
+     * Large-file path, step one: {@code Put Block}. Stages the first {@code length} bytes
+     * of {@code buffer} as an uncommitted block of the named blob. Nothing becomes visible
+     * until {@link #commitBlockList}; a blob that only ever received uncommitted blocks
+     * reads as absent and is garbage-collected by the service seven days after the last
+     * successful {@code Put Block}. Block ids must be base64 and the same length within
+     * one blob, which the adapter guarantees.
+     */
+    void stageBlock(String name, String base64BlockId, byte[] buffer, int length);
+
+    /**
+     * Large-file path, step two: {@code Put Block List}. Commits the named blocks in list
+     * order, overwriting any existing blob of the same name; the blob is visible only from
+     * this moment.
+     */
+    void commitBlockList(String name, List<String> base64BlockIds, String contentType);
+
+    /**
+     * The committed blob's byte size, or {@code -1} when no committed blob of that name
+     * exists ({@code BlobNotFound}). Every other failure throws, a missing container
+     * included: an indeterminate check must never read as "absent".
+     */
+    long sizeOrAbsent(String name);
+
+    /**
+     * {@code Get Block List} (committed blocks only): the ids that make up the committed
+     * blob, in order; an empty list for a blob written by {@code Put Blob}; {@code null}
+     * when no committed blob of that name exists. Every other failure throws.
+     */
+    List<String> committedBlockIdsOrAbsent(String name);
+}

--- a/attachment-receiver/src/main/java/com/tsanet/receiver/storage/azure/AzureBlobContainer.java
+++ b/attachment-receiver/src/main/java/com/tsanet/receiver/storage/azure/AzureBlobContainer.java
@@ -12,9 +12,10 @@ import java.util.List;
  * stays logic-free so the live contract run genuinely covers it. Package-private on
  * purpose: this is not a second SPI.
  *
- * <p>Names are already-joined {@code [prefix/]caseNumber/fileName} strings. Blob names
- * are opaque to the service, so nothing is encoded on either side of this seam.
- * Implementations throw their SDK runtime exceptions ({@code BlobStorageException})
+ * <p>Names reach this seam already encoded by the adapter, as joined
+ * {@code [prefix/]encode(caseNumber)/encode(fileName)} strings. The service is not
+ * name-opaque (it normalizes traversal shapes; see the adapter javadoc), which is why the
+ * adapter encodes and nothing on this side encodes again. Implementations throw their SDK runtime exceptions ({@code BlobStorageException})
  * through; the adapter owns wrapping and classification.
  */
 interface AzureBlobContainer {

--- a/attachment-receiver/src/main/java/com/tsanet/receiver/storage/azure/SdkAzureBlobContainer.java
+++ b/attachment-receiver/src/main/java/com/tsanet/receiver/storage/azure/SdkAzureBlobContainer.java
@@ -1,0 +1,93 @@
+package com.tsanet.receiver.storage.azure;
+
+import com.azure.core.util.Context;
+import com.azure.storage.blob.BlobContainerClient;
+import com.azure.storage.blob.models.BlobErrorCode;
+import com.azure.storage.blob.models.BlobHttpHeaders;
+import com.azure.storage.blob.models.BlobStorageException;
+import com.azure.storage.blob.models.Block;
+import com.azure.storage.blob.models.BlockListType;
+import com.azure.storage.blob.options.BlockBlobCommitBlockListOptions;
+import com.azure.storage.blob.options.BlockBlobSimpleUploadOptions;
+import com.azure.storage.blob.specialized.BlockBlobClient;
+
+import java.io.ByteArrayInputStream;
+import java.util.ArrayList;
+import java.util.List;
+
+/**
+ * The logic-free SDK implementation of {@link AzureBlobContainer}: every method is one
+ * SDK call, so the live contract run is what proves it. The options-bearing overloads are
+ * used because they are the ones that carry {@link BlobHttpHeaders} (content type); they
+ * send no {@code If-None-Match} condition, which is what makes both {@link #putBlob} and
+ * {@link #commitBlockList} overwrite (the plain {@code upload}/{@code commitBlockList}
+ * overloads default to create-only).
+ */
+final class SdkAzureBlobContainer implements AzureBlobContainer {
+
+    private final BlobContainerClient container;
+
+    SdkAzureBlobContainer(BlobContainerClient container) {
+        this.container = container;
+    }
+
+    @Override
+    public void putBlob(String name, String contentType, byte[] bytes) {
+        BlockBlobSimpleUploadOptions options =
+                new BlockBlobSimpleUploadOptions(new ByteArrayInputStream(bytes), bytes.length);
+        if (contentType != null) {
+            options.setHeaders(new BlobHttpHeaders().setContentType(contentType));
+        }
+        blockBlob(name).uploadWithResponse(options, null, Context.NONE);
+    }
+
+    @Override
+    public void stageBlock(String name, String base64BlockId, byte[] buffer, int length) {
+        // Synchronous, and the stream is markable so the SDK's retry policy can replay
+        // the block. The adapter reuses the buffer after this returns; keep it that way.
+        blockBlob(name).stageBlock(base64BlockId, new ByteArrayInputStream(buffer, 0, length), length);
+    }
+
+    @Override
+    public void commitBlockList(String name, List<String> base64BlockIds, String contentType) {
+        BlockBlobCommitBlockListOptions options = new BlockBlobCommitBlockListOptions(base64BlockIds);
+        if (contentType != null) {
+            options.setHeaders(new BlobHttpHeaders().setContentType(contentType));
+        }
+        blockBlob(name).commitBlockListWithResponse(options, null, Context.NONE);
+    }
+
+    @Override
+    public long sizeOrAbsent(String name) {
+        try {
+            return container.getBlobClient(name).getProperties().getBlobSize();
+        } catch (BlobStorageException e) {
+            // Get Blob Properties is a HEAD, so the code arrives in x-ms-error-code. Only a
+            // missing blob reads as absent; a missing container or a denied read throws.
+            if (BlobErrorCode.BLOB_NOT_FOUND.equals(e.getErrorCode())) {
+                return -1;
+            }
+            throw e;
+        }
+    }
+
+    @Override
+    public List<String> committedBlockIdsOrAbsent(String name) {
+        try {
+            List<String> ids = new ArrayList<>();
+            for (Block block : blockBlob(name).listBlocks(BlockListType.COMMITTED).getCommittedBlocks()) {
+                ids.add(block.getName());
+            }
+            return ids;
+        } catch (BlobStorageException e) {
+            if (BlobErrorCode.BLOB_NOT_FOUND.equals(e.getErrorCode())) {
+                return null;
+            }
+            throw e;
+        }
+    }
+
+    private BlockBlobClient blockBlob(String name) {
+        return container.getBlobClient(name).getBlockBlobClient();
+    }
+}

--- a/attachment-receiver/src/main/java/com/tsanet/receiver/verify/RegisteringStorageFactory.java
+++ b/attachment-receiver/src/main/java/com/tsanet/receiver/verify/RegisteringStorageFactory.java
@@ -52,13 +52,18 @@ import java.util.Map;
  *       <td>either {@code sasUrl} alone, or {@code connectionString}+{@code shareName}</td>
  *       <td>{@code directoryPrefix}</td></tr>
  *   <tr><td>{@code azure_blob}</td>
- *       <td>either {@code sasUrl} (a container SAS URL) alone, or
+ *       <td>either {@code sasUrl} (an https container SAS URL) alone, or
  *           {@code connectionString}+{@code containerName}</td>
  *       <td>{@code prefix}</td></tr>
  *   <tr><td>{@code gcs}</td><td>{@code bucket}</td>
  *       <td>{@code prefix}, {@code projectId}; {@code credentialsJson} (a service-account key),
  *           else Application Default Credentials</td></tr>
  * </table>
+ *
+ * <p>{@code azure_blob} needs read and write on the container: a SAS with {@code rw} (or
+ * {@code rcw}), or Storage Blob Data Contributor. The go-live probe validates write only
+ * (it stages one uncommitted block), so a write-only SAS passes go-live and fails on the
+ * first {@code exists}; see {@link AzureBlobAttachmentStorage}.
  */
 public final class RegisteringStorageFactory implements StorageFactory {
 
@@ -134,6 +139,11 @@ public final class RegisteringStorageFactory implements StorageFactory {
         if (!blank(sasUrl)) {
             String malformed = "azure_blob sasUrl is not a well-formed container SAS URL; it must be "
                     + "an https URL that includes the container name";
+            // The SAS token is the credential and rides in the query string; the builder
+            // accepts http:// and would send it in cleartext on every request.
+            if (!sasUrl.regionMatches(true, 0, "https://", 0, 8)) {
+                throw new AttachmentStorageException(malformed);
+            }
             try {
                 container = builder.endpoint(sasUrl).buildClient();
             } catch (RuntimeException e) {

--- a/attachment-receiver/src/main/java/com/tsanet/receiver/verify/RegisteringStorageFactory.java
+++ b/attachment-receiver/src/main/java/com/tsanet/receiver/verify/RegisteringStorageFactory.java
@@ -3,10 +3,13 @@ package com.tsanet.receiver.verify;
 import com.tsanet.receiver.config.TenantConfig;
 import com.tsanet.receiver.storage.AttachmentStorage;
 import com.tsanet.receiver.storage.AttachmentStorageException;
+import com.tsanet.receiver.storage.azure.AzureBlobAttachmentStorage;
 import com.tsanet.receiver.storage.azure.AzureFilesAttachmentStorage;
 import com.tsanet.receiver.storage.gcs.GcsAttachmentStorage;
 import com.tsanet.receiver.storage.s3.S3AttachmentStorage;
 
+import com.azure.storage.blob.BlobContainerClient;
+import com.azure.storage.blob.BlobContainerClientBuilder;
 import com.azure.storage.file.share.ShareClient;
 import com.azure.storage.file.share.ShareClientBuilder;
 import com.google.auth.oauth2.GoogleCredentials;
@@ -48,6 +51,10 @@ import java.util.Map;
  *   <tr><td>{@code azure}</td>
  *       <td>either {@code sasUrl} alone, or {@code connectionString}+{@code shareName}</td>
  *       <td>{@code directoryPrefix}</td></tr>
+ *   <tr><td>{@code azure_blob}</td>
+ *       <td>either {@code sasUrl} (a container SAS URL) alone, or
+ *           {@code connectionString}+{@code containerName}</td>
+ *       <td>{@code prefix}</td></tr>
  *   <tr><td>{@code gcs}</td><td>{@code bucket}</td>
  *       <td>{@code prefix}, {@code projectId}; {@code credentialsJson} (a service-account key),
  *           else Application Default Credentials</td></tr>
@@ -62,9 +69,11 @@ public final class RegisteringStorageFactory implements StorageFactory {
         return switch (backend) {
             case "s3" -> s3(props);
             case "azure" -> azure(props);
+            case "azure_blob" -> azureBlob(props);
             case "gcs" -> gcs(props);
             default -> throw new AttachmentStorageException(
-                    "unknown storage backend '" + backend + "'; known backends are s3, azure, gcs");
+                    "unknown storage backend '" + backend
+                            + "'; known backends are s3, azure, azure_blob, gcs");
         };
     }
 
@@ -114,6 +123,40 @@ public final class RegisteringStorageFactory implements StorageFactory {
             }
         }
         return AzureFilesAttachmentStorage.forShare(share, props.get("directoryPrefix"));
+    }
+
+    private AttachmentStorage azureBlob(Map<String, String> props) throws AttachmentStorageException {
+        String sasUrl = props.get("sasUrl");
+        BlobContainerClientBuilder builder = new BlobContainerClientBuilder();
+        BlobContainerClient container;
+        // Same leak shape as the azure branch: the builder echoes a malformed value into its
+        // cause chain, so both branches throw value-free with NO cause.
+        if (!blank(sasUrl)) {
+            String malformed = "azure_blob sasUrl is not a well-formed container SAS URL; it must be "
+                    + "an https URL that includes the container name";
+            try {
+                container = builder.endpoint(sasUrl).buildClient();
+            } catch (RuntimeException e) {
+                throw new AttachmentStorageException(malformed);
+            }
+            // An account-level URL with no container path does not fail in the builder; it
+            // silently targets the root container. Reject it here, by the parsed name.
+            String containerName = container.getBlobContainerName();
+            if (blank(containerName) || "$root".equals(containerName)) {
+                throw new AttachmentStorageException(malformed);
+            }
+        } else {
+            String connectionString = require(props, "connectionString", "azure_blob");
+            String containerName = require(props, "containerName", "azure_blob");
+            try {
+                container = builder.connectionString(connectionString)
+                        .containerName(containerName).buildClient();
+            } catch (RuntimeException e) {
+                throw new AttachmentStorageException(
+                        "azure_blob connectionString is not a well-formed storage connection string");
+            }
+        }
+        return AzureBlobAttachmentStorage.forContainer(container, props.get("prefix"));
     }
 
     private AttachmentStorage gcs(Map<String, String> props) throws AttachmentStorageException {

--- a/attachment-receiver/src/test/java/com/tsanet/receiver/storage/azure/AzureBlobAttachmentStorageLiveTest.java
+++ b/attachment-receiver/src/test/java/com/tsanet/receiver/storage/azure/AzureBlobAttachmentStorageLiveTest.java
@@ -1,0 +1,185 @@
+package com.tsanet.receiver.storage.azure;
+
+import com.tsanet.receiver.storage.AttachmentStorage;
+import com.tsanet.receiver.storage.AttachmentStorageContractTest;
+import com.tsanet.receiver.storage.AttachmentStorageException;
+import com.tsanet.receiver.storage.IncomingAttachment;
+import com.azure.storage.blob.BlobContainerClient;
+import com.azure.storage.blob.BlobContainerClientBuilder;
+import com.azure.storage.blob.models.BlobItem;
+import com.azure.storage.blob.models.BlobListDetails;
+import com.azure.storage.blob.models.ListBlobsOptions;
+import com.azure.storage.blob.sas.BlobContainerSasPermission;
+import com.azure.storage.blob.sas.BlobServiceSasSignatureValues;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.condition.EnabledIfEnvironmentVariable;
+
+import java.io.ByteArrayInputStream;
+import java.time.OffsetDateTime;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.UUID;
+
+import static com.tsanet.receiver.storage.azure.AzureBlobAttachmentStorage.BLOCK_SIZE;
+import static org.junit.jupiter.api.Assertions.assertArrayEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+/**
+ * The real-container acceptance run: the shared contract test bound to a live Azure Blob
+ * container, plus the facts the offline double can only assume:
+ * <ul>
+ *   <li>a blob that received staged blocks and was never committed is invisible to
+ *       {@code exists} (it is enumerable only as an uncommitted blob);</li>
+ *   <li>the go-live probe passes on a SAS carrying only {@code cw} and leaves no committed
+ *       blob; a read-only SAS is classified as no permission; a tampered signature is
+ *       classified as wrong credential (the error-code-before-status ordering, live);</li>
+ *   <li>hostile file names round-trip under their literal encoded name: the first run of
+ *       this test, before encoding, showed the service normalizing {@code ..}, a trailing
+ *       dot, and a backslash, so "the listed name equals the encoded name" is the assertion
+ *       that proves no normalization can move a blob out of its prefix.</li>
+ * </ul>
+ *
+ * <p>Gated on {@code AZURE_BLOB_CONNECTION_STRING} + {@code AZURE_BLOB_CONTRACT_TEST_CONTAINER}.
+ * Each instance works under a random name prefix and deletes its committed blobs
+ * afterward; uncommitted probe blobs expire on their own, so a shared disposable container
+ * is safe.
+ */
+@EnabledIfEnvironmentVariable(named = "AZURE_BLOB_CONNECTION_STRING", matches = ".+")
+@EnabledIfEnvironmentVariable(named = "AZURE_BLOB_CONTRACT_TEST_CONTAINER", matches = ".+")
+class AzureBlobAttachmentStorageLiveTest extends AttachmentStorageContractTest {
+
+    private final String runPrefix = "contract-" + UUID.randomUUID();
+    private final BlobContainerClient container = new BlobContainerClientBuilder()
+            .connectionString(System.getenv("AZURE_BLOB_CONNECTION_STRING"))
+            .containerName(System.getenv("AZURE_BLOB_CONTRACT_TEST_CONTAINER"))
+            .buildClient();
+
+    @Override
+    protected AttachmentStorage newStorage() {
+        return AzureBlobAttachmentStorage.forContainer(container, runPrefix);
+    }
+
+    @AfterEach
+    void tearDownPrefix() {
+        for (String name : names(runPrefix, false)) {
+            container.getBlobClient(name).deleteIfExists();
+        }
+    }
+
+    @Test
+    void abortAfterStagedBlocksLeavesNothingVisible() throws Exception {
+        AttachmentStorage storage = newStorage();
+        IncomingAttachment attachment = new IncomingAttachment("01234567", "partial.bin", null, -1);
+        // Fail after one full block has really been staged with the service.
+        assertThrows(AttachmentStorageException.class,
+                () -> storage.store(attachment, new AzureBlobAttachmentStorageTest.DyingStream(BLOCK_SIZE + 1024)));
+        assertFalse(storage.exists("01234567", "partial.bin"),
+                "a blob with only uncommitted blocks must read as absent");
+        String name = runPrefix + "/01234567/partial.bin";
+        assertTrue(names(runPrefix + "/01234567/", true).contains(name),
+                "the block really reached the service: the blob is enumerable as uncommitted");
+        assertFalse(names(runPrefix + "/01234567/", false).contains(name),
+                "and it is not enumerable as a committed blob");
+    }
+
+    @Test
+    void stagedUploadCommitsEveryByteAgainstTheService() throws Exception {
+        // The contract payloads all fit one Put Blob; this is the only place Put Block List
+        // itself (id format, ordering, the commit) runs against the real service.
+        AttachmentStorage storage = newStorage();
+        byte[] content = new byte[BLOCK_SIZE + 4096];
+        for (int i = 0; i < content.length; i++) {
+            content[i] = (byte) i;
+        }
+        var stored = storage.store(new IncomingAttachment("01234567", "staged.bin", "application/octet-stream", -1),
+                new ByteArrayInputStream(content));
+        assertEquals(content.length, stored.bytesWritten());
+        assertTrue(storage.exists("01234567", "staged.bin"));
+        assertEquals(content.length, container.getBlobClient(stored.storageKey()).getProperties().getBlobSize());
+        assertArrayEquals(content, container.getBlobClient(stored.storageKey()).downloadContent().toBytes(),
+                "block order and the reused buffer must reproduce the stream exactly");
+    }
+
+    @Test
+    void sameNameStoreOverwritesOnBothPaths() throws Exception {
+        // Proves the options overloads really send no If-None-Match: small over nothing,
+        // staged over small, small over staged. Size after each store is the witness.
+        AttachmentStorage storage = newStorage();
+        IncomingAttachment attachment = new IncomingAttachment("01234567", "dup.bin", null, -1);
+        int[] sizes = {100, BLOCK_SIZE + 8, 200};
+        for (int size : sizes) {
+            var stored = storage.store(attachment, new ByteArrayInputStream(new byte[size]));
+            assertEquals(size, container.getBlobClient(stored.storageKey()).getProperties().getBlobSize(),
+                    "the latest store must win at size " + size);
+        }
+    }
+
+    @Test
+    void cwOnlySasPassesTheProbeAndLeavesNoCommittedBlob() throws Exception {
+        AzureBlobAttachmentStorage.forContainer(sasClient("cw"), runPrefix).verifyAccess();
+        List<String> committed = names(runPrefix + "/" + AzureBlobAttachmentStorage.VERIFY_PREFIX, false);
+        assertTrue(committed.isEmpty(), "the probe must commit nothing: " + committed);
+        assertFalse(names(runPrefix + "/" + AzureBlobAttachmentStorage.VERIFY_PREFIX, true).isEmpty(),
+                "the probe block really was staged");
+    }
+
+    @Test
+    void readOnlySasIsClassifiedAsNoPermission() {
+        AttachmentStorage storage = AzureBlobAttachmentStorage.forContainer(sasClient("r"), runPrefix);
+        AttachmentStorageException e = assertThrows(AttachmentStorageException.class, storage::verifyAccess);
+        assertTrue(e.getMessage().contains("no permission"), e.getMessage());
+    }
+
+    @Test
+    void tamperedSignatureIsClassifiedAsWrongCredential() {
+        String sas = container.generateSas(new BlobServiceSasSignatureValues(
+                OffsetDateTime.now().plusMinutes(15), BlobContainerSasPermission.parse("rw")));
+        int sig = sas.indexOf("sig=") + 4;
+        char flipped = sas.charAt(sig) == 'A' ? 'B' : 'A';
+        String tampered = sas.substring(0, sig) + flipped + sas.substring(sig + 1);
+        BlobContainerClient client = new BlobContainerClientBuilder()
+                .endpoint(container.getBlobContainerUrl() + "?" + tampered).buildClient();
+        AttachmentStorage storage = AzureBlobAttachmentStorage.forContainer(client, runPrefix);
+        AttachmentStorageException e = assertThrows(AttachmentStorageException.class, storage::verifyAccess);
+        assertTrue(e.getMessage().contains("wrong credential"), e.getMessage());
+    }
+
+    @Test
+    void hostileFileNamesRoundTripUnderTheirLiteralEncodedName() throws Exception {
+        AttachmentStorage storage = newStorage();
+        String[] hostile = {
+                "../../etc/passwd", "a/b.txt", "trailing.", "trailing/", "back\\slash.txt",
+                "report#1.txt", "50%.log", "spaces and üñïçode.txt", "q?mark.txt", ".verify-fake",
+        };
+        for (String fileName : hostile) {
+            IncomingAttachment attachment = new IncomingAttachment("01234567", fileName, null, -1);
+            var stored = storage.store(attachment, new ByteArrayInputStream("hostile".getBytes()));
+            assertTrue(storage.exists("01234567", fileName), "not visible under the same name: " + fileName);
+            List<String> committed = names(runPrefix + "/01234567/", false);
+            assertTrue(committed.contains(stored.storageKey()),
+                    "the blob is not where the adapter says it is (normalized?): " + fileName + " -> " + committed);
+            System.out.println("[hostile-name] " + fileName + " -> " + stored.storageKey().substring(runPrefix.length() + 1));
+        }
+    }
+
+    private BlobContainerClient sasClient(String permissions) {
+        String sas = container.generateSas(new BlobServiceSasSignatureValues(
+                OffsetDateTime.now().plusMinutes(15), BlobContainerSasPermission.parse(permissions)));
+        return new BlobContainerClientBuilder()
+                .endpoint(container.getBlobContainerUrl() + "?" + sas).buildClient();
+    }
+
+    private List<String> names(String prefix, boolean includeUncommitted) {
+        ListBlobsOptions options = new ListBlobsOptions().setPrefix(prefix)
+                .setDetails(new BlobListDetails().setRetrieveUncommittedBlobs(includeUncommitted));
+        List<String> names = new ArrayList<>();
+        for (BlobItem item : container.listBlobs(options, null)) {
+            names.add(item.getName());
+        }
+        return names;
+    }
+}

--- a/attachment-receiver/src/test/java/com/tsanet/receiver/storage/azure/AzureBlobAttachmentStorageLiveTest.java
+++ b/attachment-receiver/src/test/java/com/tsanet/receiver/storage/azure/AzureBlobAttachmentStorageLiveTest.java
@@ -146,6 +146,23 @@ class AzureBlobAttachmentStorageLiveTest extends AttachmentStorageContractTest {
         AttachmentStorage storage = AzureBlobAttachmentStorage.forContainer(client, runPrefix);
         AttachmentStorageException e = assertThrows(AttachmentStorageException.class, storage::verifyAccess);
         assertTrue(e.getMessage().contains("wrong credential"), e.getMessage());
+        // The service's AuthenticationFailed detail must not echo the signature: wrap() and
+        // classify() carry the SDK message into the chain.
+        int end = tampered.indexOf('&', sig);
+        String sigValue = tampered.substring(sig, end < 0 ? tampered.length() : end);
+        String chain = fullChain(e);
+        assertFalse(chain.contains(sigValue), "signature echoed in the exception chain");
+        assertFalse(chain.contains(java.net.URLDecoder.decode(sigValue, java.nio.charset.StandardCharsets.UTF_8)),
+                "decoded signature echoed in the exception chain");
+    }
+
+    /** Every message in the cause chain, so a leak two causes deep is still caught. */
+    private static String fullChain(Throwable t) {
+        StringBuilder chain = new StringBuilder();
+        for (Throwable c = t; c != null; c = c.getCause()) {
+            chain.append(c.getClass().getName()).append(": ").append(c.getMessage()).append('\n');
+        }
+        return chain.toString();
     }
 
     @Test

--- a/attachment-receiver/src/test/java/com/tsanet/receiver/storage/azure/AzureBlobAttachmentStorageTest.java
+++ b/attachment-receiver/src/test/java/com/tsanet/receiver/storage/azure/AzureBlobAttachmentStorageTest.java
@@ -116,6 +116,32 @@ class AzureBlobAttachmentStorageTest extends AttachmentStorageContractTest {
     }
 
     @Test
+    void putBlobFailureSurfacesThroughTheContractAndLeavesNothingVisible() throws Exception {
+        InMemoryAzureBlobContainer blobs = new InMemoryAzureBlobContainer();
+        blobs.failPutBlobWith = () -> new IllegalStateException("put blob rejected (simulated)");
+        AzureBlobAttachmentStorage storage = new AzureBlobAttachmentStorage(blobs, "c", null);
+        AttachmentStorageException e = assertThrows(AttachmentStorageException.class,
+                () -> storage.store(attachment("small.bin"), new ByteArrayInputStream(bytes(16))));
+        assertTrue(e.getMessage().contains("put blob"), e.getMessage());
+        assertFalse(storage.exists("01234567", "small.bin"));
+    }
+
+    @Test
+    void ambiguousCommitProbeFailureRidesAsSuppressedOnTheCommitFailure() {
+        InMemoryAzureBlobContainer blobs = new InMemoryAzureBlobContainer();
+        blobs.failCommitWith = () -> new IllegalStateException("commit timed out (simulated)");
+        blobs.failCommittedBlockIdsWith = () -> new IllegalStateException("block list unreachable (simulated)");
+        AzureBlobAttachmentStorage storage = new AzureBlobAttachmentStorage(blobs, "c", null);
+        AttachmentStorageException e = assertThrows(AttachmentStorageException.class,
+                () -> storage.store(attachment("probe.bin"), new ByteArrayInputStream(bytes(BLOCK_SIZE + 8))));
+        // Fails closed on the commit failure; the probe's own failure is not lost.
+        assertTrue(e.getMessage().contains("commit"), e.getMessage());
+        assertEquals("commit timed out (simulated)", e.getCause().getMessage());
+        assertEquals(1, e.getCause().getSuppressed().length);
+        assertEquals("block list unreachable (simulated)", e.getCause().getSuppressed()[0].getMessage());
+    }
+
+    @Test
     void stageFailureAbandonsWithoutACommit() throws Exception {
         InMemoryAzureBlobContainer blobs = new InMemoryAzureBlobContainer();
         blobs.failStageBlockWith = () -> new IllegalStateException("stage rejected (simulated)");

--- a/attachment-receiver/src/test/java/com/tsanet/receiver/storage/azure/AzureBlobAttachmentStorageTest.java
+++ b/attachment-receiver/src/test/java/com/tsanet/receiver/storage/azure/AzureBlobAttachmentStorageTest.java
@@ -1,0 +1,349 @@
+package com.tsanet.receiver.storage.azure;
+
+import com.tsanet.receiver.storage.AttachmentStorage;
+import com.tsanet.receiver.storage.AttachmentStorageContractTest;
+import com.tsanet.receiver.storage.AttachmentStorageException;
+import com.tsanet.receiver.storage.IncomingAttachment;
+import com.azure.core.http.HttpHeaders;
+import com.azure.core.http.HttpMethod;
+import com.azure.core.http.HttpRequest;
+import com.azure.core.http.HttpResponse;
+import com.azure.storage.blob.models.BlobErrorCode;
+import com.azure.storage.blob.models.BlobStorageException;
+import org.junit.jupiter.api.Test;
+import reactor.core.publisher.Flux;
+import reactor.core.publisher.Mono;
+
+import java.io.ByteArrayInputStream;
+import java.io.IOException;
+import java.io.InputStream;
+import java.nio.ByteBuffer;
+import java.nio.charset.Charset;
+
+import static com.tsanet.receiver.storage.azure.AzureBlobAttachmentStorage.BLOCK_SIZE;
+import static org.junit.jupiter.api.Assertions.assertArrayEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+/**
+ * Runs the shared contract against the strict in-memory double, plus the Blob-specific
+ * edges the contract cannot reach: the single-shot/staged split, abandon-not-commit on
+ * failure, the ambiguous-commit policy, and the three verify classifications driven by
+ * real {@link BlobStorageException}s carrying the service's error-code header (the
+ * classification order matters, because Azure answers {@code AuthenticationFailed} with
+ * 403). The uncommitted-block invisibility the double encodes is an assumption here; the
+ * live test is what proves it against the service.
+ */
+class AzureBlobAttachmentStorageTest extends AttachmentStorageContractTest {
+
+    @Override
+    protected AttachmentStorage newStorage() {
+        return new AzureBlobAttachmentStorage(new InMemoryAzureBlobContainer(), "tenant-container", "tenants/acme");
+    }
+
+    private static IncomingAttachment attachment(String fileName) {
+        return new IncomingAttachment("01234567", fileName, "application/octet-stream", -1);
+    }
+
+    private static byte[] bytes(int n) {
+        byte[] b = new byte[n];
+        for (int i = 0; i < n; i++) {
+            b[i] = (byte) i;
+        }
+        return b;
+    }
+
+    @Test
+    void smallFileUsesSinglePutBlob() throws Exception {
+        InMemoryAzureBlobContainer blobs = new InMemoryAzureBlobContainer();
+        AzureBlobAttachmentStorage storage = new AzureBlobAttachmentStorage(blobs, "c", null);
+        byte[] content = bytes(1024);
+        storage.store(attachment("small.bin"), new ByteArrayInputStream(content));
+        assertEquals(0, blobs.stagedBlocks, "a file that fits one buffer never stages blocks");
+        assertEquals(0, blobs.commits);
+        assertArrayEquals(content, blobs.contentOf("01234567/small.bin"));
+    }
+
+    @Test
+    void emptyFileStoresAZeroByteBlob() throws Exception {
+        InMemoryAzureBlobContainer blobs = new InMemoryAzureBlobContainer();
+        AzureBlobAttachmentStorage storage = new AzureBlobAttachmentStorage(blobs, "c", null);
+        var stored = storage.store(attachment("empty.bin"), new ByteArrayInputStream(new byte[0]));
+        assertEquals(0, stored.bytesWritten());
+        assertTrue(storage.exists("01234567", "empty.bin"));
+    }
+
+    @Test
+    void fileLargerThanOneBlockIsStagedAndCommittedWithEveryByte() throws Exception {
+        InMemoryAzureBlobContainer blobs = new InMemoryAzureBlobContainer();
+        AzureBlobAttachmentStorage storage = new AzureBlobAttachmentStorage(blobs, "c", null);
+        byte[] content = bytes(BLOCK_SIZE + 4096);
+        var stored = storage.store(attachment("big.bin"), new ByteArrayInputStream(content));
+        assertEquals(content.length, stored.bytesWritten());
+        assertEquals(2, blobs.stagedBlocks);
+        assertEquals(1, blobs.commits);
+        assertArrayEquals(content, blobs.contentOf("01234567/big.bin"),
+                "block order and the reused buffer must reproduce the stream exactly");
+        assertFalse(blobs.hasUncommittedBlocks("01234567/big.bin"), "a commit consumes the staged blocks");
+    }
+
+    @Test
+    void eofExactlyOnBlockBoundaryCommitsOneBlock() throws Exception {
+        InMemoryAzureBlobContainer blobs = new InMemoryAzureBlobContainer();
+        AzureBlobAttachmentStorage storage = new AzureBlobAttachmentStorage(blobs, "c", null);
+        var stored = storage.store(attachment("exact.bin"), new ByteArrayInputStream(bytes(BLOCK_SIZE)));
+        assertEquals(BLOCK_SIZE, stored.bytesWritten());
+        assertEquals(1, blobs.stagedBlocks, "a zero-length trailing read must not stage an empty block");
+        assertEquals(BLOCK_SIZE, blobs.contentOf("01234567/exact.bin").length);
+    }
+
+    @Test
+    void streamFailureMidUploadAbandonsAndLeavesNothingVisible() throws Exception {
+        InMemoryAzureBlobContainer blobs = new InMemoryAzureBlobContainer();
+        AzureBlobAttachmentStorage storage = new AzureBlobAttachmentStorage(blobs, "c", null);
+        // Yield more than one block, then die: forces the staged path, then fails it.
+        assertThrows(AttachmentStorageException.class,
+                () -> storage.store(attachment("truncated.bin"), new DyingStream(BLOCK_SIZE + 1024)));
+        assertEquals(0, blobs.commits, "a mid-stream failure must abandon, never commit");
+        assertTrue(blobs.hasUncommittedBlocks("01234567/truncated.bin"),
+                "the first block really was staged; invisibility is the property under test");
+        assertNull(blobs.contentOf("01234567/truncated.bin"));
+        assertFalse(storage.exists("01234567", "truncated.bin"));
+    }
+
+    @Test
+    void stageFailureAbandonsWithoutACommit() throws Exception {
+        InMemoryAzureBlobContainer blobs = new InMemoryAzureBlobContainer();
+        blobs.failStageBlockWith = () -> new IllegalStateException("stage rejected (simulated)");
+        AzureBlobAttachmentStorage storage = new AzureBlobAttachmentStorage(blobs, "c", null);
+        assertThrows(AttachmentStorageException.class,
+                () -> storage.store(attachment("rejected.bin"), new ByteArrayInputStream(bytes(BLOCK_SIZE + 8))));
+        assertEquals(0, blobs.commits);
+        assertFalse(storage.exists("01234567", "rejected.bin"));
+    }
+
+    @Test
+    void ambiguousCommitThatActuallyCommittedIsReportedAsSuccess() throws Exception {
+        InMemoryAzureBlobContainer blobs = new InMemoryAzureBlobContainer();
+        blobs.failCommitWith = () -> new IllegalStateException("commit timed out after commit (simulated)");
+        blobs.commitCommitsDespiteFailure = true;
+        AzureBlobAttachmentStorage storage = new AzureBlobAttachmentStorage(blobs, "c", null);
+        byte[] content = bytes(BLOCK_SIZE + 8);
+        var stored = storage.store(attachment("ambiguous.bin"), new ByteArrayInputStream(content));
+        assertEquals(content.length, stored.bytesWritten(),
+                "a commit that landed server-side is the success it was");
+    }
+
+    @Test
+    void ambiguousCommitOverAPreExistingSameSizeBlobThrows() throws Exception {
+        // The wrong-but-well-formed case for a size-based resolution: an older blob of the
+        // same name and the same length is already there, and this commit did NOT land.
+        InMemoryAzureBlobContainer blobs = new InMemoryAzureBlobContainer();
+        AzureBlobAttachmentStorage storage = new AzureBlobAttachmentStorage(blobs, "c", null);
+        byte[] content = bytes(BLOCK_SIZE + 8);
+        storage.store(attachment("same-size.bin"), new ByteArrayInputStream(content));
+        blobs.failCommitWith = () -> new IllegalStateException("commit rejected, nothing committed (simulated)");
+        assertThrows(AttachmentStorageException.class,
+                () -> storage.store(attachment("same-size.bin"), new ByteArrayInputStream(content)),
+                "an older same-size blob must not be mistaken for this call's commit");
+        assertArrayEquals(content, blobs.contentOf("01234567/same-size.bin"), "the older blob is untouched");
+    }
+
+    @Test
+    void ambiguousCommitWithNothingCommittedThrows() throws Exception {
+        InMemoryAzureBlobContainer blobs = new InMemoryAzureBlobContainer();
+        blobs.failCommitWith = () -> new IllegalStateException("commit rejected, nothing committed (simulated)");
+        AzureBlobAttachmentStorage storage = new AzureBlobAttachmentStorage(blobs, "c", null);
+        assertThrows(AttachmentStorageException.class,
+                () -> storage.store(attachment("lost.bin"), new ByteArrayInputStream(bytes(BLOCK_SIZE + 8))));
+        assertFalse(storage.exists("01234567", "lost.bin"));
+    }
+
+    @Test
+    void sameNameStoreOverwrites() throws Exception {
+        InMemoryAzureBlobContainer blobs = new InMemoryAzureBlobContainer();
+        AzureBlobAttachmentStorage storage = new AzureBlobAttachmentStorage(blobs, "c", null);
+        storage.store(attachment("dup.bin"), new ByteArrayInputStream(bytes(100)));
+        storage.store(attachment("dup.bin"), new ByteArrayInputStream(bytes(200)));
+        assertEquals(200, blobs.contentOf("01234567/dup.bin").length);
+    }
+
+    @Test
+    void traversalFileNamesAreEncodedBeforeTheyReachTheContainer() throws Exception {
+        InMemoryAzureBlobContainer blobs = new InMemoryAzureBlobContainer();
+        AzureBlobAttachmentStorage storage = new AzureBlobAttachmentStorage(blobs, "c", "tenants/acme");
+        String hostile = "../../etc/passwd";
+        // The double throws on any raw traversal component, so passing proves the encoder
+        // neutralized the name, not that the fake was lenient.
+        storage.store(attachment(hostile), new ByteArrayInputStream(bytes(16)));
+        assertTrue(storage.exists("01234567", hostile));
+        assertNotNull(blobs.contentOf("tenants/acme/01234567/%2E.%2F..%2Fetc%2Fpasswd"),
+                "leading dot and slashes encoded, interior dots pass through: one traversal-inert segment");
+        storage.store(attachment("back\\slash."), new ByteArrayInputStream(bytes(16)));
+        assertNotNull(blobs.contentOf("tenants/acme/01234567/back%5Cslash%2E"));
+    }
+
+    @Test
+    void leadingDotFileNamesCannotImpersonateTheProbeNamespace() throws Exception {
+        InMemoryAzureBlobContainer blobs = new InMemoryAzureBlobContainer();
+        AzureBlobAttachmentStorage storage = new AzureBlobAttachmentStorage(blobs, "c", null);
+        storage.store(attachment(AzureBlobAttachmentStorage.VERIFY_PREFIX + "fake"), new ByteArrayInputStream(bytes(8)));
+        assertNotNull(blobs.contentOf("01234567/%2Everify-fake"));
+        assertNull(blobs.contentOf("01234567/" + AzureBlobAttachmentStorage.VERIFY_PREFIX + "fake"));
+    }
+
+    @Test
+    void oversizedNamesSurfaceThroughTheCheckedExceptionNotARawEscape() {
+        InMemoryAzureBlobContainer blobs = new InMemoryAzureBlobContainer();
+        AzureBlobAttachmentStorage storage = new AzureBlobAttachmentStorage(blobs, "c", null);
+        String tooLong = "x".repeat(300);
+        assertThrows(AttachmentStorageException.class,
+                () -> storage.store(attachment(tooLong), new ByteArrayInputStream(bytes(8))));
+        assertThrows(AttachmentStorageException.class, () -> storage.exists("01234567", tooLong));
+    }
+
+    @Test
+    void verifyAccessStagesOneUncommittedBlockAndCommitsNothing() throws Exception {
+        InMemoryAzureBlobContainer blobs = new InMemoryAzureBlobContainer();
+        AzureBlobAttachmentStorage storage = new AzureBlobAttachmentStorage(blobs, "c", "tenants/acme");
+        storage.verifyAccess();
+        assertEquals(0, blobs.committedCount(), "the probe must leave no committed blob");
+        assertEquals(1, blobs.stagedBlocks);
+        assertEquals(1, blobs.uncommittedNames().size());
+        assertTrue(blobs.uncommittedNames().get(0).startsWith("tenants/acme/" + AzureBlobAttachmentStorage.VERIFY_PREFIX),
+                blobs.uncommittedNames().get(0));
+    }
+
+    @Test
+    void verifyAccessClassifiesWrongCredentialByErrorCodeDespiteThe403() {
+        InMemoryAzureBlobContainer blobs = new InMemoryAzureBlobContainer();
+        blobs.failStageBlockWith = () -> blobError(403, BlobErrorCode.AUTHENTICATION_FAILED);
+        AzureBlobAttachmentStorage storage = new AzureBlobAttachmentStorage(blobs, "locked", null);
+        AttachmentStorageException e = assertThrows(AttachmentStorageException.class, storage::verifyAccess);
+        assertTrue(e.getMessage().contains("wrong credential"), e.getMessage());
+    }
+
+    @Test
+    void verifyAccessClassifiesNoPermission() {
+        InMemoryAzureBlobContainer blobs = new InMemoryAzureBlobContainer();
+        blobs.failStageBlockWith = () -> blobError(403, BlobErrorCode.AUTHORIZATION_PERMISSION_MISMATCH);
+        AzureBlobAttachmentStorage storage = new AzureBlobAttachmentStorage(blobs, "locked", null);
+        AttachmentStorageException e = assertThrows(AttachmentStorageException.class, storage::verifyAccess);
+        assertTrue(e.getMessage().contains("no permission"), e.getMessage());
+        assertTrue(e.getMessage().contains("locked"), e.getMessage());
+
+        // A bare 403 with no recognized code is still no-permission, never wrong-credential.
+        blobs.failStageBlockWith = () -> blobError(403, null);
+        AttachmentStorageException bare = assertThrows(AttachmentStorageException.class, storage::verifyAccess);
+        assertTrue(bare.getMessage().contains("no permission"), bare.getMessage());
+    }
+
+    @Test
+    void verifyAccessClassifiesWrongTarget() {
+        InMemoryAzureBlobContainer blobs = new InMemoryAzureBlobContainer();
+        blobs.failStageBlockWith = () -> blobError(404, BlobErrorCode.CONTAINER_NOT_FOUND);
+        AzureBlobAttachmentStorage storage = new AzureBlobAttachmentStorage(blobs, "ghost", null);
+        AttachmentStorageException e = assertThrows(AttachmentStorageException.class, storage::verifyAccess);
+        assertTrue(e.getMessage().contains("wrong target"), e.getMessage());
+        assertTrue(e.getMessage().contains("ghost"), e.getMessage());
+    }
+
+    @Test
+    void verifyAccessConnectivityFailureIsNamedAsSuch() {
+        InMemoryAzureBlobContainer blobs = new InMemoryAzureBlobContainer();
+        blobs.failStageBlockWith = () -> new IllegalStateException("connection refused (simulated)");
+        AzureBlobAttachmentStorage storage = new AzureBlobAttachmentStorage(blobs, "c", null);
+        AttachmentStorageException e = assertThrows(AttachmentStorageException.class, storage::verifyAccess);
+        assertTrue(e.getMessage().contains("connectivity"), e.getMessage());
+    }
+
+    @Test
+    void existsThrowsWhenTheBackendCannotAnswer() {
+        InMemoryAzureBlobContainer blobs = new InMemoryAzureBlobContainer();
+        blobs.failSizeOrAbsentWith = () -> blobError(500, null);
+        AzureBlobAttachmentStorage storage = new AzureBlobAttachmentStorage(blobs, "c", null);
+        // The SPI forbids answering false on an indeterminate check.
+        assertThrows(AttachmentStorageException.class, () -> storage.exists("01234567", "x.bin"));
+    }
+
+    @Test
+    void blockIdsAreFixedLengthBase64UnderTheServiceCap() {
+        String first = AzureBlobAttachmentStorage.blockId("0f0e0d0c-0b0a-0908-0706-050403020100", 0);
+        String last = AzureBlobAttachmentStorage.blockId("0f0e0d0c-0b0a-0908-0706-050403020100", 49999);
+        assertEquals(first.length(), last.length());
+        assertEquals(42, java.util.Base64.getDecoder().decode(last).length, "42 bytes decoded, cap is 64");
+    }
+
+    /**
+     * A real {@link BlobStorageException} whose error code travels the way the SDK reads
+     * it: from the {@code x-ms-error-code} response header. A null code models a response
+     * with no service error code at all.
+     */
+    static BlobStorageException blobError(int status, BlobErrorCode code) {
+        HttpHeaders headers = new HttpHeaders();
+        if (code != null) {
+            headers.set("x-ms-error-code", code.toString());
+        }
+        HttpRequest request = new HttpRequest(HttpMethod.PUT, "https://example.invalid/container/blob");
+        HttpResponse response = new HttpResponse(request) {
+            @Override
+            public int getStatusCode() {
+                return status;
+            }
+
+            @Override
+            public String getHeaderValue(String name) {
+                return headers.getValue(com.azure.core.http.HttpHeaderName.fromString(name));
+            }
+
+            @Override
+            public HttpHeaders getHeaders() {
+                return headers;
+            }
+
+            @Override
+            public Flux<ByteBuffer> getBody() {
+                return Flux.empty();
+            }
+
+            @Override
+            public Mono<byte[]> getBodyAsByteArray() {
+                return Mono.just(new byte[0]);
+            }
+
+            @Override
+            public Mono<String> getBodyAsString() {
+                return Mono.just("");
+            }
+
+            @Override
+            public Mono<String> getBodyAsString(Charset charset) {
+                return Mono.just("");
+            }
+        };
+        return new BlobStorageException("simulated HTTP " + status, response, null);
+    }
+
+    /** Yields {@code deathAt} bytes, then fails: the wrong-but-well-formed input for a store path. */
+    static final class DyingStream extends InputStream {
+        private final long deathAt;
+        private long served;
+
+        DyingStream(long deathAt) {
+            this.deathAt = deathAt;
+        }
+
+        @Override
+        public int read() throws IOException {
+            if (served < deathAt) {
+                served++;
+                return 'x';
+            }
+            throw new IOException("stream died mid-read (simulated)");
+        }
+    }
+}

--- a/attachment-receiver/src/test/java/com/tsanet/receiver/storage/azure/InMemoryAzureBlobContainer.java
+++ b/attachment-receiver/src/test/java/com/tsanet/receiver/storage/azure/InMemoryAzureBlobContainer.java
@@ -1,0 +1,164 @@
+package com.tsanet.receiver.storage.azure;
+
+import java.io.ByteArrayOutputStream;
+import java.util.Arrays;
+import java.util.Base64;
+import java.util.HashMap;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.function.Supplier;
+
+/**
+ * A strict {@link AzureBlobContainer} double. It enforces the block-blob semantics the
+ * adapter's no-partial-visibility claim rests on — a permissive fake here would pass a
+ * broken adapter:
+ * <ul>
+ *   <li>staged blocks are invisible: {@link #sizeOrAbsent} answers {@code -1} for a name
+ *       that only ever received uncommitted blocks;</li>
+ *   <li>block ids must be valid base64, at most 64 bytes decoded, and the same length as
+ *       every other uncommitted id of the same blob (the service's 400 otherwise);</li>
+ *   <li>a commit naming a block that was never staged is rejected
+ *       ({@code InvalidBlockList}); a commit consumes the blob's uncommitted blocks;</li>
+ *   <li>{@code Put Blob} discards any uncommitted blocks of the same name, as the service
+ *       does;</li>
+ *   <li>a name component that is empty, {@code .}, {@code ..}, or contains a backslash
+ *       throws: the live run proved the service normalizes those, so a raw one reaching
+ *       the seam means the encoder did not neutralize it.</li>
+ * </ul>
+ * Failure-injection suppliers let a test make one operation throw a chosen exception;
+ * {@link #commitCommitsDespiteFailure} models the ambiguous commit (committed
+ * server-side, failed client-side).
+ */
+final class InMemoryAzureBlobContainer implements AzureBlobContainer {
+
+    private final Map<String, byte[]> committed = new HashMap<>();
+    private final Map<String, List<String>> committedBlockIds = new HashMap<>();
+    private final Map<String, Map<String, byte[]>> uncommitted = new HashMap<>();
+
+    Supplier<RuntimeException> failPutBlobWith;
+    Supplier<RuntimeException> failStageBlockWith;
+    Supplier<RuntimeException> failCommitWith;
+    Supplier<RuntimeException> failSizeOrAbsentWith;
+    Supplier<RuntimeException> failCommittedBlockIdsWith;
+    boolean commitCommitsDespiteFailure;
+
+    /** Observed for assertions. */
+    int stagedBlocks;
+    int commits;
+
+    @Override
+    public void putBlob(String name, String contentType, byte[] bytes) {
+        validate(name);
+        if (failPutBlobWith != null) {
+            throw failPutBlobWith.get();
+        }
+        committed.put(name, bytes.clone());
+        committedBlockIds.put(name, List.of());
+        uncommitted.remove(name);
+    }
+
+    @Override
+    public void stageBlock(String name, String base64BlockId, byte[] buffer, int length) {
+        validate(name);
+        if (failStageBlockWith != null) {
+            throw failStageBlockWith.get();
+        }
+        byte[] decoded;
+        try {
+            decoded = Base64.getDecoder().decode(base64BlockId);
+        } catch (IllegalArgumentException e) {
+            throw new IllegalStateException("InvalidBlockId: not base64: " + base64BlockId, e);
+        }
+        if (decoded.length > 64) {
+            throw new IllegalStateException("InvalidBlockId: " + decoded.length + " bytes, cap is 64");
+        }
+        Map<String, byte[]> blocks = uncommitted.computeIfAbsent(name, k -> new LinkedHashMap<>());
+        if (!blocks.isEmpty()) {
+            int existing = blocks.keySet().iterator().next().length();
+            if (base64BlockId.length() != existing) {
+                throw new IllegalStateException(
+                        "InvalidBlockId: ids must be the same length within a blob");
+            }
+        }
+        blocks.put(base64BlockId, Arrays.copyOf(buffer, length));
+        stagedBlocks++;
+    }
+
+    @Override
+    public void commitBlockList(String name, List<String> base64BlockIds, String contentType) {
+        if (failCommitWith != null) {
+            if (commitCommitsDespiteFailure) {
+                commit(name, base64BlockIds);
+            }
+            throw failCommitWith.get();
+        }
+        commit(name, base64BlockIds);
+    }
+
+    private void commit(String name, List<String> base64BlockIds) {
+        Map<String, byte[]> blocks = uncommitted.getOrDefault(name, Map.of());
+        ByteArrayOutputStream out = new ByteArrayOutputStream();
+        for (String id : base64BlockIds) {
+            byte[] block = blocks.get(id);
+            if (block == null) {
+                throw new IllegalStateException("InvalidBlockList: block was never staged: " + id);
+            }
+            out.writeBytes(block);
+        }
+        // Visible only now.
+        committed.put(name, out.toByteArray());
+        committedBlockIds.put(name, List.copyOf(base64BlockIds));
+        uncommitted.remove(name);
+        commits++;
+    }
+
+    @Override
+    public List<String> committedBlockIdsOrAbsent(String name) {
+        validate(name);
+        if (failCommittedBlockIdsWith != null) {
+            throw failCommittedBlockIdsWith.get();
+        }
+        return committedBlockIds.get(name);
+    }
+
+    @Override
+    public long sizeOrAbsent(String name) {
+        validate(name);
+        if (failSizeOrAbsentWith != null) {
+            throw failSizeOrAbsentWith.get();
+        }
+        byte[] bytes = committed.get(name);
+        return bytes == null ? -1 : bytes.length;
+    }
+
+    /** For assertions: the committed bytes, or {@code null} if no committed blob exists. */
+    byte[] contentOf(String name) {
+        byte[] bytes = committed.get(name);
+        return bytes == null ? null : bytes.clone();
+    }
+
+    /** For assertions: whether staged-but-uncommitted blocks exist for the name. */
+    boolean hasUncommittedBlocks(String name) {
+        return uncommitted.containsKey(name);
+    }
+
+    /** For assertions: every name that currently has uncommitted blocks. */
+    List<String> uncommittedNames() {
+        return List.copyOf(uncommitted.keySet());
+    }
+
+    int committedCount() {
+        return committed.size();
+    }
+
+    private static void validate(String name) {
+        for (String component : name.split("/", -1)) {
+            if (component.isEmpty() || ".".equals(component) || "..".equals(component)
+                    || component.contains("\\")) {
+                throw new IllegalStateException(
+                        "raw traversal shape reached the container: '" + component + "' in " + name);
+            }
+        }
+    }
+}

--- a/attachment-receiver/src/test/java/com/tsanet/receiver/verify/RegisteringStorageFactoryTest.java
+++ b/attachment-receiver/src/test/java/com/tsanet/receiver/verify/RegisteringStorageFactoryTest.java
@@ -162,6 +162,26 @@ class RegisteringStorageFactoryTest {
     }
 
     @Test
+    void azureBlobWithHttpsContainerSasUrlBuildsBlobAdapter() throws Exception {
+        // A well-formed container SAS URL with a fake signature; the client builds offline.
+        AttachmentStorage storage = factory.create(config("azure_blob", Map.of(
+                "sasUrl", "https://acct.blob.core.windows.net/attachments?sv=2024-01-01&sp=rw&sig=Zm9v",
+                "prefix", "tenants/acme")));
+        assertInstanceOf(AzureBlobAttachmentStorage.class, storage);
+    }
+
+    @Test
+    void azureBlobHttpSasUrlIsRejectedWithoutEchoingTheToken() {
+        // The builder accepts http:// and would send the SAS token in cleartext; the
+        // factory's message promises https, so the factory must be what enforces it.
+        AttachmentStorageException e = assertThrows(AttachmentStorageException.class,
+                () -> factory.create(config("azure_blob", Map.of(
+                        "sasUrl", "http://acct.blob.core.windows.net/attachments?sv=2024-01-01&sig=MARKER"))));
+        assertFalse(fullChain(e).contains("MARKER"), fullChain(e));
+        assertTrue(e.getMessage().contains("https"), e.getMessage());
+    }
+
+    @Test
     void azureBlobWithoutTargetIsAConfigError() {
         AttachmentStorageException e = assertThrows(AttachmentStorageException.class,
                 () -> factory.create(config("azure_blob", Map.of("prefix", "x"))));

--- a/attachment-receiver/src/test/java/com/tsanet/receiver/verify/RegisteringStorageFactoryTest.java
+++ b/attachment-receiver/src/test/java/com/tsanet/receiver/verify/RegisteringStorageFactoryTest.java
@@ -3,6 +3,7 @@ package com.tsanet.receiver.verify;
 import com.tsanet.receiver.config.TenantConfig;
 import com.tsanet.receiver.storage.AttachmentStorage;
 import com.tsanet.receiver.storage.AttachmentStorageException;
+import com.tsanet.receiver.storage.azure.AzureBlobAttachmentStorage;
 import com.tsanet.receiver.storage.azure.AzureFilesAttachmentStorage;
 import com.tsanet.receiver.storage.gcs.GcsAttachmentStorage;
 import com.tsanet.receiver.storage.s3.S3AttachmentStorage;
@@ -138,6 +139,83 @@ class RegisteringStorageFactoryTest {
             chain.append(c.getClass().getName()).append(": ").append(c.getMessage()).append('\n');
         }
         return chain.toString();
+    }
+
+    @Test
+    void unknownBackendMessageListsEveryRegisteredBackend() {
+        AttachmentStorageException e = assertThrows(AttachmentStorageException.class,
+                () -> factory.create(config("wasabi", Map.of())));
+        for (String backend : new String[] {"s3", "azure", "azure_blob", "gcs"}) {
+            assertTrue(e.getMessage().contains(backend), backend + " missing from: " + e.getMessage());
+        }
+    }
+
+    @Test
+    void azureBlobWithConnectionStringAndContainerBuildsBlobAdapter() throws Exception {
+        String connectionString = "DefaultEndpointsProtocol=https;AccountName=acct;"
+                + "AccountKey=Zm9vYmFyYmF6;EndpointSuffix=core.windows.net";
+        AttachmentStorage storage = factory.create(config("azure_blob", Map.of(
+                "connectionString", connectionString,
+                "containerName", "attachments",
+                "prefix", "tenants/acme")));
+        assertInstanceOf(AzureBlobAttachmentStorage.class, storage);
+    }
+
+    @Test
+    void azureBlobWithoutTargetIsAConfigError() {
+        AttachmentStorageException e = assertThrows(AttachmentStorageException.class,
+                () -> factory.create(config("azure_blob", Map.of("prefix", "x"))));
+        assertTrue(e.getMessage().contains("connectionString"), e.getMessage());
+    }
+
+    @Test
+    void azureBlobWithConnectionStringButNoContainerIsAConfigError() {
+        AttachmentStorageException e = assertThrows(AttachmentStorageException.class,
+                () -> factory.create(config("azure_blob", Map.of(
+                        "connectionString", "DefaultEndpointsProtocol=https;AccountName=acct;"
+                                + "AccountKey=Zm9vYmFyYmF6;EndpointSuffix=core.windows.net"))));
+        assertTrue(e.getMessage().contains("containerName"), e.getMessage());
+    }
+
+    // The azure_blob branch gets the same wrong-but-well-formed probes as the azure branch:
+    // every value carries a MARKER standing in for a secret, and the property is that the
+    // marker reaches no exception anywhere in the chain.
+
+    @Test
+    void azureBlobMalformedSasUrlNeverEchoesItsValue() {
+        AttachmentStorageException e = assertThrows(AttachmentStorageException.class,
+                () -> factory.create(config("azure_blob", Map.of("sasUrl", "not a url at all sig=MARKER"))));
+        assertFalse(fullChain(e).contains("MARKER"), fullChain(e));
+        assertTrue(e.getMessage().contains("sasUrl"), e.getMessage());
+    }
+
+    @Test
+    void azureBlobConnectionStringPastedIntoSasUrlNeverEchoesTheAccountKey() {
+        String pasted = "DefaultEndpointsProtocol=https;AccountName=acct;"
+                + "AccountKey=MARKER;EndpointSuffix=core.windows.net";
+        AttachmentStorageException e = assertThrows(AttachmentStorageException.class,
+                () -> factory.create(config("azure_blob", Map.of("sasUrl", pasted))));
+        assertFalse(fullChain(e).contains("MARKER"), fullChain(e));
+    }
+
+    @Test
+    void azureBlobSasUrlWithoutContainerNameIsAConfigError() {
+        // An account-level SAS URL: well-formed, but there is no container to write into.
+        AttachmentStorageException e = assertThrows(AttachmentStorageException.class,
+                () -> factory.create(config("azure_blob", Map.of(
+                        "sasUrl", "https://acct.blob.core.windows.net/?sv=2024-01-01&sig=MARKER"))));
+        assertFalse(fullChain(e).contains("MARKER"), fullChain(e));
+        assertTrue(e.getMessage().contains("container name"), e.getMessage());
+    }
+
+    @Test
+    void azureBlobMalformedConnectionStringNeverEchoesItsValue() {
+        AttachmentStorageException e = assertThrows(AttachmentStorageException.class,
+                () -> factory.create(config("azure_blob", Map.of(
+                        "connectionString", "this is not a connection string AccountKey=MARKER",
+                        "containerName", "attachments"))));
+        assertFalse(fullChain(e).contains("MARKER"), fullChain(e));
+        assertTrue(e.getMessage().contains("connectionString"), e.getMessage());
     }
 
     @Test


### PR DESCRIPTION
Closes `tsanetgit/Connect_SDK#71` (epic `tsanetgit/Connect_SDK#46`). Serves `tsanetgit/Connect-API-Code#146`.

**Account-hygiene rule, binding for this public repo:** no storage account, container, connection string, or subscription identifier appears in code, commits, or this PR. Live results are counts and outcomes only.

## What this adds

`AzureBlobAttachmentStorage`, the container-scoped sibling of the Azure Files adapter, registered in `RegisteringStorageFactory` as backend id `azure_blob` (container SAS URL, or connection string plus `containerName`; optional `prefix`). `azure` keeps meaning Azure Files. Structurally the GCS twin (`tsanetgit/Connect_SDK#68`): a package-private `AzureBlobContainer` seam over the final SDK clients, a logic-free `SdkAzureBlobContainer`, a strict in-memory double for the offline contract run.

- **Small files** are one `Put Blob`; **larger files** are staged blocks (8 MiB) and one `Put Block List`, overwrite on. A blob that only received staged blocks is invisible to `Get Blob Properties` and the service reclaims it after seven days, so a failed store abandons with no commit and no cleanup round-trip. Proven live: after a stream dies past the first block, `exists` is false while the blob is enumerable only with `include=uncommittedblobs`.
- **Ambiguous commit resolves by identity, not size.** Block ids embed a UUID minted per store call, so a `Put Block List` that failed client-side is confirmed only if the committed block list equals this call's ids. The S3/GCS size heuristic (`tsanetgit/Connect_SDK#69`) is deterministically fooled by a same-size overwrite; the offline test `ambiguousCommitOverAPreExistingSameSizeBlobThrows` is that exact case, and it throws here. #69 does not apply to this adapter.
- **`verifyAccess` stages one uncommitted block** on a `.verify-<uuid>` name: write permission only, nothing committed, nothing to delete, as the issue specifies. Stated consequence, in the javadoc: **the probe validates `w` only, while `exists` and the ambiguous-commit probe need `r`.** A `cw`-only SAS passes go-live and fails `exists` at runtime. Required rights are `rw` (or `rcw`) on the container, or Storage Blob Data Contributor.
- **Classification reads the error code before the HTTP status** because Azure answers `AuthenticationFailed` with 403. Proven live: a tampered signature classifies as wrong credential, a read-only SAS as no permission.
- **Factory** rejects a malformed SAS URL or connection string with a value-free message and **no cause** (the #68 rule, MARKER-probed across the full cause chain on every branch). It also rejects an account-level SAS URL by its parsed container name: verified with the SDK that `BlobContainerClientBuilder.endpoint()` on a URL with no container path builds a client for `$root` without throwing.

## Correction to the plan on the issue: names are encoded, not opaque

The plan said blob names stay opaque like S3/GCS. The first live run said otherwise. With opaque names, the service normalized the request path: `../../etc/passwd` was listed under a different name outside the case prefix, a trailing dot was stripped, and a backslash became a separator. Store and `exists` still agreed, so the SPI held, but a remote-controlled name escaping the tenant prefix breaks multi-tenant isolation in the hosted mode. Both name components now go through the existing `AzureFileNames` encoder (same package, reused unchanged): `/`, `\`, `%`, leading and trailing dots are percent-encoded, so nothing can traverse and nothing can start with a dot (which keeps the `.verify-` probe namespace collision-free). This is a representation change rather than a guard: there is no name that needs rejecting. The double now throws on any raw traversal component reaching the seam, so the offline traversal test proves the encoder neutralized the name rather than the fake being lenient.

Live hostile-name outcomes (second run, every name literal under its encoded form):

| pushed name | stored as |
|---|---|
| `../../etc/passwd` | `%2E.%2F..%2Fetc%2Fpasswd` |
| `a/b.txt` | `a%2Fb.txt` |
| `trailing.` | `trailing%2E` |
| `trailing/` | `trailing%2F` |
| `back\slash.txt` | `back%5Cslash.txt` |
| `report#1.txt` | `report%231.txt` |
| `50%.log` | `50%25.log` |
| `spaces and üñïçode.txt` | `spaces%20and%20%C3%BC%C3%B1%C3%AF%C3%A7ode.txt` |
| `q?mark.txt` | `q%3Fmark.txt` |
| `.verify-fake` | `%2Everify-fake` |

## Verification

- Offline, `mvn -pl attachment-receiver -am test`: **166 run, 0 failures, 37 skipped** (baseline on `main` was 117 / 0 / 23; the 37 skipped are the env-gated S3, Azure Files, GCS, and Azure Blob live classes). New offline tests: 20 in `AzureBlobAttachmentStorageTest` (7 shared-contract via the strict double plus the single-shot/staged split, exact-boundary, empty file, abandon on stream death and on stage failure, both ambiguous-commit shapes plus the same-size trap, overwrite, traversal and probe-impersonation and oversized names, all three classification groups driven by real `BlobStorageException`s with the `x-ms-error-code` header, exists-throws-on-outage, block-id shape) and 8 in `RegisteringStorageFactoryTest`.
- Live, `AzureBlobAttachmentStorageLiveTest` against a disposable container in a private test account, gated on `AZURE_BLOB_CONNECTION_STRING` + `AZURE_BLOB_CONTRACT_TEST_CONTAINER`: **14 / 14** in about 37 s. The 7 shared-contract tests, abort after staged blocks, a real staged commit with byte-for-byte readback, overwrite on both paths (small over nothing, staged over small, small over staged, by size), the `cw`-only SAS probe leaving no committed blob, read-only SAS as no permission, tampered signature as wrong credential, and the ten hostile names above.
- SDK facts checked against the jar with `javap` before use: `stageBlock`, `commitBlockListWithResponse`, the options types that carry content type, `listBlocks(COMMITTED)`, and that `BlobStorageException.getErrorCode()` reads the `x-ms-error-code` header (so a HEAD carries it). Azure REST docs for Put Block, Put Block List, Get Blob Properties, and blob naming read today.

## Prose claims and the lines that make them true

| claim | line |
|---|---|
| Uncommitted blocks are invisible; abandon leaves nothing | `staged()` commits only after the loop; live `abortAfterStagedBlocksLeavesNothingVisible` |
| Ambiguous commit is confirmed by identity | `resolveAmbiguousCommit` compares `blockIds.equals(committedBlockIdsOrAbsent(name))` |
| Block ids are fixed-length under the 64-byte cap | `blockId()` is `%s-%05d` of a UUID, 42 bytes; test `blockIdsAreFixedLengthBase64UnderTheServiceCap` |
| Options overloads overwrite (no `If-None-Match`) | live `sameNameStoreOverwritesOnBothPaths` |
| Store and exists cannot disagree | both call `nameOrThrow` |
| Only `BlobNotFound` reads as absent | `SdkAzureBlobContainer.sizeOrAbsent` / `committedBlockIdsOrAbsent` catch that code and rethrow the rest |
| Account-level SAS URL builds a `$root` client | jshell probe against the SDK; factory test `azureBlobSasUrlWithoutContainerNameIsAConfigError` |
| Probe needs `w` only | live `cwOnlySasPassesTheProbeAndLeavesNoCommittedBlob` |

## Blast radius (`pre-pr-artifacts.py`, base `origin/main`)

No mechanical detector fired. The judgment lines:

- **Single-place decision.** `grep -rn 'forContainer(\|forShare(\|forBucket(\|new S3AttachmentStorage(' src/main`: every construction is inside `RegisteringStorageFactory`; the only other hits are the three factory-method declarations. Old form of the decision (`"s3"` / `"azure"` / `"gcs"` literals outside the factory): none in `src/main` beyond a javadoc example in `TenantConfig`.
- **Vocabulary gained a member.** The unknown-backend message now lists `azure_blob`, asserted by `unknownBackendMessageListsEveryRegisteredBackend`. Repo-wide doc sweep: one stale surface, `skills/connect-sdk-deploy/SKILL.md` line 36 enumerates "AWS S3, Azure Files, and Google Cloud Storage adapters". Left untouched here because that skill carries its own revision convention; follow-up below.
- **Guard vs representation.** The one guard is the factory's `$root`/blank container-name check, needed because the builder does not throw. Name safety is a representation change (encoding), see above.
- **Schema / stored shape.** The factory reads new keys from the existing free-form `storageProperties` map; pre-existing configs lack them and get a clear `require()` error. No table, contract, or record changed.
- **Newly reachable failures.** Every new failure surfaces as `AttachmentStorageException` toward the gated ingest endpoint (`tsanetgit/Connect_SDK#51`) or as the STORAGE check's FAIL line in `GoLiveVerifier`, the same paths the other adapters use.
- **Dependency.** `com.azure:azure-storage-blob`, version 12.30.0 resolved by the `azure-sdk-bom` 1.2.35 already in the module pom (still the latest stable BOM on Maven Central today).

## Untouched on purpose

- `GoLiveVerifier` and `AttachmentStorageContractTest`, per the issue. The verifier's PASS line still says "write-read-delete probe", which is inexact for this adapter.
- `AzureFileNames` is reused, not modified. Its 255-character component cap is stricter than Blob's 1,024-character name limit; an over-long name fails fast through the SPI's checked exception (offline test).

## Follow-ups (not in this PR)

- `skills/connect-sdk-deploy/SKILL.md` should list the Azure Blob adapter and the `azure_blob` backend id on its next revision.
- `GoLiveVerifier`'s PASS wording, if the probe description should be per-adapter.

## Advisor and gate

Advisor consulted twice. The design call agreed with the GCS-shaped structure and asked for `getProperties`-based absence with only `BlobNotFound` mapped, the `$root` builder probe, all three classification groups in the double, and content type via the options overloads. The pre-done call found the size-based ambiguous-commit false positive on a same-size overwrite (fixed: identity resolution via the block list), and that the first live class never executed a real commit or overwrite (fixed: two live tests). Pre-PR gate: **LOOKS GOOD**, first run. Review is this repo's CI plus a QA-persona pass from a separate session.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
