### PR TITLE
attachment-receiver: follow-ups from the Azure Blob adapter review (#73)

### DIFF
--- a/attachment-receiver/src/main/java/com/tsanet/receiver/storage/azure/AzureBlobAttachmentStorage.java
+++ b/attachment-receiver/src/main/java/com/tsanet/receiver/storage/azure/AzureBlobAttachmentStorage.java
@@ -68,8 +68,8 @@ import java.util.UUID;
  * (tsanetgit/Connect-API-Code#140, question 2).
  *
  * <p><b>Go-live probe.</b> {@link #verifyAccess} stages one uncommitted block on a
- * {@code .verify-<uuid>} name (write), then reads that name's properties (read), expecting
- * {@code BlobNotFound}. Nothing is committed and nothing needs deleting, so it replaces
+ * {@code .verify-<uuid>} name (write), then reads that name's properties (read); the answer,
+ * absent, is ignored, since the probe tests permission, not state. Nothing is committed and nothing needs deleting, so it replaces
  * the other adapters' write-read-delete sentinel while validating the same two rights the
  * adapter needs at runtime: write for {@link #store}, read for {@link #exists} and the
  * ambiguous-commit resolution. Required rights are therefore SAS {@code rw} (or

--- a/attachment-receiver/src/main/java/com/tsanet/receiver/storage/azure/AzureBlobAttachmentStorage.java
+++ b/attachment-receiver/src/main/java/com/tsanet/receiver/storage/azure/AzureBlobAttachmentStorage.java
@@ -68,13 +68,15 @@ import java.util.UUID;
  * (tsanetgit/Connect-API-Code#140, question 2).
  *
  * <p><b>Go-live probe.</b> {@link #verifyAccess} stages one uncommitted block on a
- * {@code .verify-<uuid>} name: it needs only write permission and leaves no committed blob,
- * replacing the other adapters' write-read-delete sentinel (this is the issue's design).
- * The consequence, stated rather than hidden: <b>the probe validates write only, while
- * operation needs read as well</b> — {@link #exists} and the ambiguous-commit probe are
- * {@code Get Blob Properties}. A SAS carrying only {@code cw} passes go-live and fails
- * {@code exists} at runtime. Required rights are therefore SAS {@code rw} (or {@code rcw})
- * on the container, or the Storage Blob Data Contributor role for an Entra identity.
+ * {@code .verify-<uuid>} name (write), then reads that name's properties (read), expecting
+ * {@code BlobNotFound}. Nothing is committed and nothing needs deleting, so it replaces
+ * the other adapters' write-read-delete sentinel while validating the same two rights the
+ * adapter needs at runtime: write for {@link #store}, read for {@link #exists} and the
+ * ambiguous-commit resolution. Required rights are therefore SAS {@code rw} (or
+ * {@code rcw}) on the container, or the Storage Blob Data Contributor role for an Entra
+ * identity. A SAS carrying only {@code cw} fails go-live at the read stage
+ * (tsanetgit/Connect_SDK#73; before it, such a SAS passed go-live and failed on the first
+ * {@code exists}).
  *
  * <p>Failure classification reads the service error code before the HTTP status, because
  * Azure Storage answers {@code AuthenticationFailed} with 403, not 401.
@@ -197,38 +199,46 @@ public final class AzureBlobAttachmentStorage implements AttachmentStorage {
         byte[] probe = "attachment-receiver go-live probe".getBytes(StandardCharsets.UTF_8);
         try {
             // One uncommitted block: proves write permission, commits nothing, and the
-            // service reclaims it in seven days. No read, no delete, nothing to clean up.
+            // service reclaims it in seven days. Nothing to delete.
             container.stageBlock(probeName, blockId(UUID.randomUUID().toString(), 0), probe, probe.length);
         } catch (RuntimeException e) {
-            throw new AttachmentStorageException(classify(e), e);
+            throw new AttachmentStorageException(classify("write", e), e);
+        }
+        try {
+            // Get Blob Properties on the same name proves read permission. The answer is
+            // "absent" (only uncommitted blocks exist) and is deliberately ignored: the
+            // probe tests permission, not state.
+            container.sizeOrAbsent(probeName);
+        } catch (RuntimeException e) {
+            throw new AttachmentStorageException(classify("read", e), e);
         }
     }
 
     /** Wrong-credential, no-permission, and wrong-target must read differently. */
-    private String classify(RuntimeException e) {
+    private String classify(String stage, RuntimeException e) {
         if (e instanceof BlobStorageException bse) {
             BlobErrorCode code = bse.getErrorCode();
             int status = bse.getStatusCode();
             if (BlobErrorCode.AUTHENTICATION_FAILED.equals(code)
                     || BlobErrorCode.INVALID_AUTHENTICATION_INFO.equals(code)
                     || BlobErrorCode.NO_AUTHENTICATION_INFORMATION.equals(code)) {
-                return "wrong credential: the container rejected the identity (verify write, " + code + ")";
+                return "wrong credential: the container rejected the identity (verify " + stage + ", " + code + ")";
             }
             if (BlobErrorCode.AUTHORIZATION_FAILURE.equals(code)
                     || BlobErrorCode.AUTHORIZATION_PERMISSION_MISMATCH.equals(code)
                     || BlobErrorCode.INSUFFICIENT_ACCOUNT_PERMISSIONS.equals(code)
                     || status == 403) {
-                return "no permission: write denied on container '" + containerName + "'"
+                return "no permission: " + stage + " denied on container '" + containerName + "'"
                         + (code == null ? "" : " (" + code + ")");
             }
             if (BlobErrorCode.CONTAINER_NOT_FOUND.equals(code) || status == 404) {
                 return "wrong target: container '" + containerName
-                        + "' (or its account) does not exist (verify write)";
+                        + "' (or its account) does not exist (verify " + stage + ")";
             }
-            return "verify write failed on container '" + containerName + "': " + code
+            return "verify " + stage + " failed on container '" + containerName + "': " + code
                     + " (HTTP " + status + ")";
         }
-        return "connectivity: cannot reach the container (verify write): " + e.getMessage();
+        return "connectivity: cannot reach the container (verify " + stage + "): " + e.getMessage();
     }
 
     private int fill(InputStream content, byte[] buffer, String name)

--- a/attachment-receiver/src/main/java/com/tsanet/receiver/verify/GoLiveVerifier.java
+++ b/attachment-receiver/src/main/java/com/tsanet/receiver/verify/GoLiveVerifier.java
@@ -11,7 +11,7 @@ import java.util.List;
 
 /**
  * Runs a tenant's go-live checks: build the configured storage and prove it with the
- * SPI's write-read-delete probe; dry-run the CRM credentials when delivery is
+ * SPI's storage access probe; dry-run the CRM credentials when delivery is
  * configured. Run on configuration save and on demand; a passing report is the
  * precondition for registering the tenant's receive config with the platform.
  *
@@ -41,7 +41,7 @@ public final class GoLiveVerifier {
             AttachmentStorage storage = storageFactory.create(config);
             storage.verifyAccess();
             return new CheckResult(Check.STORAGE, Status.PASS,
-                    "backend '" + config.storageBackend() + "' passed the write-read-delete probe");
+                    "backend '" + config.storageBackend() + "' passed the storage access probe");
         } catch (Exception e) {
             return new CheckResult(Check.STORAGE, Status.FAIL, failureMessage(e));
         }

--- a/attachment-receiver/src/main/java/com/tsanet/receiver/verify/RegisteringStorageFactory.java
+++ b/attachment-receiver/src/main/java/com/tsanet/receiver/verify/RegisteringStorageFactory.java
@@ -61,9 +61,9 @@ import java.util.Map;
  * </table>
  *
  * <p>{@code azure_blob} needs read and write on the container: a SAS with {@code rw} (or
- * {@code rcw}), or Storage Blob Data Contributor. The go-live probe validates write only
- * (it stages one uncommitted block), so a write-only SAS passes go-live and fails on the
- * first {@code exists}; see {@link AzureBlobAttachmentStorage}.
+ * {@code rcw}), or Storage Blob Data Contributor. The go-live probe validates both: it
+ * stages one uncommitted block (write) and reads that name's properties (read), committing
+ * nothing; see {@link AzureBlobAttachmentStorage}.
  */
 public final class RegisteringStorageFactory implements StorageFactory {
 
@@ -110,12 +110,17 @@ public final class RegisteringStorageFactory implements StorageFactory {
         // logged config error. Both branches therefore throw a value-free message and,
         // unlike the gcs branch, deliberately attach NO cause: here the cause is the leak.
         if (!blank(sasUrl)) {
+            String malformed = "azure sasUrl is not a well-formed share SAS URL; it must be an https URL "
+                    + "that includes the share name";
+            // The SAS token is the credential and rides in the query string; the builder
+            // accepts http:// and would send it in cleartext on every request.
+            if (!sasUrl.regionMatches(true, 0, "https://", 0, 8)) {
+                throw new AttachmentStorageException(malformed);
+            }
             try {
                 share = builder.endpoint(sasUrl).buildClient();
             } catch (RuntimeException e) {
-                throw new AttachmentStorageException(
-                        "azure sasUrl is not a well-formed share SAS URL; it must be an https URL "
-                                + "that includes the share name");
+                throw new AttachmentStorageException(malformed);
             }
         } else {
             String connectionString = require(props, "connectionString", "azure");

--- a/attachment-receiver/src/test/java/com/tsanet/receiver/storage/azure/AzureBlobAttachmentStorageLiveTest.java
+++ b/attachment-receiver/src/test/java/com/tsanet/receiver/storage/azure/AzureBlobAttachmentStorageLiveTest.java
@@ -34,9 +34,10 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
  * <ul>
  *   <li>a blob that received staged blocks and was never committed is invisible to
  *       {@code exists} (it is enumerable only as an uncommitted blob);</li>
- *   <li>the go-live probe passes on a SAS carrying only {@code cw} and leaves no committed
- *       blob; a read-only SAS is classified as no permission; a tampered signature is
- *       classified as wrong credential (the error-code-before-status ordering, live);</li>
+ *   <li>the go-live probe passes on an {@code rw} SAS and leaves no committed blob; a
+ *       {@code cw}-only SAS fails at the read stage and a read-only SAS at the write stage,
+ *       both classified as no permission; a tampered signature is classified as wrong
+ *       credential (the error-code-before-status ordering, live);</li>
  *   <li>hostile file names round-trip under their literal encoded name: the first run of
  *       this test, before encoding, showed the service normalizing {@code ..}, a trailing
  *       dot, and a backslash, so "the listed name equals the encoded name" is the assertion
@@ -119,8 +120,8 @@ class AzureBlobAttachmentStorageLiveTest extends AttachmentStorageContractTest {
     }
 
     @Test
-    void cwOnlySasPassesTheProbeAndLeavesNoCommittedBlob() throws Exception {
-        AzureBlobAttachmentStorage.forContainer(sasClient("cw"), runPrefix).verifyAccess();
+    void rwSasPassesTheProbeAndLeavesNoCommittedBlob() throws Exception {
+        AzureBlobAttachmentStorage.forContainer(sasClient("rw"), runPrefix).verifyAccess();
         List<String> committed = names(runPrefix + "/" + AzureBlobAttachmentStorage.VERIFY_PREFIX, false);
         assertTrue(committed.isEmpty(), "the probe must commit nothing: " + committed);
         assertFalse(names(runPrefix + "/" + AzureBlobAttachmentStorage.VERIFY_PREFIX, true).isEmpty(),
@@ -128,10 +129,20 @@ class AzureBlobAttachmentStorageLiveTest extends AttachmentStorageContractTest {
     }
 
     @Test
-    void readOnlySasIsClassifiedAsNoPermission() {
+    void cwOnlySasIsClassifiedAsNoPermissionAtTheReadStage() {
+        // The case tsanetgit/Connect_SDK#73 flips: before it, this SAS passed go-live.
+        AttachmentStorage storage = AzureBlobAttachmentStorage.forContainer(sasClient("cw"), runPrefix);
+        AttachmentStorageException e = assertThrows(AttachmentStorageException.class, storage::verifyAccess);
+        assertTrue(e.getMessage().contains("no permission: read denied"), e.getMessage());
+        assertTrue(names(runPrefix + "/" + AzureBlobAttachmentStorage.VERIFY_PREFIX, false).isEmpty(),
+                "still nothing committed");
+    }
+
+    @Test
+    void readOnlySasIsClassifiedAsNoPermissionAtTheWriteStage() {
         AttachmentStorage storage = AzureBlobAttachmentStorage.forContainer(sasClient("r"), runPrefix);
         AttachmentStorageException e = assertThrows(AttachmentStorageException.class, storage::verifyAccess);
-        assertTrue(e.getMessage().contains("no permission"), e.getMessage());
+        assertTrue(e.getMessage().contains("no permission: write denied"), e.getMessage());
     }
 
     @Test

--- a/attachment-receiver/src/test/java/com/tsanet/receiver/storage/azure/AzureBlobAttachmentStorageTest.java
+++ b/attachment-receiver/src/test/java/com/tsanet/receiver/storage/azure/AzureBlobAttachmentStorageTest.java
@@ -242,6 +242,20 @@ class AzureBlobAttachmentStorageTest extends AttachmentStorageContractTest {
         assertEquals(1, blobs.uncommittedNames().size());
         assertTrue(blobs.uncommittedNames().get(0).startsWith("tenants/acme/" + AzureBlobAttachmentStorage.VERIFY_PREFIX),
                 blobs.uncommittedNames().get(0));
+        assertEquals(blobs.uncommittedNames().get(0), blobs.lastSizeOrAbsentName,
+                "the read stage must read the probe name, not some other name");
+    }
+
+    @Test
+    void verifyAccessClassifiesReadDeniedAsNoPermissionAtTheReadStage() {
+        // The cw-only SAS shape: the block stages, the read is refused.
+        InMemoryAzureBlobContainer blobs = new InMemoryAzureBlobContainer();
+        blobs.failSizeOrAbsentWith = () -> blobError(403, BlobErrorCode.AUTHORIZATION_PERMISSION_MISMATCH);
+        AzureBlobAttachmentStorage storage = new AzureBlobAttachmentStorage(blobs, "write-only", null);
+        AttachmentStorageException e = assertThrows(AttachmentStorageException.class, storage::verifyAccess);
+        assertTrue(e.getMessage().contains("no permission: read denied"), e.getMessage());
+        assertEquals(1, blobs.stagedBlocks, "the write stage ran and committed nothing");
+        assertEquals(0, blobs.committedCount());
     }
 
     @Test

--- a/attachment-receiver/src/test/java/com/tsanet/receiver/storage/azure/InMemoryAzureBlobContainer.java
+++ b/attachment-receiver/src/test/java/com/tsanet/receiver/storage/azure/InMemoryAzureBlobContainer.java
@@ -46,6 +46,7 @@ final class InMemoryAzureBlobContainer implements AzureBlobContainer {
     /** Observed for assertions. */
     int stagedBlocks;
     int commits;
+    String lastSizeOrAbsentName;
 
     @Override
     public void putBlob(String name, String contentType, byte[] bytes) {
@@ -125,6 +126,7 @@ final class InMemoryAzureBlobContainer implements AzureBlobContainer {
     @Override
     public long sizeOrAbsent(String name) {
         validate(name);
+        lastSizeOrAbsentName = name;
         if (failSizeOrAbsentWith != null) {
             throw failSizeOrAbsentWith.get();
         }

--- a/attachment-receiver/src/test/java/com/tsanet/receiver/verify/GoLiveVerifierTest.java
+++ b/attachment-receiver/src/test/java/com/tsanet/receiver/verify/GoLiveVerifierTest.java
@@ -31,6 +31,9 @@ class GoLiveVerifierTest {
     void passesStorageAndSkipsCrmWhenUnconfigured() {
         VerificationReport report = new GoLiveVerifier(WORKING, null).verify(STORAGE_ONLY);
         assertEquals(Status.PASS, result(report, Check.STORAGE).status());
+        // Adapter-neutral wording: not every adapter's probe is write-read-delete.
+        assertTrue(result(report, Check.STORAGE).message().contains("passed the storage access probe"),
+                result(report, Check.STORAGE).message());
         assertEquals(Status.SKIPPED, result(report, Check.CRM).status());
         assertTrue(report.passed(), "SKIPPED must not fail a tenant");
     }

--- a/attachment-receiver/src/test/java/com/tsanet/receiver/verify/RegisteringStorageFactoryTest.java
+++ b/attachment-receiver/src/test/java/com/tsanet/receiver/verify/RegisteringStorageFactoryTest.java
@@ -81,6 +81,25 @@ class RegisteringStorageFactoryTest {
     }
 
     @Test
+    void azureWithHttpsShareSasUrlBuildsAzureAdapter() throws Exception {
+        AttachmentStorage storage = factory.create(config("azure", Map.of(
+                "sasUrl", "https://acct.file.core.windows.net/attachments?sv=2024-01-01&sp=rcwd&sig=Zm9v",
+                "directoryPrefix", "tenants/acme")));
+        assertInstanceOf(AzureFilesAttachmentStorage.class, storage);
+    }
+
+    @Test
+    void azureHttpSasUrlIsRejectedWithoutEchoingTheToken() {
+        // Same gap tsanetgit/Connect_SDK#72 closed on the azure_blob branch: the builder
+        // accepts http:// and would send the SAS token in cleartext.
+        AttachmentStorageException e = assertThrows(AttachmentStorageException.class,
+                () -> factory.create(config("azure", Map.of(
+                        "sasUrl", "http://acct.file.core.windows.net/attachments?sv=2024-01-01&sig=MARKER"))));
+        assertFalse(fullChain(e).contains("MARKER"), fullChain(e));
+        assertTrue(e.getMessage().contains("https"), e.getMessage());
+    }
+
+    @Test
     void azureWithoutTargetIsAConfigError() {
         AttachmentStorageException e = assertThrows(AttachmentStorageException.class,
                 () -> factory.create(config("azure", Map.of("directoryPrefix", "x"))));

--- a/skills/connect-sdk-deploy/SKILL.md
+++ b/skills/connect-sdk-deploy/SKILL.md
@@ -33,7 +33,7 @@ the release version, branch names, and module list against the live repository.
 | `TSANet-integration-app` | Console reference app exposing the library as CLI commands (`login`, `requests`, `notes add`, `webhooks create`, ...) | Spring Boot jar |
 | `TSANet-integration-demo` | Scripted demo scenarios over the library | Spring Boot jar |
 | `demo-ui` | The branded web demo: dashboard, partner search, dynamic process forms, full case lifecycle from the browser. This is "the SDK demo" most people mean. | Spring Boot jar, port 8090 |
-| `attachment-receiver` | The storage half of receiving pushed files: a streaming storage SPI with AWS S3, Azure Files (backend id `azure`), Azure Blob Storage (backend id `azure_blob`, the default Azure option for member self-service), and Google Cloud Storage adapters, an encrypted per-tenant config store, and a go-live verifier. The HTTPS endpoint that accepts the push is not built yet; no standalone docs yet. | Spring Boot jar |
+| `attachment-receiver` | The storage half of receiving pushed files: a streaming storage SPI with AWS S3, Azure Files (backend id `azure`), Azure Blob Storage (backend id `azure_blob`), and Google Cloud Storage adapters, an encrypted per-tenant config store, and a go-live verifier. The HTTPS endpoint that accepts the push is not built yet; no standalone docs yet. | Spring Boot jar |
 
 ## Access model (read this first, it shapes everything)
 

--- a/skills/connect-sdk-deploy/SKILL.md
+++ b/skills/connect-sdk-deploy/SKILL.md
@@ -22,7 +22,7 @@ its root `README.md`, `docs/RUNBOOK.md`, `docs/USER_GUIDE.md`, and
 answering; this skill tells you what matters, where the traps are, and what has changed
 recently, but the repo docs win on any conflict.
 
-Facts below were verified against `main` on 2026-09-02 (release v1.0.0). If months have passed, re-verify
+Facts below were verified against `main` on 2026-09-07 (release v1.0.0). If months have passed, re-verify
 the release version, branch names, and module list against the live repository.
 
 ## Repository map
@@ -33,7 +33,7 @@ the release version, branch names, and module list against the live repository.
 | `TSANet-integration-app` | Console reference app exposing the library as CLI commands (`login`, `requests`, `notes add`, `webhooks create`, ...) | Spring Boot jar |
 | `TSANet-integration-demo` | Scripted demo scenarios over the library | Spring Boot jar |
 | `demo-ui` | The branded web demo: dashboard, partner search, dynamic process forms, full case lifecycle from the browser. This is "the SDK demo" most people mean. | Spring Boot jar, port 8090 |
-| `attachment-receiver` | The storage half of receiving pushed files: a streaming storage SPI with AWS S3, Azure Files, and Google Cloud Storage adapters, an encrypted per-tenant config store, and a go-live verifier. The HTTPS endpoint that accepts the push is not built yet; no standalone docs yet. | Spring Boot jar |
+| `attachment-receiver` | The storage half of receiving pushed files: a streaming storage SPI with AWS S3, Azure Files (backend id `azure`), Azure Blob Storage (backend id `azure_blob`, the default Azure option for member self-service), and Google Cloud Storage adapters, an encrypted per-tenant config store, and a go-live verifier. The HTTPS endpoint that accepts the push is not built yet; no standalone docs yet. | Spring Boot jar |
 
 ## Access model (read this first, it shapes everything)
 


### PR DESCRIPTION
Closes `tsanetgit/Connect_SDK#73` (epic `tsanetgit/Connect_SDK#46`). The four items the review of `tsanetgit/Connect_SDK#72` left out of that diff, one PR, each scoped to the file it names.

**Account-hygiene rule, binding for this public repo:** no storage account, container, connection string, or subscription identifier appears here. Live results are counts and outcomes.

## The four changes

1. **Files `sasUrl` branch enforces https** (`RegisteringStorageFactory.azure`). The message already promised "an https URL"; nothing checked it, and `ShareClientBuilder` accepts `http://`, which would send the SAS token in cleartext on every request. Same case-insensitive scheme check the `azure_blob` branch got in #72, before the builder runs, same value-free message, no cause. Scheme only: the `$root` check stays a Blob concern because the two builders parse differently. Tests: `http://…?sig=MARKER` rejected with no `MARKER` anywhere in the cause chain, and an https share SAS URL still builds `AzureFilesAttachmentStorage`.
2. **Blob go-live probe validates read as well as write** (`AzureBlobAttachmentStorage.verifyAccess`). After staging the uncommitted block, a second try block reads the probe name's properties through the existing `sizeOrAbsent`. The answer, absent, is ignored: the probe tests permission, not state. A service refusal classifies through `classify(stage, e)`, so the operator reads "read denied" or "write denied". Nothing committed, nothing to delete, the seven-day expiry is untouched (a read does not move the `Put Block` clock). The javadoc that documented the gap in #72 now documents the fix, in the adapter class javadoc, the inline comment, and the factory note.
3. **`connect-sdk-deploy` skill** names all four adapters and both Azure backend ids (`azure` for Files, `azure_blob` for Blob) in its module table; the verified-date line moves to today. Nothing else in the skill changes. The installed copy under the skills directory is a symlink into this repo, so it follows the merge.
4. **`GoLiveVerifier` PASS wording** is adapter-neutral: "passed the storage access probe", in the message and the class javadoc. `GoLiveVerifierTest` asserts it. Repo-wide grep for `write-read-delete` after the change: one hit remains, the Blob adapter javadoc describing the *other* adapters' sentinel, which is still true.

## The case that flips

Before this PR a container SAS carrying only `cw` passed go-live and failed on the first `exists`. Now it fails go-live at the read stage. Proven live: the service answers the `Get Blob Properties` on the probe name with `AuthorizationPermissionMismatch` (403), which classifies as "no permission: read denied". A read-only SAS still fails at the write stage ("write denied"), and an `rw` SAS passes and leaves no committed blob, with the probe block enumerable only as uncommitted. This supersedes the `cw`-only acceptance line in `tsanetgit/Connect_SDK#71`, as #73 states.

## Rights parity, the check that gates the javadoc claim

The new javadoc says the probe validates "the same two rights the adapter needs at runtime". Sweep of every seam method the adapter calls (`grep -n 'container\.' AzureBlobAttachmentStorage.java` against `AzureBlobContainer`):

| seam method | REST operation | right |
|---|---|---|
| `putBlob` | Put Blob | write |
| `stageBlock` | Put Block | write |
| `commitBlockList` | Put Block List | write |
| `sizeOrAbsent` | Get Blob Properties | read |
| `committedBlockIdsOrAbsent` | Get Block List | read |

`SdkAzureBlobContainer` calls no delete and no list. `rw` is the complete runtime set, so an `rw` SAS that passes go-live cannot fail on a later operation for lack of a right.

## Verification

- Offline, `mvn -pl attachment-receiver -am test`: **174 run, 0 failures, 38 skipped** (was 170 / 0 / 37 at `main`). New: two factory tests for the Files https branch, one Blob test for read-denied-at-read-stage (with the double recording that the read hit the probe name), the verifier wording assertion, and one live test.
- Live, `AzureBlobAttachmentStorageLiveTest` against a disposable container in a private test account: **15 / 15**, about 46 s. The renamed `cwOnlySasIsClassifiedAsNoPermissionAtTheReadStage`, the new `rwSasPassesTheProbeAndLeavesNoCommittedBlob`, `readOnlySasIsClassifiedAsNoPermissionAtTheWriteStage`, and the fourteen cases from #72 unchanged.
- The final two-line wording commit (`3efeda7`) is javadoc and skill prose only; the affected test classes were rerun after it.

## Prose claims and the lines that make them true

| claim | line |
|---|---|
| Probe validates read | `verifyAccess`, second try block calling `sizeOrAbsent(probeName)` |
| `cw`-only fails at the read stage | live `cwOnlySasIsClassifiedAsNoPermissionAtTheReadStage`; offline `verifyAccessClassifiesReadDeniedAsNoPermissionAtTheReadStage` |
| Still nothing committed | live `rwSasPassesTheProbeAndLeavesNoCommittedBlob` asserts the committed listing under `.verify-` is empty |
| The read hits the probe name | offline assertion on the double's `lastSizeOrAbsentName` |
| `rw` is the complete runtime rights set | the sweep table above |
| Files branch rejects `http://` value-free | `azureHttpSasUrlIsRejectedWithoutEchoingTheToken` |
| Verifier wording | `GoLiveVerifierTest.passesStorageAndSkipsCrmWhenUnconfigured` |

## Blast radius (`pre-pr-artifacts.py`, base `origin/main`)

No mechanical detector fired. Judgment lines:

- **Guard vs representation.** The https check is a guard. The representation alternative, parsing the URL and requiring the scheme, is the same check with more code; the value-free rule forbids echoing the parsed parts anyway.
- **Third or later fix to one class.** This is the second https check in the factory (first was #72). Both branches now share the shape; a shared helper would be the third-time move.
- **Newly reachable failure.** The probe's read stage is a second network call that can fail on transient connectivity where there was none. It surfaces through `classify("read", …)` as the STORAGE check's FAIL line in `GoLiveVerifier`, the same handler as the write stage. Existing offline classification tests inject at `stageBlock` and their write-stage strings are byte-identical, so they still assert the correct stage without edits.
- **Abstraction / schema / stored shape.** None introduced or changed.

## Advisor and gate

Advisor consulted twice. Orientation: keep the `cw`-only live test flipped rather than deleted (it is the one case that discriminates old from new), thread the stage through every `classify` arm, treat the javadoc that documented the gap as part of item 2, keep item 1 scheme-only. Pre-done: the rights-parity sweep above was its one blocking check, plus the two wording trims in the second commit. Pre-PR gate: **LOOKS GOOD**, first run. Review is CI plus a QA-persona pass from a separate session.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
