### PR TITLE
attachment-receiver: ambiguous-finish resolves by attempt identity in the S3 and GCS adapters (#69)

### DIFF
--- a/attachment-receiver/src/main/java/com/tsanet/receiver/storage/azure/AzureBlobAttachmentStorage.java
+++ b/attachment-receiver/src/main/java/com/tsanet/receiver/storage/azure/AzureBlobAttachmentStorage.java
@@ -53,10 +53,9 @@ import java.util.UUID;
  *       truncated object — and there is deliberately no cleanup round-trip that could
  *       itself fail (the GCS adapter's shape, unlike S3's abort call).</li>
  *   <li><b>Ambiguous commit, resolved exactly.</b> A {@code Put Block List} that fails
- *       client-side may have committed server-side. The S3 and GCS adapters resolve that
- *       by size, which a same-size overwrite or a concurrent writer can fool
- *       (tsanetgit/Connect_SDK#69). Here the block ids carry a UUID minted for this store
- *       call, so the resolution is identity, not size: the blob's committed block list
+ *       client-side may have committed server-side. As in the S3 and GCS adapters since
+ *       tsanetgit/Connect_SDK#69, the resolution is identity, not size. Here the block ids
+ *       carry a UUID minted for this store call: the blob's committed block list
  *       ({@code Get Block List}) equal to the ids this call staged means this commit
  *       landed, and nothing else can produce that list. Any other shape throws.</li>
  * </ul>

--- a/attachment-receiver/src/main/java/com/tsanet/receiver/storage/gcs/GcsAttachmentStorage.java
+++ b/attachment-receiver/src/main/java/com/tsanet/receiver/storage/gcs/GcsAttachmentStorage.java
@@ -36,11 +36,15 @@ import java.util.UUID;
  *       {@code abandon()}ed, not finished — finishing a partial upload would finalize a
  *       truncated object. There is deliberately no cleanup round-trip that could itself
  *       fail, unlike S3's {@code AbortMultipartUpload}.</li>
- *   <li><b>Ambiguous finish.</b> A {@code finish} that fails client-side may have committed
- *       server-side. When the object is then visible at exactly the byte count written, the
- *       store is treated as committed and reported as success, mirroring the S3 adapter's
- *       ambiguous-complete policy. (Like both twins, this cannot distinguish a concurrent
- *       same-name writer's object.)</li>
+ *   <li><b>Ambiguous finish, resolved by identity.</b> A {@code finish} that fails
+ *       client-side may have committed server-side. Each resumable attempt is stamped with
+ *       a UUID as custom metadata ({@value #ATTEMPT_METADATA_KEY}) on the {@code BlobInfo}
+ *       the session opens with, which GCS stores on the finalized object. The visible
+ *       object carrying this attempt's UUID means this finish landed; a previous object of
+ *       the same name (same size or not), a concurrent writer's, or nothing at all fails
+ *       closed and throws (tsanetgit/Connect_SDK#69). Single-request objects written by
+ *       {@code create} are deliberately unmarked: a later attempt's ambiguous finish over
+ *       one then fails closed, which is right.</li>
  * </ul>
  *
  * <p>Required IAM on the bucket/prefix: {@code storage.objects.create},
@@ -54,6 +58,9 @@ public final class GcsAttachmentStorage implements AttachmentStorage {
 
     /** Stream read granularity; a 256 KiB multiple, so it is also a valid resumable chunk size. */
     static final int BUFFER_SIZE = 5 * 1024 * 1024;
+
+    /** Custom-metadata key carrying the per-attempt UUID on resumable objects. */
+    static final String ATTEMPT_METADATA_KEY = "tsanet-upload-attempt";
 
     private final GcsBucket bucket;
     private final String bucketName;
@@ -94,9 +101,10 @@ public final class GcsAttachmentStorage implements AttachmentStorage {
     private StoredAttachment resumable(IncomingAttachment attachment, InputStream content,
                                        String key, byte[] firstBuffer)
             throws AttachmentStorageException {
+        String attempt = UUID.randomUUID().toString();
         GcsBucket.Upload upload;
         try {
-            upload = bucket.startResumable(key, attachment.contentType());
+            upload = bucket.startResumable(key, attachment.contentType(), attempt);
         } catch (RuntimeException e) {
             throw wrap("resumable start", key, e);
         }
@@ -132,21 +140,22 @@ public final class GcsAttachmentStorage implements AttachmentStorage {
         try {
             upload.finish();
         } catch (RuntimeException finishFailure) {
-            return resolveAmbiguousFinish(key, total, finishFailure);
+            return resolveAmbiguousFinish(key, attempt, total, finishFailure);
         }
         return new StoredAttachment(key, total);
     }
 
     /**
-     * A failed finish is ambiguous: GCS may have committed server-side. The object visible
-     * at exactly the byte count written means exactly that — report the commit as the
-     * success it was. Every other shape throws.
+     * A failed finish is ambiguous: GCS may have committed server-side. The visible object
+     * carrying this attempt's UUID means exactly that — report the commit as the success
+     * it was. Another marker or none (a previous same-name object, a concurrent writer's,
+     * nothing committed) fails closed. Every other shape throws.
      */
-    private StoredAttachment resolveAmbiguousFinish(String key, long total,
+    private StoredAttachment resolveAmbiguousFinish(String key, String attempt, long total,
                                                     RuntimeException finishFailure)
             throws AttachmentStorageException {
         try {
-            if (bucket.sizeOrAbsent(key) == total) {
+            if (attempt.equals(bucket.attemptMarkerOrAbsent(key))) {
                 return new StoredAttachment(key, total);
             }
         } catch (RuntimeException probeFailure) {

--- a/attachment-receiver/src/main/java/com/tsanet/receiver/storage/gcs/GcsBucket.java
+++ b/attachment-receiver/src/main/java/com/tsanet/receiver/storage/gcs/GcsBucket.java
@@ -29,12 +29,20 @@ interface GcsBucket {
      * Large-file path: start a resumable upload. The object does not become visible until
      * {@link Upload#finish()}; an {@link Upload#abandon() abandoned} upload never produces a
      * visible object and the session expires server-side, which is how the SPI's
-     * no-partial-visibility rule holds without an abort call.
+     * no-partial-visibility rule holds without an abort call. {@code attemptMarker} is
+     * stored as custom metadata on the finalized object, so the adapter can later tell
+     * this attempt's object from any other.
      */
-    Upload startResumable(String key, String contentType);
+    Upload startResumable(String key, String contentType, String attemptMarker);
 
     /** The object's byte size, or {@code -1} when it does not exist; throws on access error. */
     long sizeOrAbsent(String key);
+
+    /**
+     * The visible object's attempt marker, or {@code null} when the object is absent or
+     * carries none (a {@link #create single-request} object); throws on access error.
+     */
+    String attemptMarkerOrAbsent(String key);
 
     byte[] download(String key);
 

--- a/attachment-receiver/src/main/java/com/tsanet/receiver/storage/gcs/SdkGcsBucket.java
+++ b/attachment-receiver/src/main/java/com/tsanet/receiver/storage/gcs/SdkGcsBucket.java
@@ -9,6 +9,7 @@ import com.google.cloud.storage.StorageException;
 
 import java.io.IOException;
 import java.nio.ByteBuffer;
+import java.util.Map;
 
 /**
  * The logic-free SDK implementation of {@link GcsBucket}: every method is one or two SDK
@@ -28,12 +29,14 @@ final class SdkGcsBucket implements GcsBucket {
 
     @Override
     public void create(String key, String contentType, byte[] bytes) {
-        storage.create(blobInfo(key, contentType), bytes);
+        storage.create(blobInfo(key, contentType, null), bytes);
     }
 
     @Override
-    public Upload startResumable(String key, String contentType) {
-        WriteChannel channel = storage.writer(blobInfo(key, contentType));
+    public Upload startResumable(String key, String contentType, String attemptMarker) {
+        // The BlobInfo opens the resumable session, and its metadata lands on the object
+        // when the session finalizes.
+        WriteChannel channel = storage.writer(blobInfo(key, contentType, attemptMarker));
         channel.setChunkSize(GcsAttachmentStorage.BUFFER_SIZE);
         return new Upload() {
             @Override
@@ -70,6 +73,15 @@ final class SdkGcsBucket implements GcsBucket {
     }
 
     @Override
+    public String attemptMarkerOrAbsent(String key) {
+        Blob blob = storage.get(BlobId.of(bucket, key));
+        if (blob == null || blob.getMetadata() == null) {
+            return null;
+        }
+        return blob.getMetadata().get(GcsAttachmentStorage.ATTEMPT_METADATA_KEY);
+    }
+
+    @Override
     public byte[] download(String key) {
         return storage.readAllBytes(BlobId.of(bucket, key));
     }
@@ -79,10 +91,13 @@ final class SdkGcsBucket implements GcsBucket {
         storage.delete(BlobId.of(bucket, key));
     }
 
-    private BlobInfo blobInfo(String key, String contentType) {
+    private BlobInfo blobInfo(String key, String contentType, String attemptMarker) {
         BlobInfo.Builder builder = BlobInfo.newBuilder(BlobId.of(bucket, key));
         if (contentType != null) {
             builder.setContentType(contentType);
+        }
+        if (attemptMarker != null) {
+            builder.setMetadata(Map.of(GcsAttachmentStorage.ATTEMPT_METADATA_KEY, attemptMarker));
         }
         return builder.build();
     }

--- a/attachment-receiver/src/main/java/com/tsanet/receiver/storage/s3/S3AttachmentStorage.java
+++ b/attachment-receiver/src/main/java/com/tsanet/receiver/storage/s3/S3AttachmentStorage.java
@@ -17,6 +17,7 @@ import java.io.InputStream;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
+import java.util.Map;
 import java.util.Objects;
 import java.util.UUID;
 
@@ -36,10 +37,16 @@ import java.util.UUID;
  * SDK only ever sees replayable byte bodies, never the caller's stream, so SDK-level
  * retries are safe and the stream is never closed by this class.
  *
- * <p>One deliberate policy for the ambiguous-complete edge (a
- * {@code CompleteMultipartUpload} that fails client-side after succeeding server-side):
- * when the failed complete's abort answers {@code NoSuchUpload} and the object is
- * visible, the store is treated as committed and reported as success.
+ * <p>The ambiguous-complete edge (a {@code CompleteMultipartUpload} that fails
+ * client-side after succeeding server-side) is resolved by identity: each multipart
+ * attempt is stamped with a UUID as user metadata ({@value #ATTEMPT_METADATA_KEY}) on
+ * {@code CreateMultipartUpload}, which S3 stores on the completed object. When the failed
+ * complete's abort answers {@code NoSuchUpload} and a HEAD of the key returns this
+ * attempt's UUID, the store is reported as the success it was. A previous object of the
+ * same name (same size or not), a concurrent writer's, or an expired session with nothing
+ * committed fails closed and throws (tsanetgit/Connect_SDK#69). Single-request objects
+ * written by {@code PutObject} are deliberately unmarked: a later attempt's ambiguous
+ * complete over one then fails closed, which is right.
  *
  * <p>Required IAM on the bucket/prefix: {@code s3:PutObject}, {@code s3:GetObject},
  * {@code s3:DeleteObject} (the verify sentinel), {@code s3:ListBucket} (without it a
@@ -55,6 +62,9 @@ public final class S3AttachmentStorage implements AttachmentStorage {
 
     /** S3's minimum non-last part size: 5 MiB exactly, not 5 MB. */
     static final int PART_SIZE = 5 * 1024 * 1024;
+
+    /** User-metadata key carrying the per-attempt UUID; lowercase, as S3 returns keys. */
+    static final String ATTEMPT_METADATA_KEY = "tsanet-upload-attempt";
 
     private final S3Client s3;
     private final String bucket;
@@ -100,10 +110,11 @@ public final class S3AttachmentStorage implements AttachmentStorage {
     private StoredAttachment multipart(IncomingAttachment attachment, InputStream content,
                                        String key, byte[] firstBuffer)
             throws AttachmentStorageException {
+        String attempt = UUID.randomUUID().toString();
         String uploadId;
         try {
             uploadId = s3.createMultipartUpload(b -> {
-                b.bucket(bucket).key(key);
+                b.bucket(bucket).key(key).metadata(Map.of(ATTEMPT_METADATA_KEY, attempt));
                 if (attachment.contentType() != null) {
                     b.contentType(attachment.contentType());
                 }
@@ -151,7 +162,7 @@ public final class S3AttachmentStorage implements AttachmentStorage {
             s3.completeMultipartUpload(b -> b.bucket(bucket).key(key).uploadId(uploadId)
                     .multipartUpload(mu -> mu.parts(parts)));
         } catch (Exception completeFailure) {
-            return resolveAmbiguousComplete(key, uploadId, total, completeFailure);
+            return resolveAmbiguousComplete(key, uploadId, attempt, total, completeFailure);
         }
         return new StoredAttachment(key, total);
     }
@@ -167,17 +178,19 @@ public final class S3AttachmentStorage implements AttachmentStorage {
 
     /**
      * A failed complete is ambiguous: S3 may have committed server-side. Abort answering
-     * {@code NoSuchUpload} while the object is visible means exactly that — report the
-     * commit as the success it was. Every other shape aborts and throws.
+     * {@code NoSuchUpload} while the visible object carries this attempt's UUID means
+     * exactly that — report the commit as the success it was. A visible object with
+     * another marker or none (a previous same-name object, a concurrent writer's, a
+     * session that merely expired) fails closed. Every other shape aborts and throws.
      */
-    private StoredAttachment resolveAmbiguousComplete(String key, String uploadId, long total,
-                                                      Exception completeFailure)
+    private StoredAttachment resolveAmbiguousComplete(String key, String uploadId, String attempt,
+                                                      long total, Exception completeFailure)
             throws AttachmentStorageException {
         try {
             s3.abortMultipartUpload(b -> b.bucket(bucket).key(key).uploadId(uploadId));
         } catch (NoSuchUploadException uploadGone) {
             try {
-                if (existsKey(key)) {
+                if (attempt.equals(attemptMarkerOrAbsent(key))) {
                     return new StoredAttachment(key, total);
                 }
             } catch (Exception headFailure) {
@@ -188,6 +201,25 @@ public final class S3AttachmentStorage implements AttachmentStorage {
             completeFailure.addSuppressed(abortFailure);
         }
         throw wrap("complete", key, completeFailure);
+    }
+
+    /**
+     * The visible object's attempt marker, or {@code null} when the key is absent or the
+     * object is unmarked. Same 404 discrimination as {@link #existsKey}: an absent key is a
+     * definite "not this attempt", not a probe error.
+     */
+    private String attemptMarkerOrAbsent(String key) throws AttachmentStorageException {
+        try {
+            return s3.headObject(b -> b.bucket(bucket).key(key)).metadata().get(ATTEMPT_METADATA_KEY);
+        } catch (S3Exception e) {
+            if (e.statusCode() == 404) {
+                return null;
+            }
+            throw wrap("attempt marker read", key, e);
+        } catch (SdkException e) {
+            throw new AttachmentStorageException(
+                    "attempt marker read failed for " + key + ": cannot reach S3: " + e.getMessage(), e);
+        }
     }
 
     @Override

--- a/attachment-receiver/src/test/java/com/tsanet/receiver/storage/gcs/GcsAttachmentStorageLiveTest.java
+++ b/attachment-receiver/src/test/java/com/tsanet/receiver/storage/gcs/GcsAttachmentStorageLiveTest.java
@@ -2,13 +2,21 @@ package com.tsanet.receiver.storage.gcs;
 
 import com.tsanet.receiver.storage.AttachmentStorage;
 import com.tsanet.receiver.storage.AttachmentStorageContractTest;
+import com.tsanet.receiver.storage.IncomingAttachment;
 import com.google.cloud.storage.Blob;
+import com.google.cloud.storage.BlobId;
 import com.google.cloud.storage.Storage;
 import com.google.cloud.storage.StorageOptions;
 import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.condition.EnabledIfEnvironmentVariable;
 
+import java.io.ByteArrayInputStream;
 import java.util.UUID;
+
+import static com.tsanet.receiver.storage.gcs.GcsAttachmentStorage.BUFFER_SIZE;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
 
 /**
  * The real-bucket acceptance run: the shared contract test bound to a live GCS bucket.
@@ -29,6 +37,26 @@ class GcsAttachmentStorageLiveTest extends AttachmentStorageContractTest {
     @Override
     protected AttachmentStorage newStorage() {
         return GcsAttachmentStorage.forBucket(storage, bucket, runPrefix);
+    }
+
+    @Test
+    void completedResumableObjectCarriesThisAttemptsMarkerAndSingleRequestObjectsDoNot() throws Exception {
+        // The fact tsanetgit/Connect_SDK#69's identity resolution rests on, for GCS: custom
+        // metadata on the BlobInfo that opens the resumable session lands on the finalized
+        // object. Env-gated like the rest of the class; run it when credentials exist.
+        AttachmentStorage adapter = newStorage();
+        var resumable = adapter.store(new IncomingAttachment("01234567", "marked.bin", null, -1),
+                new ByteArrayInputStream(new byte[BUFFER_SIZE + 1024]));
+        Blob marked = storage.get(BlobId.of(bucket, resumable.storageKey()));
+        assertNotNull(marked, "the finalized object must be visible");
+        assertNotNull(marked.getMetadata(), "metadata from the session's BlobInfo must be on the finalized object");
+        UUID.fromString(marked.getMetadata().get(GcsAttachmentStorage.ATTEMPT_METADATA_KEY));
+        var single = adapter.store(new IncomingAttachment("01234567", "small.bin", null, -1),
+                new ByteArrayInputStream(new byte[16]));
+        Blob unmarked = storage.get(BlobId.of(bucket, single.storageKey()));
+        assertNull(unmarked.getMetadata() == null ? null
+                        : unmarked.getMetadata().get(GcsAttachmentStorage.ATTEMPT_METADATA_KEY),
+                "single-request objects stay unmarked");
     }
 
     @AfterEach

--- a/attachment-receiver/src/test/java/com/tsanet/receiver/storage/gcs/GcsAttachmentStorageTest.java
+++ b/attachment-receiver/src/test/java/com/tsanet/receiver/storage/gcs/GcsAttachmentStorageTest.java
@@ -133,6 +133,23 @@ class GcsAttachmentStorageTest extends AttachmentStorageContractTest {
     }
 
     @Test
+    void ambiguousFinishProbeFailureRidesAsSuppressedOnTheFinishFailure() {
+        // The marker read itself fails: the store fails closed on the finish failure and
+        // the probe's own failure is not lost.
+        InMemoryGcsBucket gcs = new InMemoryGcsBucket();
+        gcs.failFinish = new StorageException(503, "finish RPC failed (simulated)");
+        gcs.finishCommitsBeforeFailing = false;
+        gcs.failAttemptMarker = new StorageException(500, "marker read failed (simulated)");
+        GcsAttachmentStorage storage = new GcsAttachmentStorage(gcs, "b", null);
+        AttachmentStorageException e = assertThrows(AttachmentStorageException.class,
+                () -> storage.store(attachment("probe.bin"), new java.io.ByteArrayInputStream(bytes(BUFFER_SIZE + 8))));
+        assertTrue(e.getMessage().contains("finish"), e.getMessage());
+        assertEquals("finish RPC failed (simulated)", e.getCause().getMessage());
+        assertEquals(1, e.getCause().getSuppressed().length);
+        assertEquals("marker read failed (simulated)", e.getCause().getSuppressed()[0].getMessage());
+    }
+
+    @Test
     void ambiguousFinishWithNothingCommittedThrows() {
         InMemoryGcsBucket gcs = new InMemoryGcsBucket();
         gcs.failFinish = new StorageException(503, "finish RPC failed, nothing committed");

--- a/attachment-receiver/src/test/java/com/tsanet/receiver/storage/gcs/GcsAttachmentStorageTest.java
+++ b/attachment-receiver/src/test/java/com/tsanet/receiver/storage/gcs/GcsAttachmentStorageTest.java
@@ -11,6 +11,7 @@ import java.io.IOException;
 import java.io.InputStream;
 
 import static com.tsanet.receiver.storage.gcs.GcsAttachmentStorage.BUFFER_SIZE;
+import static org.junit.jupiter.api.Assertions.assertArrayEquals;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertThrows;
@@ -95,6 +96,40 @@ class GcsAttachmentStorageTest extends AttachmentStorageContractTest {
         var stored = storage.store(attachment("ambiguous.bin"), new java.io.ByteArrayInputStream(content));
         assertEquals(content.length, stored.bytesWritten(),
                 "a finish that committed server-side is the success it was");
+    }
+
+    @Test
+    void ambiguousFinishOverAPreExistingSameSizeObjectThrows() throws Exception {
+        // The false-positive shape the size probe could not see: an older object of the
+        // same name and length is already there, and this finish never committed.
+        InMemoryGcsBucket gcs = new InMemoryGcsBucket();
+        GcsAttachmentStorage storage = new GcsAttachmentStorage(gcs, "b", null);
+        byte[] older = bytes(BUFFER_SIZE + 8);
+        storage.store(attachment("same-size.bin"), new java.io.ByteArrayInputStream(older));
+        byte[] newer = bytes(BUFFER_SIZE + 8);
+        newer[0] = (byte) 0xFF;
+        gcs.failFinish = new StorageException(503, "finish RPC failed, nothing committed");
+        gcs.finishCommitsBeforeFailing = false;
+        assertThrows(AttachmentStorageException.class,
+                () -> storage.store(attachment("same-size.bin"), new java.io.ByteArrayInputStream(newer)),
+                "an older same-size object must not be mistaken for this attempt's finish");
+        assertArrayEquals(older, gcs.contentOf("01234567/same-size.bin"), "the older object is untouched");
+    }
+
+    @Test
+    void ambiguousFinishOverAnUnmarkedSingleRequestObjectThrows() throws Exception {
+        // create() objects carry no marker on purpose: a later attempt's ambiguous finish
+        // over one must fail closed, never adopt it as its own commit.
+        InMemoryGcsBucket gcs = new InMemoryGcsBucket();
+        GcsAttachmentStorage storage = new GcsAttachmentStorage(gcs, "b", null);
+        byte[] older = bytes(64);
+        storage.store(attachment("unmarked.bin"), new java.io.ByteArrayInputStream(older));
+        assertNull(gcs.attemptMarkerOrAbsent("01234567/unmarked.bin"), "single-request objects stay unmarked");
+        gcs.failFinish = new StorageException(503, "finish RPC failed, nothing committed");
+        gcs.finishCommitsBeforeFailing = false;
+        assertThrows(AttachmentStorageException.class,
+                () -> storage.store(attachment("unmarked.bin"), new java.io.ByteArrayInputStream(bytes(BUFFER_SIZE + 8))));
+        assertArrayEquals(older, gcs.contentOf("01234567/unmarked.bin"), "the older object is untouched");
     }
 
     @Test

--- a/attachment-receiver/src/test/java/com/tsanet/receiver/storage/gcs/InMemoryGcsBucket.java
+++ b/attachment-receiver/src/test/java/com/tsanet/receiver/storage/gcs/InMemoryGcsBucket.java
@@ -17,12 +17,14 @@ import java.util.Map;
 final class InMemoryGcsBucket implements GcsBucket {
 
     private final Map<String, byte[]> objects = new HashMap<>();
+    private final Map<String, String> attemptMarkers = new HashMap<>();
 
     /** When set, the named operation throws this instead of succeeding. */
     StorageException failCreate;
     StorageException failStartResumable;
     StorageException failFinish;
     StorageException failSizeOrAbsent;
+    StorageException failAttemptMarker;
     StorageException failDownload;
 
     /** Ambiguous-finish: commit the object, then throw {@link #failFinish}. */
@@ -37,10 +39,11 @@ final class InMemoryGcsBucket implements GcsBucket {
             throw failCreate;
         }
         objects.put(key, bytes.clone());
+        attemptMarkers.remove(key); // an unmarked single-request object
     }
 
     @Override
-    public Upload startResumable(String key, String contentType) {
+    public Upload startResumable(String key, String contentType, String attemptMarker) {
         if (failStartResumable != null) {
             throw failStartResumable;
         }
@@ -56,12 +59,17 @@ final class InMemoryGcsBucket implements GcsBucket {
             public void finish() {
                 if (failFinish != null) {
                     if (finishCommitsBeforeFailing) {
-                        objects.put(key, staged.toByteArray());
+                        commit();
                     }
                     throw failFinish;
                 }
-                // Visible only now: the resumable object appears on finalize.
+                commit();
+            }
+
+            /** Visible only now: the resumable object appears on finalize, marker included. */
+            private void commit() {
                 objects.put(key, staged.toByteArray());
+                attemptMarkers.put(key, attemptMarker);
             }
 
             @Override
@@ -79,6 +87,14 @@ final class InMemoryGcsBucket implements GcsBucket {
         }
         byte[] bytes = objects.get(key);
         return bytes == null ? -1 : bytes.length;
+    }
+
+    @Override
+    public String attemptMarkerOrAbsent(String key) {
+        if (failAttemptMarker != null) {
+            throw failAttemptMarker;
+        }
+        return attemptMarkers.get(key);
     }
 
     @Override

--- a/attachment-receiver/src/test/java/com/tsanet/receiver/storage/s3/S3AttachmentStorageLiveTest.java
+++ b/attachment-receiver/src/test/java/com/tsanet/receiver/storage/s3/S3AttachmentStorageLiveTest.java
@@ -10,11 +10,14 @@ import org.junit.jupiter.api.condition.EnabledIfEnvironmentVariable;
 import software.amazon.awssdk.services.s3.S3Client;
 
 import java.io.IOException;
+import java.io.ByteArrayInputStream;
 import java.io.InputStream;
 import java.util.UUID;
 
 import static com.tsanet.receiver.storage.s3.S3AttachmentStorage.PART_SIZE;
 import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
@@ -48,6 +51,25 @@ class S3AttachmentStorageLiveTest extends AttachmentStorageContractTest {
         s3.listMultipartUploads(b -> b.bucket(bucket).prefix(runPrefix)).uploads()
                 .forEach(u -> s3.abortMultipartUpload(
                         b -> b.bucket(bucket).key(u.key()).uploadId(u.uploadId())));
+    }
+
+    @Test
+    void completedMultipartObjectCarriesThisAttemptsMarkerAndSingleRequestObjectsDoNot() throws Exception {
+        // The fact tsanetgit/Connect_SDK#69's identity resolution rests on: user metadata
+        // given at CreateMultipartUpload lands on the completed object, and comes back from
+        // HEAD under the lowercase key. Proven here against the service, not the stub.
+        AttachmentStorage storage = newStorage();
+        var multipart = storage.store(new IncomingAttachment("01234567", "marked.bin", null, -1),
+                new ByteArrayInputStream(new byte[PART_SIZE + 1024]));
+        String marker = s3.headObject(b -> b.bucket(bucket).key(multipart.storageKey()))
+                .metadata().get(S3AttachmentStorage.ATTEMPT_METADATA_KEY);
+        assertNotNull(marker, "metadata from CreateMultipartUpload must be on the completed object");
+        UUID.fromString(marker); // a well-formed attempt id, or this throws
+        var single = storage.store(new IncomingAttachment("01234567", "small.bin", null, -1),
+                new ByteArrayInputStream(new byte[16]));
+        assertNull(s3.headObject(b -> b.bucket(bucket).key(single.storageKey()))
+                .metadata().get(S3AttachmentStorage.ATTEMPT_METADATA_KEY),
+                "single-request objects stay unmarked");
     }
 
     @Test

--- a/attachment-receiver/src/test/java/com/tsanet/receiver/storage/s3/S3AttachmentStorageTest.java
+++ b/attachment-receiver/src/test/java/com/tsanet/receiver/storage/s3/S3AttachmentStorageTest.java
@@ -188,6 +188,23 @@ class S3AttachmentStorageTest {
     }
 
     @Test
+    void ambiguousCompleteProbeFailureRidesAsSuppressedOnTheCompleteFailure() {
+        // The marker read itself fails: the store fails closed on the complete failure and
+        // the probe's own failure is not lost.
+        s3.failCompleteWith = () -> SdkClientException.create("response timed out (simulated)");
+        s3.completeCommitsDespiteFailure = false;
+        s3.failAbortWith = () -> NoSuchUploadException.builder().statusCode(404).build();
+        s3.failHeadWith = () -> S3Exception.builder().statusCode(500).message("head failed (simulated)").build();
+        AttachmentStorageException e = assertThrows(AttachmentStorageException.class,
+                () -> storage.store(attachment("probe.bin"), new ByteArrayInputStream(bytes(PART_SIZE + 5))));
+        assertTrue(e.getMessage().contains("complete"), e.getMessage());
+        assertEquals("response timed out (simulated)", e.getCause().getMessage());
+        assertTrue(java.util.Arrays.stream(e.getCause().getSuppressed())
+                        .anyMatch(t -> t.getMessage() != null && t.getMessage().contains("attempt marker read")),
+                "the probe failure must ride as suppressed on the complete failure");
+    }
+
+    @Test
     void ambiguousCompleteWithNoVisibleObjectStillThrows() {
         s3.failCompleteWith = () -> SdkClientException.create("response timed out (simulated)");
         s3.completeCommitsDespiteFailure = false;

--- a/attachment-receiver/src/test/java/com/tsanet/receiver/storage/s3/S3AttachmentStorageTest.java
+++ b/attachment-receiver/src/test/java/com/tsanet/receiver/storage/s3/S3AttachmentStorageTest.java
@@ -154,6 +154,40 @@ class S3AttachmentStorageTest {
     }
 
     @Test
+    void ambiguousCompleteOverAPreExistingSameSizeObjectThrows() throws Exception {
+        // The false-positive shape a visibility or size probe cannot see: an older object of
+        // the same name and length is already there, the session merely expired
+        // (abort -> NoSuchUpload), and this complete never committed.
+        int size = PART_SIZE + 5;
+        byte[] older = bytes(size);
+        storage.store(attachment("same-size.bin"), new ByteArrayInputStream(older));
+        byte[] newer = bytes(size);
+        newer[0] = (byte) 0xFF;
+        s3.failCompleteWith = () -> SdkClientException.create("response timed out (simulated)");
+        s3.completeCommitsDespiteFailure = false;
+        s3.failAbortWith = () -> NoSuchUploadException.builder().statusCode(404).build();
+        assertThrows(AttachmentStorageException.class,
+                () -> storage.store(attachment("same-size.bin"), new ByteArrayInputStream(newer)),
+                "an older same-size object must not be mistaken for this attempt's commit");
+        assertArrayEquals(older, s3.objects.get("01234567/same-size.bin"), "the older object is untouched");
+    }
+
+    @Test
+    void ambiguousCompleteOverAnUnmarkedSingleRequestObjectThrows() throws Exception {
+        // PutObject objects carry no marker on purpose: a later attempt's ambiguous complete
+        // over one must fail closed, never adopt it as its own commit.
+        byte[] older = bytes(64);
+        storage.store(attachment("unmarked.bin"), new ByteArrayInputStream(older));
+        assertFalse(s3.objectMetadata.containsKey("01234567/unmarked.bin"), "single-request objects stay unmarked");
+        s3.failCompleteWith = () -> SdkClientException.create("response timed out (simulated)");
+        s3.completeCommitsDespiteFailure = false;
+        s3.failAbortWith = () -> NoSuchUploadException.builder().statusCode(404).build();
+        assertThrows(AttachmentStorageException.class,
+                () -> storage.store(attachment("unmarked.bin"), new ByteArrayInputStream(bytes(PART_SIZE + 5))));
+        assertArrayEquals(older, s3.objects.get("01234567/unmarked.bin"), "the older object is untouched");
+    }
+
+    @Test
     void ambiguousCompleteWithNoVisibleObjectStillThrows() {
         s3.failCompleteWith = () -> SdkClientException.create("response timed out (simulated)");
         s3.completeCommitsDespiteFailure = false;

--- a/attachment-receiver/src/test/java/com/tsanet/receiver/storage/s3/StubS3Client.java
+++ b/attachment-receiver/src/test/java/com/tsanet/receiver/storage/s3/StubS3Client.java
@@ -31,6 +31,7 @@ import java.io.UncheckedIOException;
 import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
+import java.util.Locale;
 import java.util.Map;
 import java.util.TreeMap;
 import java.util.function.Supplier;
@@ -43,7 +44,10 @@ import java.util.function.Supplier;
 final class StubS3Client implements S3Client {
 
     final Map<String, byte[]> objects = new HashMap<>();
+    /** User metadata per committed key; keys lowercased the way S3 returns them. */
+    final Map<String, Map<String, String>> objectMetadata = new HashMap<>();
     final Map<String, TreeMap<Integer, byte[]>> pendingUploads = new HashMap<>();
+    private final Map<String, Map<String, String>> pendingMetadata = new HashMap<>();
     final List<String> calls = new ArrayList<>();
 
     Supplier<RuntimeException> failPutWith;
@@ -63,6 +67,7 @@ final class StubS3Client implements S3Client {
             throw failPutWith.get();
         }
         objects.put(request.key(), toBytes(body));
+        objectMetadata.remove(request.key()); // an unmarked single-request object
         return PutObjectResponse.builder().build();
     }
 
@@ -71,6 +76,9 @@ final class StubS3Client implements S3Client {
         String uploadId = "upload-" + (++uploadCounter) + ":" + request.key();
         calls.add("createMultipart:" + request.key());
         pendingUploads.put(uploadId, new TreeMap<>());
+        Map<String, String> lowercased = new HashMap<>();
+        request.metadata().forEach((k, v) -> lowercased.put(k.toLowerCase(Locale.ROOT), v));
+        pendingMetadata.put(uploadId, lowercased);
         return CreateMultipartUploadResponse.builder().uploadId(uploadId).build();
     }
 
@@ -102,6 +110,8 @@ final class StubS3Client implements S3Client {
         ByteArrayOutputStream whole = new ByteArrayOutputStream();
         parts.values().forEach(p -> whole.writeBytes(p));
         objects.put(key, whole.toByteArray());
+        // Metadata given at initiation lands on the completed object, as on S3.
+        objectMetadata.put(key, pendingMetadata.remove(uploadId));
     }
 
     @Override
@@ -123,7 +133,10 @@ final class StubS3Client implements S3Client {
         if (!objects.containsKey(request.key())) {
             throw NoSuchKeyException.builder().statusCode(404).build();
         }
-        return HeadObjectResponse.builder().contentLength((long) objects.get(request.key()).length).build();
+        return HeadObjectResponse.builder()
+                .contentLength((long) objects.get(request.key()).length)
+                .metadata(objectMetadata.getOrDefault(request.key(), Map.of()))
+                .build();
     }
 
     @Override


### PR DESCRIPTION
Closes `tsanetgit/Connect_SDK#69` (epic `tsanetgit/Connect_SDK#46`). Disclosed as a known parity caveat in `tsanetgit/Connect_SDK#68`; the Azure Blob adapter (`tsanetgit/Connect_SDK#72`) shipped the identity approach first, this brings S3 and GCS to the same guarantee.

**Account-hygiene rule, binding for this public repo:** no account, bucket, or credential identifier appears here.

## The gap, and the option taken

Both adapters resolved an ambiguous finalize (the client-side `CompleteMultipartUpload` or resumable `finish` fails after the server may have committed) with a probe the wrong object could satisfy: on S3, "abort answers `NoSuchUpload` and the key is visible"; on GCS, "the object is visible at exactly the byte count written". Because `store` overwrites a same-name object, an older object of the same size plus a finalize that never committed read as success while the stale bytes stayed.

Of the three options in the issue, this is **option 1, identity by a per-attempt marker**. Each multipart or resumable attempt is stamped with a UUID as object metadata (`tsanet-upload-attempt`) at initiation, which both services store on the completed object, and the probe requires the visible object's marker to equal this attempt's. Why not the others: option 2 (generation or ETag changed) still reports success when a *concurrent* writer committed instead of us, whereas identity fails closed there too; option 3 (checksum) breaks silently on SSE-KMS buckets, where the S3 ETag is not the content hash. Identity also mirrors the Blob adapter's block-list resolution, so all three adapters now answer the ambiguous case the same way.

## What changed

- **S3.** The UUID goes on `CreateMultipartUpload` as user metadata. `resolveAmbiguousComplete` keeps the abort step (still the cleanup call for a live session) and, on `NoSuchUpload`, requires a HEAD of the key to return this attempt's marker. The new `attemptMarkerOrAbsent` keeps `existsKey`'s 404 discrimination: an absent key is a definite "not this attempt", not a probe error. The key constant is lowercase because S3 returns user-metadata keys lowercased.
- **GCS.** The seam widens: `startResumable` carries the marker as custom metadata on the `BlobInfo` the session opens with; `attemptMarkerOrAbsent` reads it back with both null guards (absent object, no metadata); `sizeOrAbsent` stays for `exists`. `resolveAmbiguousFinish` compares identity and drops the size comparison. `SdkGcsBucket` stays logic-free.
- **Single-request objects stay unmarked on purpose** (`PutObject`, `create`). A later attempt's ambiguous finalize over one then finds no marker and fails closed, which is right. Both javadocs say so, and a test per adapter makes it true.
- **Doubles.** `StubS3Client` lowercases metadata keys at initiation, commits them on both commit branches (including commit-despite-failure), and returns them from `HeadObject`. `InMemoryGcsBucket` records the marker on both finish branches. Those are what keep the existing committed-ambiguous tests green with no edits.
- **Javadoc, three files.** The S3 policy paragraph, the GCS bullet including its "cannot distinguish a concurrent same-name writer" parenthetical (now false: it fails closed), and the Blob adapter's cross-reference that said S3 and GCS resolve by size.

## Verification

- Offline, `mvn -pl attachment-receiver -am test`: **182 run, 0 failures, 40 skipped** (was 174 / 0 / 38 at `main`; the extra skips are the new S3 and GCS live tests without their env vars). Four new tests, two per adapter: an older same-size object plus a finalize that never committed (S3 variant with abort answering `NoSuchUpload`, the expired-session shape), and an older *unmarked* single-request object plus the same. Each asserts the store throws and the older bytes are untouched. The existing committed-ambiguous tests are unchanged and green.
- **Red probe.** With the two old predicates temporarily restored (`existsKey(key)` on S3, `sizeOrAbsent(key) == total` on GCS), three tests fail with "expected `AttachmentStorageException`, nothing thrown": both S3 tests and the GCS same-size test (QA re-ran the probe and counted the same three). The GCS unmarked test stays green under the old predicate because its 64-byte older object already differs in size from a multi-buffer attempt; it pins the unmarked policy rather than the mechanism. The patch was then re-applied. The tests discriminate the defect, not a proxy.
- **S3, run live.** `S3AttachmentStorageLiveTest` against a disposable bucket in a private test account: **9 / 9**. The 7 shared-contract tests, abort-after-partial-commit, and a new test, `completedMultipartObjectCarriesThisAttemptsMarkerAndSingleRequestObjectsDoNot`, which is the fact this design rests on observed against the service: user metadata given at `CreateMultipartUpload` comes back from `HeadObject` on the completed object under the lowercase key, and a `PutObject` object carries no marker. The doc sentences it confirms, from the S3 multipart overview read today: "If you want to provide metadata describing the object being uploaded, you must provide it in the request to initiate the multipart upload" and "Amazon S3 associates that metadata with the object."
- **GCS, not run live, stated plainly.** There are no GCS credentials on the build machine. The propagation fact is cited from the GCS resumable-upload guide (the initial POST of the session carries the object metadata) and the SDK surface confirmed by `javap` (`BlobInfo.Builder.setMetadata(Map)`, `BlobInfo.getMetadata()`). The env-gated mirror test `completedResumableObjectCarriesThisAttemptsMarkerAndSingleRequestObjectsDoNot` is now in `GcsAttachmentStorageLiveTest`, so the follow-up is "set `GCS_CONTRACT_TEST_BUCKET` and run".

## Observable side effect

Every multipart or resumable object now permanently carries the `tsanet-upload-attempt` metadata entry. It is a non-secret UUID; anything downstream that enumerates object metadata will see it.

## Prose claims and the lines that make them true

| claim | line |
|---|---|
| Same-size older object fails closed | `ambiguousCompleteOverAPreExistingSameSizeObjectThrows`, `ambiguousFinishOverAPreExistingSameSizeObjectThrows` (both red-probed) |
| Unmarked single-request object fails closed | `ambiguousCompleteOverAnUnmarkedSingleRequestObjectThrows`, `ambiguousFinishOverAnUnmarkedSingleRequestObjectThrows` |
| Committed-ambiguous still succeeds | existing `ambiguousCompleteThatActuallyCommittedIsReportedAsSuccess`, `ambiguousFinishThatActuallyCommittedIsReportedAsSuccess`, unchanged |
| Marker is on the completed object | S3: live `completedMultipartObjectCarriesThisAttemptsMarkerAndSingleRequestObjectsDoNot`; GCS: vendor doc above; the doubles model it on both commit branches |
| S3 keys come back lowercased | constant is lowercase; the stub lowercases at initiation so stub and live agree |
| Absent key is not a probe error | `attemptMarkerOrAbsent` 404 branch returns null, same as `existsKey` |

## Blast radius (`pre-pr-artifacts.py`, base `origin/main`)

No mechanical detector fired. Judgment lines:

- **Guard vs representation.** This *is* the representation change: the probe now compares an identity the attempt owns instead of a property (size, visibility) any object can have.
- **Third or later fix to one class.** First fix; the caveat was disclosed in #68 and tracked as #69.
- **Newly reachable failure.** The marker read is a new HEAD (S3) or get (GCS) on the ambiguous path only; failures ride as suppressed on the finalize failure and surface as `AttachmentStorageException` toward the ingest path, the same handler as before.
- **Abstraction / schema / stored shape.** `GcsBucket` gained a parameter and a method; both implementations are in the diff and the seam is package-private with no other consumers (`grep -rn 'startResumable\|GcsBucket' src` shows only the adapter, the SDK implementation, and the double). Object metadata is additive; pre-existing objects have no marker and are treated as "not this attempt", which is the fail-closed outcome.

## Advisor and gate

Advisor consulted twice. Orientation: confirmed option 1 over 2 and 3 with the reasons above, keep the S3 abort as cleanup, lowercase the S3 key and make the stub lowercase too, commit the marker on both commit-despite-failure branches, update the GCS concurrent-writer parenthetical. Pre-done: required the red probe to be observed rather than expected, and the two unmarked-object tests to make the javadoc claim true; both done. Pre-PR gate: **LOOKS GOOD**, first run. Review is CI plus a QA-persona pass from a separate session.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
