### PR TITLE
connect-library: V2 attachment client (grant, upload, complete, abandon) with demo and console (#76)

### DIFF
--- a/TSANet-integration-app/src/main/java/com/tsanet/facade/cli/CollaborationRequestAttachmentDeliverExecutor.java
+++ b/TSANet-integration-app/src/main/java/com/tsanet/facade/cli/CollaborationRequestAttachmentDeliverExecutor.java
@@ -1,0 +1,84 @@
+package com.tsanet.facade.cli;
+
+import com.tsanet.api.TsaNetApiSession;
+import com.tsanet.api.attachments.v2.AttachmentCompleteResult;
+import com.tsanet.api.attachments.v2.AttachmentV2Exception;
+import com.tsanet.api.connectapi.dto.CollaborationRequestStatusDto;
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.Arrays;
+import java.util.List;
+import java.util.Scanner;
+import org.springframework.stereotype.Component;
+
+/**
+ * {@code deliver-attachment}: one file to the partner on the direct path (V2). Prints the
+ * grant's mode and per-part progress as the upload runs, then the platform's recorded
+ * outcome, in the platform's own words.
+ */
+@Component
+public class CollaborationRequestAttachmentDeliverExecutor {
+    private final TsaNetApiSession session;
+    private final CollaborationRequestResolver requestResolver;
+
+    public CollaborationRequestAttachmentDeliverExecutor(
+        TsaNetApiSession session,
+        CollaborationRequestResolver requestResolver
+    ) {
+        this.session = session;
+        this.requestResolver = requestResolver;
+    }
+
+    public void execute(String[] args, Scanner scanner, CliRunContext cliRunContext) {
+        requestResolver.requireAuthentication();
+        CollaborationRequestStatusDto request = requestResolver.resolve(args);
+
+        List<String> files = CliArgs.files(args);
+        if (files.size() != 1) {
+            System.out.println(EntityPrinter.error(cliRunContext, "Provide exactly one --file PATH (one grant delivers one file)"));
+            return;
+        }
+        Path file = Path.of(files.get(0));
+        if (!Files.isRegularFile(file)) {
+            System.out.println(EntityPrinter.error(cliRunContext, "Attachment path is not a regular file: " + file));
+            return;
+        }
+        String description = CliArgs.description(args).orElse(null);
+        boolean sha256 = Arrays.asList(args).contains("--sha256");
+        String contentType = probeContentType(file);
+
+        System.out.println(EntityPrinter.info(cliRunContext, "Delivering " + file.getFileName()
+            + " to the partner on request id=" + request.id() + " token=" + request.token()));
+        try {
+            AttachmentCompleteResult outcome = session.attachmentsV2().send(
+                request.token(),
+                file,
+                contentType,
+                description,
+                sha256,
+                progress -> System.out.println(EntityPrinter.info(cliRunContext, progress.mode() + ": "
+                    + progress.partsDone() + "/" + progress.partsTotal() + " parts, "
+                    + progress.bytesSent() + " of " + progress.bytesTotal() + " bytes"))
+            );
+            System.out.println(EntityPrinter.info(cliRunContext, "Platform outcome: " + outcome.status()
+                + (outcome.verification() != null && outcome.verification().method() != null
+                    ? " (verified by " + outcome.verification().method() + ")" : "")
+                + (outcome.noteId() != null ? ", case note " + outcome.noteId() : "")
+                + (outcome.message() != null ? " - " + outcome.message() : "")));
+        } catch (AttachmentV2Exception ex) {
+            System.out.println(EntityPrinter.error(cliRunContext, "Delivery failed: " + ex.getMessage()));
+        } catch (IllegalArgumentException | IllegalStateException ex) {
+            System.out.println(EntityPrinter.error(cliRunContext, ex.getMessage()));
+        }
+    }
+
+    private static String probeContentType(Path file) {
+        try {
+            String probed = Files.probeContentType(file);
+            return probed == null ? "application/octet-stream" : probed;
+        } catch (IOException e) {
+            return "application/octet-stream";
+        }
+    }
+}

--- a/TSANet-integration-app/src/main/java/com/tsanet/facade/cli/commands/DeliverAttachmentCommand.java
+++ b/TSANet-integration-app/src/main/java/com/tsanet/facade/cli/commands/DeliverAttachmentCommand.java
@@ -1,0 +1,40 @@
+package com.tsanet.facade.cli.commands;
+
+import com.tsanet.facade.cli.CliRunContext;
+import com.tsanet.facade.cli.CollaborationRequestAttachmentDeliverExecutor;
+import com.tsanet.facade.cli.EntityPrinter;
+import java.util.Scanner;
+import org.springframework.stereotype.Component;
+
+@Component
+public class DeliverAttachmentCommand implements Command {
+    private final CollaborationRequestAttachmentDeliverExecutor deliverExecutor;
+    private final CliRunContext cliRunContext;
+
+    public DeliverAttachmentCommand(
+        CollaborationRequestAttachmentDeliverExecutor deliverExecutor,
+        CliRunContext cliRunContext
+    ) {
+        this.deliverExecutor = deliverExecutor;
+        this.cliRunContext = cliRunContext;
+    }
+
+    @Override
+    public String name() {
+        return "deliver-attachment";
+    }
+
+    @Override
+    public String description() {
+        return "Deliver one file to the partner on the direct path, V2 (--id/--token, --file PATH, --description TEXT, --sha256)";
+    }
+
+    @Override
+    public void execute(String[] args, Scanner scanner) {
+        try {
+            deliverExecutor.execute(args, scanner, cliRunContext);
+        } catch (Exception ex) {
+            System.out.println(EntityPrinter.error(cliRunContext, "Failed: " + ex.getMessage()));
+        }
+    }
+}

--- a/connect-library/src/main/java/com/tsanet/api/TsaNetApiSession.java
+++ b/connect-library/src/main/java/com/tsanet/api/TsaNetApiSession.java
@@ -1,6 +1,7 @@
 package com.tsanet.api;
 
 import com.tsanet.api.facade.AttachmentsFacade;
+import com.tsanet.api.facade.AttachmentsV2Facade;
 import com.tsanet.api.facade.AuthFacade;
 import com.tsanet.api.facade.CaseNotesFacade;
 import com.tsanet.api.facade.CaseResponsesFacade;
@@ -25,4 +26,7 @@ public interface TsaNetApiSession {
     PartnersFacade partners();
 
     AttachmentsFacade attachments();
+
+    /** The V2 direct-delivery attachment client (tsanetgit/Connect-API-Code#147). */
+    AttachmentsV2Facade attachmentsV2();
 }

--- a/connect-library/src/main/java/com/tsanet/api/attachments/v2/AttachmentCompleteRequest.java
+++ b/connect-library/src/main/java/com/tsanet/api/attachments/v2/AttachmentCompleteRequest.java
@@ -1,0 +1,25 @@
+package com.tsanet.api.attachments.v2;
+
+import com.fasterxml.jackson.annotation.JsonInclude;
+import java.util.List;
+
+/**
+ * Body of {@code POST .../grants/{grantId}/complete}: what the client uploaded, from the
+ * {@code AttachmentCompleteRequestDTO} schema (tsanetgit/Connect-API-Code#147). Empty
+ * collections and nulls are omitted on the wire, so a single-mode complete carries only
+ * {@code sizeBytes}.
+ *
+ * @param sizeBytes the byte count actually sent
+ * @param sha256    the digest supplied on grant, if any
+ * @param parts     multipart mode only: the receipts the provider returned, in part order
+ */
+@JsonInclude(JsonInclude.Include.NON_EMPTY)
+public record AttachmentCompleteRequest(long sizeBytes, String sha256, List<PartReceipt> parts) {
+    public AttachmentCompleteRequest {
+        parts = parts == null ? List.of() : List.copyOf(parts);
+    }
+
+    /** An ETag (S3), block id (Azure) or the provider's equivalent, forwarded exactly as received. */
+    public record PartReceipt(int partNumber, String receipt) {
+    }
+}

--- a/connect-library/src/main/java/com/tsanet/api/attachments/v2/AttachmentCompleteResult.java
+++ b/connect-library/src/main/java/com/tsanet/api/attachments/v2/AttachmentCompleteResult.java
@@ -1,0 +1,40 @@
+package com.tsanet.api.attachments.v2;
+
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import java.time.OffsetDateTime;
+import java.util.UUID;
+
+/**
+ * The platform's recorded outcome for a grant, from the {@code AttachmentCompleteResultDTO}
+ * schema (tsanetgit/Connect-API-Code#147). {@code status} is the platform's word, never the
+ * client's: {@code DELIVERED}, {@code DELIVERED_UNVERIFIED}, {@code FAILED} or {@code EXPIRED}.
+ * A client that uploaded every byte without error still reports whatever this says.
+ */
+@JsonIgnoreProperties(ignoreUnknown = true)
+public record AttachmentCompleteResult(
+    UUID grantId,
+    String fileName,
+    String status,
+    VerificationResult verification,
+    Long noteId,
+    String message
+) {
+    public static final String DELIVERED = "DELIVERED";
+    public static final String DELIVERED_UNVERIFIED = "DELIVERED_UNVERIFIED";
+    public static final String FAILED = "FAILED";
+    public static final String EXPIRED = "EXPIRED";
+
+    /** True only for a platform-verified delivery. */
+    public boolean delivered() {
+        return DELIVERED.equals(status);
+    }
+
+    /** True when the sender reported completion and the platform could not verify arrival. */
+    public boolean deliveredUnverified() {
+        return DELIVERED_UNVERIFIED.equals(status);
+    }
+
+    @JsonIgnoreProperties(ignoreUnknown = true)
+    public record VerificationResult(String method, OffsetDateTime verifiedAt, Boolean sizeMatched, Boolean checksumMatched) {
+    }
+}

--- a/connect-library/src/main/java/com/tsanet/api/attachments/v2/AttachmentGrant.java
+++ b/connect-library/src/main/java/com/tsanet/api/attachments/v2/AttachmentGrant.java
@@ -1,0 +1,69 @@
+package com.tsanet.api.attachments.v2;
+
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import java.time.OffsetDateTime;
+import java.util.List;
+import java.util.Map;
+import java.util.UUID;
+
+/**
+ * A grant: permission plus upload instructions for one file on one case, from the
+ * {@code AttachmentGrantDTO} schema of the V2 contract draft (tsanetgit/Connect-API-Code#147).
+ * The client executes {@link Upload} verbatim and never branches on the receiver.
+ *
+ * <p>{@code toString} on every record that carries a URL or headers is redacted: signed URLs
+ * and the headers block are credentials, and a record's default {@code toString} would put
+ * them into any log line or exception message that interpolates the grant.
+ */
+@JsonIgnoreProperties(ignoreUnknown = true)
+public record AttachmentGrant(
+    UUID grantId,
+    String fileName,
+    OffsetDateTime expiresAt,
+    Receiver receiver,
+    Upload upload,
+    Verification verification
+) {
+    @Override
+    public String toString() {
+        return "AttachmentGrant[grantId=" + grantId + ", fileName=" + fileName + ", expiresAt=" + expiresAt
+            + ", receiver=" + receiver + ", upload=" + upload + ", verification=" + verification + "]";
+    }
+
+    /** What the platform echoes about the receiver so a client can fail fast. */
+    @JsonIgnoreProperties(ignoreUnknown = true)
+    public record Receiver(Long companyId, String targetKind, Long maxSizeBytes) {
+    }
+
+    /**
+     * The upload instructions. {@code mode} is one of {@code single}, {@code multipart},
+     * {@code resumable}, {@code relay}; {@code headers} are sent verbatim on every request.
+     */
+    @JsonIgnoreProperties(ignoreUnknown = true)
+    public record Upload(String mode, String method, String url, Map<String, String> headers, List<Part> parts) {
+        public Upload {
+            headers = headers == null ? Map.of() : Map.copyOf(headers);
+            parts = parts == null ? List.of() : List.copyOf(parts);
+        }
+
+        @Override
+        public String toString() {
+            return "Upload[mode=" + mode + ", method=" + method + ", url=<redacted>, headers="
+                + headers.keySet() + ", parts=" + parts.size() + "]";
+        }
+    }
+
+    /** One presigned part URL in multipart mode; sizes are fixed by the platform. */
+    @JsonIgnoreProperties(ignoreUnknown = true)
+    public record Part(int partNumber, String url, long sizeBytes) {
+        @Override
+        public String toString() {
+            return "Part[partNumber=" + partNumber + ", url=<redacted>, sizeBytes=" + sizeBytes + "]";
+        }
+    }
+
+    /** What complete will be able to prove: {@code platform}, {@code receiver_reported} or {@code none}. */
+    @JsonIgnoreProperties(ignoreUnknown = true)
+    public record Verification(String mode) {
+    }
+}

--- a/connect-library/src/main/java/com/tsanet/api/attachments/v2/AttachmentGrantRequest.java
+++ b/connect-library/src/main/java/com/tsanet/api/attachments/v2/AttachmentGrantRequest.java
@@ -1,0 +1,37 @@
+package com.tsanet.api.attachments.v2;
+
+import com.fasterxml.jackson.annotation.JsonInclude;
+
+/**
+ * Body of {@code POST /v2/collaboration-requests/{token}/attachments/grants}: one file the
+ * sender wants to deliver to the partner on this case. Field names follow the
+ * {@code AttachmentGrantRequestDTO} schema of the V2 contract draft
+ * (tsanetgit/Connect-API-Code#147) exactly, so this record can be replaced by the generated
+ * class once the contract lands in the OpenAPI spec.
+ *
+ * @param fileName    the file's name as the partner will see it (max 255)
+ * @param contentType the file's media type (max 255)
+ * @param sizeBytes   the declared byte count, at least 1; enforced by the signed upload
+ * @param sha256      optional hex digest, verified on complete where the target supports it
+ * @param description optional text carried into the case note
+ */
+@JsonInclude(JsonInclude.Include.NON_NULL)
+public record AttachmentGrantRequest(
+    String fileName,
+    String contentType,
+    long sizeBytes,
+    String sha256,
+    String description
+) {
+    public AttachmentGrantRequest {
+        if (fileName == null || fileName.isBlank()) {
+            throw new IllegalArgumentException("fileName must not be blank");
+        }
+        if (contentType == null || contentType.isBlank()) {
+            throw new IllegalArgumentException("contentType must not be blank");
+        }
+        if (sizeBytes < 1) {
+            throw new IllegalArgumentException("sizeBytes must be at least 1, got " + sizeBytes);
+        }
+    }
+}

--- a/connect-library/src/main/java/com/tsanet/api/attachments/v2/AttachmentV2Exception.java
+++ b/connect-library/src/main/java/com/tsanet/api/attachments/v2/AttachmentV2Exception.java
@@ -1,0 +1,62 @@
+package com.tsanet.api.attachments.v2;
+
+/**
+ * Any failure on the V2 attachment path: a problem-details answer from the Connect API, a
+ * rejected or failed upload request, or a client-side precondition. The message is
+ * value-free by construction: it carries the HTTP status, the problem type, and the
+ * platform's own title and detail, never a signed URL, a header value or a token.
+ *
+ * <p>{@link #problemType()} is the relative {@code type} URI from the contract
+ * (tsanetgit/Connect-API-Code#147), for example {@code attachment/grant-expired}; the
+ * {@code UPLOAD_*} and {@code CLIENT_*} constants are this client's own types for failures
+ * that never reach the platform.
+ */
+public class AttachmentV2Exception extends RuntimeException {
+
+    public static final String GRANT_EXPIRED = "attachment/grant-expired";
+    public static final String GRANT_ALREADY_COMPLETED = "attachment/grant-already-completed";
+    public static final String UPLOAD_NOT_FOUND = "attachment/upload-not-found";
+    public static final String SIZE_MISMATCH = "attachment/size-mismatch";
+    public static final String CHECKSUM_MISMATCH = "attachment/checksum-mismatch";
+    public static final String RECEIVER_NOT_CONFIGURED = "attachment/receiver-not-configured";
+    public static final String SIZE_EXCEEDS_RECEIVER_LIMIT = "attachment/size-exceeds-receiver-limit";
+
+    /** The storage or relay answered a signed upload request with a non-2xx status. */
+    public static final String UPLOAD_REJECTED = "client/upload-rejected";
+    /** The upload could not reach the storage or relay after the retry budget. */
+    public static final String UPLOAD_UNREACHABLE = "client/upload-unreachable";
+    /** The grant's {@code upload.mode} is not one this client implements. */
+    public static final String UNSUPPORTED_UPLOAD_MODE = "client/unsupported-upload-mode";
+    /** A client-side precondition failed (file size, missing part receipts, unreadable file). */
+    public static final String CLIENT_PRECONDITION = "client/precondition";
+    /** The Connect API could not be reached at all. */
+    public static final String CONNECTIVITY = "client/connectivity";
+
+    private final int status;
+    private final String problemType;
+
+    public AttachmentV2Exception(String message, int status, String problemType) {
+        this(message, status, problemType, null);
+    }
+
+    public AttachmentV2Exception(String message, int status, String problemType, Throwable cause) {
+        super(message, cause);
+        this.status = status;
+        this.problemType = problemType;
+    }
+
+    /** HTTP status of the failing response, or 0 when no response was received. */
+    public int status() {
+        return status;
+    }
+
+    /** The relative problem type, or one of this class's {@code client/...} constants. */
+    public String problemType() {
+        return problemType;
+    }
+
+    /** Whether {@link #problemType()} is (or ends with) the given contract type. */
+    public boolean isProblem(String type) {
+        return problemType != null && (problemType.equals(type) || problemType.endsWith("/" + type));
+    }
+}

--- a/connect-library/src/main/java/com/tsanet/api/attachments/v2/UploadProgress.java
+++ b/connect-library/src/main/java/com/tsanet/api/attachments/v2/UploadProgress.java
@@ -1,0 +1,8 @@
+package com.tsanet.api.attachments.v2;
+
+/**
+ * A progress snapshot: parts (or chunks) done of total, and bytes sent of total. Single and
+ * relay uploads report one part.
+ */
+public record UploadProgress(String mode, int partsDone, int partsTotal, long bytesSent, long bytesTotal) {
+}

--- a/connect-library/src/main/java/com/tsanet/api/attachments/v2/UploadProgressListener.java
+++ b/connect-library/src/main/java/com/tsanet/api/attachments/v2/UploadProgressListener.java
@@ -1,0 +1,9 @@
+package com.tsanet.api.attachments.v2;
+
+/** Receives {@link UploadProgress} snapshots as an upload advances; called on the uploading thread. */
+@FunctionalInterface
+public interface UploadProgressListener {
+    UploadProgressListener NONE = progress -> { };
+
+    void onProgress(UploadProgress progress);
+}

--- a/connect-library/src/main/java/com/tsanet/api/attachments/v2/UploadReceipts.java
+++ b/connect-library/src/main/java/com/tsanet/api/attachments/v2/UploadReceipts.java
@@ -1,0 +1,13 @@
+package com.tsanet.api.attachments.v2;
+
+import java.util.List;
+
+/**
+ * What an executed upload produced: the mode that ran, the bytes sent, and in multipart mode
+ * the provider's receipts in part order. Feeds {@link AttachmentCompleteRequest}.
+ */
+public record UploadReceipts(String mode, long bytesSent, List<AttachmentCompleteRequest.PartReceipt> parts) {
+    public UploadReceipts {
+        parts = parts == null ? List.of() : List.copyOf(parts);
+    }
+}

--- a/connect-library/src/main/java/com/tsanet/api/connectapi/internal/AttachmentUploadExecutor.java
+++ b/connect-library/src/main/java/com/tsanet/api/connectapi/internal/AttachmentUploadExecutor.java
@@ -63,6 +63,13 @@ import java.util.concurrent.atomic.AtomicLong;
  * upload failure rather than re-granting on its own. Bodies are re-created per attempt from
  * the file region, so a retry never re-reads a consumed stream.
  *
+ * <p><b>URL scheme.</b> Upload URLs are executed as the platform returned them, {@code http}
+ * included: the contract's rule is that the client executes the block verbatim and never
+ * branches on the receiver, and these URLs come from the authenticated platform per grant,
+ * short-lived, not from operator configuration (where this repo does enforce https, since a
+ * pasted SAS URL is a standing credential). Rejecting a scheme here would also reject the
+ * relay and any test host the platform chooses to point at.
+ *
  * <p>Nothing here announces anything: the caller completes or abandons the grant.
  */
 final class AttachmentUploadExecutor {
@@ -118,7 +125,11 @@ final class AttachmentUploadExecutor {
                                   UploadProgressListener progress, boolean relay) {
         String mode = relay ? "relay" : "single";
         requireUrl(upload.url(), mode);
-        HttpRequest request = put(upload.url(), headers, new FileRegionPublisher(file, 0, size), size);
+        // Byte-level progress as the body streams (position within the region, so a retry
+        // truthfully restarts from zero), throttled to whole MiB; the final report says done.
+        FileRegionPublisher body = new FileRegionPublisher(file, 0, size, sent ->
+            progress.onProgress(new UploadProgress(mode, 0, 1, sent, size)));
+        HttpRequest request = put(upload.url(), headers, body, size);
         sendWithRetry(request, relay ? RetryScope.CONNECT_ONLY : RetryScope.TRANSIENT, mode + " upload");
         progress.onProgress(new UploadProgress(mode, 1, 1, size, size));
         return new UploadReceipts(mode, size, List.of());
@@ -131,6 +142,9 @@ final class AttachmentUploadExecutor {
             throw precondition("multipart grant carries no parts");
         }
         parts.sort(Comparator.comparingInt(AttachmentGrant.Part::partNumber));
+        if (parts.stream().mapToInt(AttachmentGrant.Part::partNumber).distinct().count() != parts.size()) {
+            throw precondition("multipart grant repeats a part number; the regions would overlap");
+        }
         long declared = parts.stream().mapToLong(AttachmentGrant.Part::sizeBytes).sum();
         if (declared != size) {
             throw precondition("multipart parts total " + declared + " bytes but the file is " + size + " bytes");
@@ -290,7 +304,7 @@ final class AttachmentUploadExecutor {
             AttachmentV2Exception.UPLOAD_REJECTED);
     }
 
-    private Duration backoff(int attempt, Optional<String> retryAfter) {
+    Duration backoff(int attempt, Optional<String> retryAfter) {
         if (retryAfter.isPresent()) {
             try {
                 long seconds = Long.parseLong(retryAfter.get().trim());
@@ -369,14 +383,23 @@ final class AttachmentUploadExecutor {
      * Single-subscriber, demand-driven, {@value #READ_BUFFER}-byte reads.
      */
     static final class FileRegionPublisher implements HttpRequest.BodyPublisher {
+        private static final long PROGRESS_STEP = 1024 * 1024;
+
         private final Path file;
         private final long offset;
         private final long length;
+        private final java.util.function.LongConsumer onBytes;
 
         FileRegionPublisher(Path file, long offset, long length) {
+            this(file, offset, length, null);
+        }
+
+        /** {@code onBytes} receives the bytes read so far in this subscription, once per whole MiB. */
+        FileRegionPublisher(Path file, long offset, long length, java.util.function.LongConsumer onBytes) {
             this.file = file;
             this.offset = offset;
             this.length = length;
+            this.onBytes = onBytes;
         }
 
         @Override
@@ -455,11 +478,16 @@ final class AttachmentUploadExecutor {
                             fail(new IOException("file ended " + remaining + " bytes before the declared region did"));
                             return;
                         }
+                        long before = position - offset;
                         position += read;
                         remaining -= read;
                         buffer.flip();
                         demand.decrementAndGet();
                         subscriber.onNext(buffer);
+                        long after = position - offset;
+                        if (onBytes != null && after / PROGRESS_STEP != before / PROGRESS_STEP) {
+                            onBytes.accept(after);
+                        }
                     }
                     if (!cancelled && !terminated && remaining == 0) {
                         terminated = true;
@@ -471,7 +499,7 @@ final class AttachmentUploadExecutor {
             }
 
             private void fail(Throwable error) {
-                if (terminated) {
+                if (terminated || cancelled) {
                     return;
                 }
                 terminated = true;

--- a/connect-library/src/main/java/com/tsanet/api/connectapi/internal/AttachmentUploadExecutor.java
+++ b/connect-library/src/main/java/com/tsanet/api/connectapi/internal/AttachmentUploadExecutor.java
@@ -1,0 +1,491 @@
+package com.tsanet.api.connectapi.internal;
+
+import com.tsanet.api.attachments.v2.AttachmentCompleteRequest.PartReceipt;
+import com.tsanet.api.attachments.v2.AttachmentGrant;
+import com.tsanet.api.attachments.v2.AttachmentV2Exception;
+import com.tsanet.api.attachments.v2.UploadProgress;
+import com.tsanet.api.attachments.v2.UploadProgressListener;
+import com.tsanet.api.attachments.v2.UploadReceipts;
+import java.io.IOException;
+import java.net.ConnectException;
+import java.net.URI;
+import java.net.http.HttpClient;
+import java.net.http.HttpConnectTimeoutException;
+import java.net.http.HttpRequest;
+import java.net.http.HttpResponse;
+import java.nio.ByteBuffer;
+import java.nio.channels.FileChannel;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.StandardOpenOption;
+import java.time.Duration;
+import java.util.ArrayList;
+import java.util.Comparator;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Locale;
+import java.util.Map;
+import java.util.Optional;
+import java.util.Set;
+import java.util.concurrent.Flow;
+import java.util.concurrent.ThreadLocalRandom;
+import java.util.concurrent.atomic.AtomicInteger;
+import java.util.concurrent.atomic.AtomicLong;
+
+/**
+ * Executes a grant's {@code upload} block verbatim against a file, on the JDK's
+ * {@link HttpClient} rather than the library's {@code RestTemplate}: that template wraps a
+ * {@code BufferingClientHttpRequestFactory}, which would hold a whole part in memory twice
+ * over, and its re-auth interceptor must never fire against a storage host.
+ *
+ * <ul>
+ *   <li><b>single</b>: one PUT of the whole file, the grant's headers verbatim.</li>
+ *   <li><b>multipart</b>: one PUT per part in part order, each streamed from its file region;
+ *       the receipt is the {@code ETag} the provider answers with, forwarded as received.</li>
+ *   <li><b>resumable</b>: sequential PUTs of {@value #RESUMABLE_CHUNK}-byte chunks with
+ *       {@code Content-Range}, expecting 308 until the last chunk; after a connection failure
+ *       the committed offset is recovered with an empty {@code Content-Range: bytes *&#47;total}
+ *       query and the upload resumes there.</li>
+ *   <li><b>relay</b>: the single path, but a relay PUT is a live push to the receiver, so it
+ *       is retried only when the connection never opened.</li>
+ * </ul>
+ *
+ * <p><b>Content-Length.</b> The JDK client refuses {@code Content-Length} (and {@code Host},
+ * {@code Connection}, {@code Expect}, {@code Upgrade}) as explicit headers, so those are
+ * filtered from the verbatim pass-through and the length is guaranteed by the body publisher
+ * instead: every body here declares its exact length, which is what keeps a store that signs
+ * {@code Content-Length} from refusing the PUT. The wire header is the same value the grant
+ * carried.
+ *
+ * <p><b>Retry.</b> Per request, {@value #MAX_ATTEMPTS} attempts with exponential backoff and
+ * jitter on I/O failure, 5xx and 429 ({@code Retry-After} honored, capped); any other 4xx is
+ * terminal, including a 403 from an expired signed URL, which the caller surfaces as an
+ * upload failure rather than re-granting on its own. Bodies are re-created per attempt from
+ * the file region, so a retry never re-reads a consumed stream.
+ *
+ * <p>Nothing here announces anything: the caller completes or abandons the grant.
+ */
+final class AttachmentUploadExecutor {
+
+    static final int RESUMABLE_CHUNK = 8 * 1024 * 1024;
+    static final int MAX_ATTEMPTS = 3;
+    static final int READ_BUFFER = 64 * 1024;
+    private static final Duration MAX_RETRY_AFTER = Duration.ofSeconds(30);
+    private static final Set<String> RESTRICTED_HEADERS = Set.of("content-length", "host", "connection", "expect", "upgrade");
+
+    private final HttpClient http;
+    private final Duration baseBackoff;
+
+    AttachmentUploadExecutor() {
+        this(HttpClient.newBuilder()
+                .version(HttpClient.Version.HTTP_1_1)
+                .followRedirects(HttpClient.Redirect.NEVER)
+                .connectTimeout(Duration.ofSeconds(30))
+                .build(),
+            Duration.ofSeconds(1));
+    }
+
+    AttachmentUploadExecutor(HttpClient http, Duration baseBackoff) {
+        this.http = http;
+        this.baseBackoff = baseBackoff;
+    }
+
+    UploadReceipts execute(AttachmentGrant grant, Path file, UploadProgressListener listener) {
+        AttachmentGrant.Upload upload = grant.upload();
+        if (upload == null || upload.mode() == null) {
+            throw precondition("grant carries no upload block");
+        }
+        UploadProgressListener progress = listener == null ? UploadProgressListener.NONE : listener;
+        long size = sizeOf(file);
+        Map<String, String> headers = passThrough(upload.headers());
+        String mode = upload.mode().toLowerCase(Locale.ROOT);
+        try {
+            return switch (mode) {
+                case "single" -> single(upload, headers, file, size, progress, false);
+                case "relay" -> single(upload, headers, file, size, progress, true);
+                case "multipart" -> multipart(upload, headers, file, size, progress);
+                case "resumable" -> resumable(upload, headers, file, size, progress);
+                default -> throw new AttachmentV2Exception("upload mode '" + upload.mode()
+                    + "' is not implemented by this client", 0, AttachmentV2Exception.UNSUPPORTED_UPLOAD_MODE);
+            };
+        } catch (UploadIoFailure io) {
+            // The one boundary where the internal I/O signal becomes the facade's exception.
+            throw new AttachmentV2Exception(io.getMessage(), 0, AttachmentV2Exception.UPLOAD_UNREACHABLE, io.getCause());
+        }
+    }
+
+    private UploadReceipts single(AttachmentGrant.Upload upload, Map<String, String> headers, Path file, long size,
+                                  UploadProgressListener progress, boolean relay) {
+        String mode = relay ? "relay" : "single";
+        requireUrl(upload.url(), mode);
+        HttpRequest request = put(upload.url(), headers, new FileRegionPublisher(file, 0, size), size);
+        sendWithRetry(request, relay ? RetryScope.CONNECT_ONLY : RetryScope.TRANSIENT, mode + " upload");
+        progress.onProgress(new UploadProgress(mode, 1, 1, size, size));
+        return new UploadReceipts(mode, size, List.of());
+    }
+
+    private UploadReceipts multipart(AttachmentGrant.Upload upload, Map<String, String> headers, Path file, long size,
+                                     UploadProgressListener progress) {
+        List<AttachmentGrant.Part> parts = new ArrayList<>(upload.parts());
+        if (parts.isEmpty()) {
+            throw precondition("multipart grant carries no parts");
+        }
+        parts.sort(Comparator.comparingInt(AttachmentGrant.Part::partNumber));
+        long declared = parts.stream().mapToLong(AttachmentGrant.Part::sizeBytes).sum();
+        if (declared != size) {
+            throw precondition("multipart parts total " + declared + " bytes but the file is " + size + " bytes");
+        }
+        List<PartReceipt> receipts = new ArrayList<>(parts.size());
+        long offset = 0;
+        for (AttachmentGrant.Part part : parts) {
+            requireUrl(part.url(), "multipart part " + part.partNumber());
+            HttpRequest request = put(part.url(), headers, new FileRegionPublisher(file, offset, part.sizeBytes()), part.sizeBytes());
+            HttpResponse<Void> response = sendWithRetry(request, RetryScope.TRANSIENT, "part " + part.partNumber());
+            String receipt = response.headers().firstValue("ETag")
+                .orElseThrow(() -> new AttachmentV2Exception("part " + part.partNumber()
+                    + " was accepted without an ETag; the platform cannot seal it", response.statusCode(),
+                    AttachmentV2Exception.CLIENT_PRECONDITION));
+            receipts.add(new PartReceipt(part.partNumber(), receipt));
+            offset += part.sizeBytes();
+            progress.onProgress(new UploadProgress("multipart", receipts.size(), parts.size(), offset, size));
+        }
+        return new UploadReceipts("multipart", size, receipts);
+    }
+
+    private UploadReceipts resumable(AttachmentGrant.Upload upload, Map<String, String> headers, Path file, long size,
+                                     UploadProgressListener progress) {
+        requireUrl(upload.url(), "resumable");
+        int chunks = (int) ((size + RESUMABLE_CHUNK - 1) / RESUMABLE_CHUNK);
+        long offset = 0;
+        int done = 0;
+        int stalls = 0;
+        while (offset < size) {
+            long length = Math.min(RESUMABLE_CHUNK, size - offset);
+            long end = offset + length - 1;
+            Map<String, String> chunkHeaders = new LinkedHashMap<>(headers);
+            chunkHeaders.put("Content-Range", "bytes " + offset + "-" + end + "/" + size);
+            HttpRequest request = put(upload.url(), chunkHeaders, new FileRegionPublisher(file, offset, length), length);
+            long nextOffset;
+            try {
+                HttpResponse<Void> response = sendWithRetry(request, RetryScope.TRANSIENT_STATUS_ONLY, "resumable chunk at " + offset);
+                // A 308 says how much the session holds in its Range header. No Range means
+                // nothing is committed (the resumable-protocol reading); treating it as a full
+                // chunk would skip bytes silently, so it counts as no progress and the chunk is
+                // resent, and a session that never reports Range fails closed after the budget.
+                nextOffset = response.statusCode() == 308 ? committedOffset(response, offset) : size;
+            } catch (UploadIoFailure io) {
+                // The session may have taken some or all of the chunk: ask where it stands.
+                nextOffset = queryCommittedOffset(upload.url(), headers, size, io);
+            }
+            if (nextOffset <= offset) {
+                // The session took none of that chunk (a dropped connection before commit):
+                // resend it, within the same budget a failed part gets.
+                if (++stalls >= MAX_ATTEMPTS) {
+                    throw new AttachmentV2Exception("resumable session made no progress at offset " + offset
+                        + " after " + stalls + " attempts", 0, AttachmentV2Exception.UPLOAD_UNREACHABLE);
+                }
+                continue;
+            }
+            stalls = 0;
+            offset = nextOffset;
+            done = (int) Math.min(chunks, (offset + RESUMABLE_CHUNK - 1) / RESUMABLE_CHUNK);
+            progress.onProgress(new UploadProgress("resumable", done, chunks, offset, size));
+        }
+        return new UploadReceipts("resumable", size, List.of());
+    }
+
+    /** {@code PUT} with {@code Content-Range: bytes *&#47;total} and no body: 308 + Range tells the committed offset. */
+    private long queryCommittedOffset(String url, Map<String, String> headers, long size, UploadIoFailure cause) {
+        Map<String, String> queryHeaders = new LinkedHashMap<>(headers);
+        queryHeaders.put("Content-Range", "bytes */" + size);
+        HttpRequest query = put(url, queryHeaders, HttpRequest.BodyPublishers.noBody(), 0);
+        HttpResponse<Void> response;
+        try {
+            response = http.send(query, HttpResponse.BodyHandlers.discarding());
+        } catch (IOException e) {
+            cause.addSuppressed(e);
+            throw new AttachmentV2Exception("resumable upload lost its connection and the session could not be queried",
+                0, AttachmentV2Exception.UPLOAD_UNREACHABLE, cause);
+        } catch (InterruptedException e) {
+            Thread.currentThread().interrupt();
+            throw new AttachmentV2Exception("interrupted while querying the resumable session", 0,
+                AttachmentV2Exception.UPLOAD_UNREACHABLE, e);
+        }
+        if (response.statusCode() == 308) {
+            return committedOffset(response, 0);
+        }
+        if (response.statusCode() / 100 == 2) {
+            return size;
+        }
+        throw rejected("resumable session query", response.statusCode());
+    }
+
+    /** {@code Range: bytes=0-N} on a 308 means N+1 bytes are committed; no Range means {@code fallback}. */
+    private static long committedOffset(HttpResponse<?> response, long fallback) {
+        Optional<String> range = response.headers().firstValue("Range");
+        if (range.isEmpty()) {
+            return fallback;
+        }
+        String value = range.get().trim();
+        int dash = value.lastIndexOf('-');
+        if (dash < 0) {
+            return fallback;
+        }
+        try {
+            return Long.parseLong(value.substring(dash + 1).trim()) + 1;
+        } catch (NumberFormatException e) {
+            return fallback;
+        }
+    }
+
+    private enum RetryScope { TRANSIENT, TRANSIENT_STATUS_ONLY, CONNECT_ONLY }
+
+    /** Thrown internally when a request could not complete over the network after its budget. */
+    private static final class UploadIoFailure extends RuntimeException {
+        UploadIoFailure(String message, Throwable cause) {
+            super(message, cause);
+        }
+    }
+
+    private HttpResponse<Void> sendWithRetry(HttpRequest request, RetryScope scope, String what) {
+        Exception last = null;
+        for (int attempt = 1; attempt <= MAX_ATTEMPTS; attempt++) {
+            HttpResponse<Void> response;
+            try {
+                response = http.send(request, HttpResponse.BodyHandlers.discarding());
+            } catch (IOException e) {
+                last = e;
+                boolean connectLevel = e instanceof ConnectException || e instanceof HttpConnectTimeoutException;
+                boolean retryable = switch (scope) {
+                    case TRANSIENT -> true;
+                    case TRANSIENT_STATUS_ONLY -> false;
+                    case CONNECT_ONLY -> connectLevel;
+                };
+                if (!retryable || attempt == MAX_ATTEMPTS) {
+                    throw new UploadIoFailure(what + " could not reach the upload target: " + e.getClass().getSimpleName(), e);
+                }
+                sleep(backoff(attempt, Optional.empty()));
+                continue;
+            } catch (InterruptedException e) {
+                Thread.currentThread().interrupt();
+                throw new AttachmentV2Exception("interrupted during " + what, 0, AttachmentV2Exception.UPLOAD_UNREACHABLE, e);
+            }
+            int status = response.statusCode();
+            if (status / 100 == 2 || (status == 308 && scope == RetryScope.TRANSIENT_STATUS_ONLY)) {
+                return response;
+            }
+            // A relay PUT is a live push: once the receiver answered, re-sending could duplicate it.
+            boolean transientStatus = (status == 429 || status / 100 == 5) && scope != RetryScope.CONNECT_ONLY;
+            if (transientStatus && attempt < MAX_ATTEMPTS) {
+                sleep(backoff(attempt, response.headers().firstValue("Retry-After")));
+                continue;
+            }
+            throw rejected(what, status);
+        }
+        throw new UploadIoFailure(what + " exhausted its retry budget", last);
+    }
+
+    private static AttachmentV2Exception rejected(String what, int status) {
+        return new AttachmentV2Exception(what + " was rejected by the upload target: HTTP " + status, status,
+            AttachmentV2Exception.UPLOAD_REJECTED);
+    }
+
+    private Duration backoff(int attempt, Optional<String> retryAfter) {
+        if (retryAfter.isPresent()) {
+            try {
+                long seconds = Long.parseLong(retryAfter.get().trim());
+                return Duration.ofSeconds(Math.min(seconds, MAX_RETRY_AFTER.toSeconds()));
+            } catch (NumberFormatException ignored) {
+                // Fall through to exponential backoff for date-formatted values.
+            }
+        }
+        long millis = baseBackoff.toMillis() * (1L << (attempt - 1));
+        long jitter = millis == 0 ? 0 : ThreadLocalRandom.current().nextLong(millis / 2 + 1);
+        return Duration.ofMillis(millis + jitter);
+    }
+
+    private static void sleep(Duration duration) {
+        if (duration.isZero() || duration.isNegative()) {
+            return;
+        }
+        try {
+            Thread.sleep(duration.toMillis());
+        } catch (InterruptedException e) {
+            Thread.currentThread().interrupt();
+            throw new AttachmentV2Exception("interrupted while backing off", 0, AttachmentV2Exception.UPLOAD_UNREACHABLE, e);
+        }
+    }
+
+    private static HttpRequest put(String url, Map<String, String> headers, HttpRequest.BodyPublisher body, long bytes) {
+        HttpRequest.Builder builder = HttpRequest.newBuilder(URI.create(url))
+            .timeout(timeoutFor(bytes))
+            .PUT(body);
+        headers.forEach(builder::header);
+        return builder.build();
+    }
+
+    /** One minute plus one second per 512 KiB: generous for a slow uplink, finite for a stuck one. */
+    static Duration timeoutFor(long bytes) {
+        return Duration.ofSeconds(60 + bytes / (512 * 1024));
+    }
+
+    /** The grant's headers minus the ones the JDK client reserves; the length rides on the body instead. */
+    static Map<String, String> passThrough(Map<String, String> headers) {
+        Map<String, String> out = new LinkedHashMap<>();
+        headers.forEach((name, value) -> {
+            if (name != null && value != null && !RESTRICTED_HEADERS.contains(name.toLowerCase(Locale.ROOT))) {
+                out.put(name, value);
+            }
+        });
+        return out;
+    }
+
+    private static void requireUrl(String url, String what) {
+        if (url == null || url.isBlank()) {
+            throw precondition(what + " carries no url");
+        }
+    }
+
+    private static long sizeOf(Path file) {
+        try {
+            long size = Files.size(file);
+            if (size < 1) {
+                throw precondition("file is empty; the contract requires at least one byte");
+            }
+            return size;
+        } catch (IOException e) {
+            throw new AttachmentV2Exception("cannot read the file to upload: " + e.getClass().getSimpleName(), 0,
+                AttachmentV2Exception.CLIENT_PRECONDITION, e);
+        }
+    }
+
+    private static AttachmentV2Exception precondition(String message) {
+        return new AttachmentV2Exception(message, 0, AttachmentV2Exception.CLIENT_PRECONDITION);
+    }
+
+    /**
+     * A body publisher over one region of a file, with an exact {@link #contentLength()}. Each
+     * subscription opens its own channel, so the same request can be re-sent on retry.
+     * Single-subscriber, demand-driven, {@value #READ_BUFFER}-byte reads.
+     */
+    static final class FileRegionPublisher implements HttpRequest.BodyPublisher {
+        private final Path file;
+        private final long offset;
+        private final long length;
+
+        FileRegionPublisher(Path file, long offset, long length) {
+            this.file = file;
+            this.offset = offset;
+            this.length = length;
+        }
+
+        @Override
+        public long contentLength() {
+            return length;
+        }
+
+        @Override
+        public void subscribe(Flow.Subscriber<? super ByteBuffer> subscriber) {
+            FileChannel channel;
+            try {
+                channel = FileChannel.open(file, StandardOpenOption.READ);
+            } catch (IOException e) {
+                subscriber.onSubscribe(new Flow.Subscription() {
+                    @Override
+                    public void request(long n) {
+                    }
+
+                    @Override
+                    public void cancel() {
+                    }
+                });
+                subscriber.onError(e);
+                return;
+            }
+            subscriber.onSubscribe(new RegionSubscription(channel, subscriber));
+        }
+
+        private final class RegionSubscription implements Flow.Subscription {
+            private final FileChannel channel;
+            private final Flow.Subscriber<? super ByteBuffer> subscriber;
+            private final AtomicLong demand = new AtomicLong();
+            private final AtomicInteger wip = new AtomicInteger();
+            private long position = offset;
+            private long remaining = length;
+            private volatile boolean cancelled;
+            private boolean terminated;
+
+            RegionSubscription(FileChannel channel, Flow.Subscriber<? super ByteBuffer> subscriber) {
+                this.channel = channel;
+                this.subscriber = subscriber;
+            }
+
+            @Override
+            public void request(long n) {
+                if (n <= 0) {
+                    fail(new IllegalArgumentException("non-positive request: " + n));
+                    return;
+                }
+                demand.addAndGet(n);
+                drain();
+            }
+
+            @Override
+            public void cancel() {
+                cancelled = true;
+                close();
+            }
+
+            private void drain() {
+                if (wip.getAndIncrement() != 0) {
+                    return;
+                }
+                int missed = 1;
+                do {
+                    while (!cancelled && !terminated && remaining > 0 && demand.get() > 0) {
+                        ByteBuffer buffer = ByteBuffer.allocate((int) Math.min(READ_BUFFER, remaining));
+                        int read;
+                        try {
+                            read = channel.read(buffer, position);
+                        } catch (IOException e) {
+                            fail(e);
+                            return;
+                        }
+                        if (read <= 0) {
+                            fail(new IOException("file ended " + remaining + " bytes before the declared region did"));
+                            return;
+                        }
+                        position += read;
+                        remaining -= read;
+                        buffer.flip();
+                        demand.decrementAndGet();
+                        subscriber.onNext(buffer);
+                    }
+                    if (!cancelled && !terminated && remaining == 0) {
+                        terminated = true;
+                        close();
+                        subscriber.onComplete();
+                    }
+                    missed = wip.addAndGet(-missed);
+                } while (missed != 0);
+            }
+
+            private void fail(Throwable error) {
+                if (terminated) {
+                    return;
+                }
+                terminated = true;
+                close();
+                subscriber.onError(error);
+            }
+
+            private void close() {
+                try {
+                    channel.close();
+                } catch (IOException ignored) {
+                    // Nothing useful to do with a close failure on a read-only channel.
+                }
+            }
+        }
+    }
+}

--- a/connect-library/src/main/java/com/tsanet/api/connectapi/internal/AttachmentsV2Api.java
+++ b/connect-library/src/main/java/com/tsanet/api/connectapi/internal/AttachmentsV2Api.java
@@ -1,0 +1,23 @@
+package com.tsanet.api.connectapi.internal;
+
+import com.tsanet.api.attachments.v2.AttachmentCompleteRequest;
+import com.tsanet.api.attachments.v2.AttachmentCompleteResult;
+import com.tsanet.api.attachments.v2.AttachmentGrant;
+import com.tsanet.api.attachments.v2.AttachmentGrantRequest;
+import java.util.UUID;
+
+/**
+ * The three Connect API calls of the V2 attachment contract, as a seam the gateway is
+ * tested against (the way the V1 gateway is tested against the generated
+ * {@code CaseAttachmentsApi}). Not a second SPI: the only production implementation is
+ * {@link ConnectApiAttachmentsV2Api}, and the seam disappears when the contract lands in
+ * the OpenAPI spec and the generated API class takes its place.
+ */
+public interface AttachmentsV2Api {
+
+    AttachmentGrant createGrant(String caseToken, AttachmentGrantRequest request, String idempotencyKey);
+
+    AttachmentCompleteResult complete(String caseToken, UUID grantId, AttachmentCompleteRequest request);
+
+    void abandon(String caseToken, UUID grantId);
+}

--- a/connect-library/src/main/java/com/tsanet/api/connectapi/internal/ConnectApiAttachmentsV2Api.java
+++ b/connect-library/src/main/java/com/tsanet/api/connectapi/internal/ConnectApiAttachmentsV2Api.java
@@ -56,22 +56,24 @@ public final class ConnectApiAttachmentsV2Api implements AttachmentsV2Api {
         if (idempotencyKey != null && !idempotencyKey.isBlank()) {
             headers.add("Idempotency-Key", idempotencyKey);
         }
-        AttachmentGrant grant = invoke("grant", GRANTS_PATH, HttpMethod.POST, Map.of("token", caseToken),
-            request, headers, new ParameterizedTypeReference<AttachmentGrant>() { });
+        ResponseEntity<AttachmentGrant> response = invoke("grant", GRANTS_PATH, HttpMethod.POST,
+            Map.of("token", caseToken), request, headers, new ParameterizedTypeReference<AttachmentGrant>() { });
+        AttachmentGrant grant = response.getBody();
         if (grant == null || grant.grantId() == null || grant.upload() == null) {
             throw new AttachmentV2Exception("grant returned no usable grant (missing grantId or upload block)",
-                200, AttachmentV2Exception.CLIENT_PRECONDITION);
+                response.getStatusCode().value(), AttachmentV2Exception.CLIENT_PRECONDITION);
         }
         return grant;
     }
 
     @Override
     public AttachmentCompleteResult complete(String caseToken, UUID grantId, AttachmentCompleteRequest request) {
-        AttachmentCompleteResult result = invoke("complete", COMPLETE_PATH, HttpMethod.POST,
+        ResponseEntity<AttachmentCompleteResult> response = invoke("complete", COMPLETE_PATH, HttpMethod.POST,
             Map.of("token", caseToken, "grantId", grantId.toString()),
             request, new HttpHeaders(), new ParameterizedTypeReference<AttachmentCompleteResult>() { });
+        AttachmentCompleteResult result = response.getBody();
         if (result == null || result.status() == null) {
-            throw new AttachmentV2Exception("complete returned no outcome status", 200,
+            throw new AttachmentV2Exception("complete returned no outcome status", response.getStatusCode().value(),
                 AttachmentV2Exception.CLIENT_PRECONDITION);
         }
         return result;
@@ -83,20 +85,22 @@ public final class ConnectApiAttachmentsV2Api implements AttachmentsV2Api {
             null, new HttpHeaders(), new ParameterizedTypeReference<Void>() { });
     }
 
-    private <T> T invoke(String operation, String path, HttpMethod method, Map<String, Object> pathParams,
-                         Object body, HttpHeaders headers, ParameterizedTypeReference<T> returnType) {
+    private <T> ResponseEntity<T> invoke(String operation, String path, HttpMethod method, Map<String, Object> pathParams,
+                                         Object body, HttpHeaders headers, ParameterizedTypeReference<T> returnType) {
         List<MediaType> accept = apiClient.selectHeaderAccept(ACCEPT);
         MediaType contentType = body == null ? null : apiClient.selectHeaderContentType(JSON);
         try {
-            ResponseEntity<T> response = apiClient.invokeAPI(path, method, pathParams, new LinkedMultiValueMap<>(),
+            return apiClient.invokeAPI(path, method, pathParams, new LinkedMultiValueMap<>(),
                 body, headers, new LinkedMultiValueMap<>(), new LinkedMultiValueMap<>(), accept, contentType,
                 AUTH_NAMES, returnType);
-            return response.getBody();
         } catch (HttpStatusCodeException e) {
             throw translate(operation, e);
         } catch (ResourceAccessException e) {
-            throw new AttachmentV2Exception(operation + " failed: cannot reach the Connect API: " + e.getMessage(),
-                0, AttachmentV2Exception.CONNECTIVITY, e);
+            // Spring's message carries the expanded request URL, and these paths carry the
+            // case token: name the failure by its cause type only.
+            Throwable root = e.getCause() != null ? e.getCause() : e;
+            throw new AttachmentV2Exception(operation + " failed: cannot reach the Connect API ("
+                + root.getClass().getSimpleName() + ")", 0, AttachmentV2Exception.CONNECTIVITY, e);
         } catch (RestClientException e) {
             throw new AttachmentV2Exception(operation + " failed: " + e.getClass().getSimpleName(),
                 0, AttachmentV2Exception.CONNECTIVITY, e);

--- a/connect-library/src/main/java/com/tsanet/api/connectapi/internal/ConnectApiAttachmentsV2Api.java
+++ b/connect-library/src/main/java/com/tsanet/api/connectapi/internal/ConnectApiAttachmentsV2Api.java
@@ -1,0 +1,140 @@
+package com.tsanet.api.connectapi.internal;
+
+import com.tsanet.api.attachments.v2.AttachmentCompleteRequest;
+import com.tsanet.api.attachments.v2.AttachmentCompleteResult;
+import com.tsanet.api.attachments.v2.AttachmentGrant;
+import com.tsanet.api.attachments.v2.AttachmentGrantRequest;
+import com.tsanet.api.attachments.v2.AttachmentV2Exception;
+import com.tsanet.api.generated.invoker.ApiClient;
+import java.util.List;
+import java.util.Map;
+import java.util.UUID;
+import org.springframework.core.ParameterizedTypeReference;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.HttpMethod;
+import org.springframework.http.MediaType;
+import org.springframework.http.ResponseEntity;
+import org.springframework.util.LinkedMultiValueMap;
+import org.springframework.util.MultiValueMap;
+import org.springframework.web.client.HttpStatusCodeException;
+import org.springframework.web.client.ResourceAccessException;
+import org.springframework.web.client.RestClientException;
+import tools.jackson.databind.JsonNode;
+import tools.jackson.databind.json.JsonMapper;
+
+/**
+ * {@link AttachmentsV2Api} over the generated {@link ApiClient}'s raw {@code invokeAPI}, with
+ * the {@code bearerAuth} scheme, so the session's bearer supplier and the 401 re-auth
+ * interceptor apply exactly as they do to the generated V1 calls. The V2 paths are not in
+ * the OpenAPI spec yet (tsanetgit/Connect-API-Code#147 is a draft), which is the only
+ * reason this class exists instead of a generated one.
+ *
+ * <p>Errors: an {@code application/problem+json} body is mapped to
+ * {@link AttachmentV2Exception} with the platform's {@code type}, {@code title} and
+ * {@code detail}; nothing from the request is echoed. A response that is not a problem
+ * document yields the status alone.
+ */
+public final class ConnectApiAttachmentsV2Api implements AttachmentsV2Api {
+
+    static final String GRANTS_PATH = "/v2/collaboration-requests/{token}/attachments/grants";
+    static final String GRANT_PATH = GRANTS_PATH + "/{grantId}";
+    static final String COMPLETE_PATH = GRANT_PATH + "/complete";
+    private static final String[] AUTH_NAMES = {"bearerAuth"};
+    private static final String[] ACCEPT = {"application/json", "application/problem+json"};
+    private static final String[] JSON = {"application/json"};
+
+    private final ApiClient apiClient;
+    private final JsonMapper problemMapper = JsonMapper.builder().build();
+
+    public ConnectApiAttachmentsV2Api(ApiClient apiClient) {
+        this.apiClient = apiClient;
+    }
+
+    @Override
+    public AttachmentGrant createGrant(String caseToken, AttachmentGrantRequest request, String idempotencyKey) {
+        HttpHeaders headers = new HttpHeaders();
+        if (idempotencyKey != null && !idempotencyKey.isBlank()) {
+            headers.add("Idempotency-Key", idempotencyKey);
+        }
+        AttachmentGrant grant = invoke("grant", GRANTS_PATH, HttpMethod.POST, Map.of("token", caseToken),
+            request, headers, new ParameterizedTypeReference<AttachmentGrant>() { });
+        if (grant == null || grant.grantId() == null || grant.upload() == null) {
+            throw new AttachmentV2Exception("grant returned no usable grant (missing grantId or upload block)",
+                200, AttachmentV2Exception.CLIENT_PRECONDITION);
+        }
+        return grant;
+    }
+
+    @Override
+    public AttachmentCompleteResult complete(String caseToken, UUID grantId, AttachmentCompleteRequest request) {
+        AttachmentCompleteResult result = invoke("complete", COMPLETE_PATH, HttpMethod.POST,
+            Map.of("token", caseToken, "grantId", grantId.toString()),
+            request, new HttpHeaders(), new ParameterizedTypeReference<AttachmentCompleteResult>() { });
+        if (result == null || result.status() == null) {
+            throw new AttachmentV2Exception("complete returned no outcome status", 200,
+                AttachmentV2Exception.CLIENT_PRECONDITION);
+        }
+        return result;
+    }
+
+    @Override
+    public void abandon(String caseToken, UUID grantId) {
+        invoke("abandon", GRANT_PATH, HttpMethod.DELETE, Map.of("token", caseToken, "grantId", grantId.toString()),
+            null, new HttpHeaders(), new ParameterizedTypeReference<Void>() { });
+    }
+
+    private <T> T invoke(String operation, String path, HttpMethod method, Map<String, Object> pathParams,
+                         Object body, HttpHeaders headers, ParameterizedTypeReference<T> returnType) {
+        List<MediaType> accept = apiClient.selectHeaderAccept(ACCEPT);
+        MediaType contentType = body == null ? null : apiClient.selectHeaderContentType(JSON);
+        try {
+            ResponseEntity<T> response = apiClient.invokeAPI(path, method, pathParams, new LinkedMultiValueMap<>(),
+                body, headers, new LinkedMultiValueMap<>(), new LinkedMultiValueMap<>(), accept, contentType,
+                AUTH_NAMES, returnType);
+            return response.getBody();
+        } catch (HttpStatusCodeException e) {
+            throw translate(operation, e);
+        } catch (ResourceAccessException e) {
+            throw new AttachmentV2Exception(operation + " failed: cannot reach the Connect API: " + e.getMessage(),
+                0, AttachmentV2Exception.CONNECTIVITY, e);
+        } catch (RestClientException e) {
+            throw new AttachmentV2Exception(operation + " failed: " + e.getClass().getSimpleName(),
+                0, AttachmentV2Exception.CONNECTIVITY, e);
+        }
+    }
+
+    /** Problem details in, value-free exception out. */
+    private AttachmentV2Exception translate(String operation, HttpStatusCodeException e) {
+        int status = e.getStatusCode().value();
+        String type = null;
+        String title = null;
+        String detail = null;
+        String raw = e.getResponseBodyAsString();
+        if (raw != null && !raw.isBlank()) {
+            try {
+                JsonNode node = problemMapper.readTree(raw);
+                type = text(node, "type");
+                title = text(node, "title");
+                detail = text(node, "detail");
+            } catch (RuntimeException ignored) {
+                // Not a problem document; the status alone is the message.
+            }
+        }
+        StringBuilder message = new StringBuilder(operation).append(" failed: HTTP ").append(status);
+        if (title != null) {
+            message.append(' ').append(title);
+        }
+        if (type != null) {
+            message.append(" (").append(type).append(')');
+        }
+        if (detail != null) {
+            message.append(": ").append(detail);
+        }
+        return new AttachmentV2Exception(message.toString(), status, type, e);
+    }
+
+    private static String text(JsonNode node, String field) {
+        JsonNode value = node.get(field);
+        return value == null || value.isNull() ? null : value.asString();
+    }
+}

--- a/connect-library/src/main/java/com/tsanet/api/connectapi/internal/ConnectApiAttachmentsV2Gateway.java
+++ b/connect-library/src/main/java/com/tsanet/api/connectapi/internal/ConnectApiAttachmentsV2Gateway.java
@@ -14,6 +14,7 @@ import java.nio.file.Files;
 import java.nio.file.Path;
 import java.security.MessageDigest;
 import java.security.NoSuchAlgorithmException;
+import java.time.Duration;
 import java.util.HexFormat;
 import java.util.UUID;
 
@@ -32,16 +33,18 @@ public class ConnectApiAttachmentsV2Gateway implements AttachmentsV2Facade {
     private final AttachmentsV2Api api;
     private final ConnectApiSessionStore sessionStore;
     private final AttachmentUploadExecutor executor;
+    private final Duration completeBackoff;
 
     public ConnectApiAttachmentsV2Gateway(AttachmentsV2Api api, ConnectApiSessionStore sessionStore) {
-        this(api, sessionStore, new AttachmentUploadExecutor());
+        this(api, sessionStore, new AttachmentUploadExecutor(), Duration.ofSeconds(1));
     }
 
     ConnectApiAttachmentsV2Gateway(AttachmentsV2Api api, ConnectApiSessionStore sessionStore,
-                                   AttachmentUploadExecutor executor) {
+                                   AttachmentUploadExecutor executor, Duration completeBackoff) {
         this.api = api;
         this.sessionStore = sessionStore;
         this.executor = executor;
+        this.completeBackoff = completeBackoff;
     }
 
     @Override
@@ -128,9 +131,23 @@ public class ConnectApiAttachmentsV2Gateway implements AttachmentsV2Facade {
                     throw e;
                 }
                 last = e;
+                pause(completeBackoff.multipliedBy(attempt));
             }
         }
         throw last;
+    }
+
+    private static void pause(Duration duration) {
+        if (duration.isZero() || duration.isNegative()) {
+            return;
+        }
+        try {
+            Thread.sleep(duration.toMillis());
+        } catch (InterruptedException e) {
+            Thread.currentThread().interrupt();
+            throw new AttachmentV2Exception("interrupted while retrying complete", 0,
+                AttachmentV2Exception.CONNECTIVITY, e);
+        }
     }
 
     private static AttachmentCompleteRequest completeRequest(UploadReceipts receipts, String sha256) {

--- a/connect-library/src/main/java/com/tsanet/api/connectapi/internal/ConnectApiAttachmentsV2Gateway.java
+++ b/connect-library/src/main/java/com/tsanet/api/connectapi/internal/ConnectApiAttachmentsV2Gateway.java
@@ -1,0 +1,182 @@
+package com.tsanet.api.connectapi.internal;
+
+import com.tsanet.api.attachments.v2.AttachmentCompleteRequest;
+import com.tsanet.api.attachments.v2.AttachmentCompleteResult;
+import com.tsanet.api.attachments.v2.AttachmentGrant;
+import com.tsanet.api.attachments.v2.AttachmentGrantRequest;
+import com.tsanet.api.attachments.v2.AttachmentV2Exception;
+import com.tsanet.api.attachments.v2.UploadProgressListener;
+import com.tsanet.api.attachments.v2.UploadReceipts;
+import com.tsanet.api.facade.AttachmentsV2Facade;
+import java.io.IOException;
+import java.io.InputStream;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.security.MessageDigest;
+import java.security.NoSuchAlgorithmException;
+import java.util.HexFormat;
+import java.util.UUID;
+
+/**
+ * {@link AttachmentsV2Facade} over the {@link AttachmentsV2Api} seam and the
+ * {@link AttachmentUploadExecutor}. Owns the flow rules of the contract
+ * (tsanetgit/Connect-API-Code#147): abandon on any upload failure, one re-grant on a
+ * complete-time {@code grant-expired}, complete retried on transient failure because it is
+ * idempotent on the grant id, and the platform's recorded outcome returned unchanged.
+ */
+public class ConnectApiAttachmentsV2Gateway implements AttachmentsV2Facade {
+
+    static final String DEFAULT_CONTENT_TYPE = "application/octet-stream";
+    private static final int COMPLETE_ATTEMPTS = 3;
+
+    private final AttachmentsV2Api api;
+    private final ConnectApiSessionStore sessionStore;
+    private final AttachmentUploadExecutor executor;
+
+    public ConnectApiAttachmentsV2Gateway(AttachmentsV2Api api, ConnectApiSessionStore sessionStore) {
+        this(api, sessionStore, new AttachmentUploadExecutor());
+    }
+
+    ConnectApiAttachmentsV2Gateway(AttachmentsV2Api api, ConnectApiSessionStore sessionStore,
+                                   AttachmentUploadExecutor executor) {
+        this.api = api;
+        this.sessionStore = sessionStore;
+        this.executor = executor;
+    }
+
+    @Override
+    public AttachmentGrant grant(String caseToken, AttachmentGrantRequest request) {
+        requireLogin();
+        requireToken(caseToken);
+        return api.createGrant(caseToken, request, UUID.randomUUID().toString());
+    }
+
+    @Override
+    public UploadReceipts upload(AttachmentGrant grant, Path file, UploadProgressListener listener) {
+        if (grant == null) {
+            throw new IllegalArgumentException("grant must not be null");
+        }
+        requireRegularFile(file);
+        return executor.execute(grant, file, listener);
+    }
+
+    @Override
+    public AttachmentCompleteResult complete(String caseToken, UUID grantId, AttachmentCompleteRequest request) {
+        requireLogin();
+        requireToken(caseToken);
+        return completeWithRetry(caseToken, grantId, request);
+    }
+
+    @Override
+    public void abandon(String caseToken, UUID grantId) {
+        requireLogin();
+        requireToken(caseToken);
+        api.abandon(caseToken, grantId);
+    }
+
+    @Override
+    public AttachmentCompleteResult send(String caseToken, Path file, String contentType, String description,
+                                         boolean withSha256, UploadProgressListener listener) {
+        requireLogin();
+        requireToken(caseToken);
+        requireRegularFile(file);
+        long size = sizeOf(file);
+        String sha256 = withSha256 ? sha256Of(file) : null;
+        String type = contentType == null || contentType.isBlank() ? DEFAULT_CONTENT_TYPE : contentType.strip();
+        String text = description == null || description.isBlank() ? null : description.strip();
+        AttachmentGrantRequest request =
+            new AttachmentGrantRequest(file.getFileName().toString(), type, size, sha256, text);
+
+        AttachmentGrant grant = api.createGrant(caseToken, request, UUID.randomUUID().toString());
+        UploadReceipts receipts = uploadOrAbandon(caseToken, grant, file, listener);
+        try {
+            return completeWithRetry(caseToken, grant.grantId(), completeRequest(receipts, sha256));
+        } catch (AttachmentV2Exception e) {
+            if (!e.isProblem(AttachmentV2Exception.GRANT_EXPIRED)) {
+                throw e;
+            }
+        }
+        // The grant expired between upload and complete: one fresh grant, one more upload.
+        AttachmentGrant fresh = api.createGrant(caseToken, request, UUID.randomUUID().toString());
+        UploadReceipts again = uploadOrAbandon(caseToken, fresh, file, listener);
+        return completeWithRetry(caseToken, fresh.grantId(), completeRequest(again, sha256));
+    }
+
+    private UploadReceipts uploadOrAbandon(String caseToken, AttachmentGrant grant, Path file,
+                                           UploadProgressListener listener) {
+        try {
+            return executor.execute(grant, file, listener);
+        } catch (RuntimeException uploadFailure) {
+            // Best effort, and the upload failure stays primary: nothing may become visible.
+            try {
+                api.abandon(caseToken, grant.grantId());
+            } catch (RuntimeException abandonFailure) {
+                uploadFailure.addSuppressed(abandonFailure);
+            }
+            throw uploadFailure;
+        }
+    }
+
+    private AttachmentCompleteResult completeWithRetry(String caseToken, UUID grantId, AttachmentCompleteRequest request) {
+        AttachmentV2Exception last = null;
+        for (int attempt = 1; attempt <= COMPLETE_ATTEMPTS; attempt++) {
+            try {
+                return api.complete(caseToken, grantId, request);
+            } catch (AttachmentV2Exception e) {
+                boolean transientFailure = e.status() == 0 || e.status() / 100 == 5;
+                if (!transientFailure || attempt == COMPLETE_ATTEMPTS) {
+                    throw e;
+                }
+                last = e;
+            }
+        }
+        throw last;
+    }
+
+    private static AttachmentCompleteRequest completeRequest(UploadReceipts receipts, String sha256) {
+        return new AttachmentCompleteRequest(receipts.bytesSent(), sha256, receipts.parts());
+    }
+
+    private void requireLogin() {
+        sessionStore.getBearerToken().orElseThrow(() -> new IllegalStateException("Not logged in"));
+    }
+
+    private static void requireToken(String caseToken) {
+        if (caseToken == null || caseToken.isBlank()) {
+            throw new IllegalArgumentException("caseToken must not be blank");
+        }
+    }
+
+    private static void requireRegularFile(Path file) {
+        if (file == null || !Files.isRegularFile(file)) {
+            throw new IllegalArgumentException("file must be an existing regular file");
+        }
+    }
+
+    private static long sizeOf(Path file) {
+        try {
+            return Files.size(file);
+        } catch (IOException e) {
+            throw new AttachmentV2Exception("cannot read the file to send: " + e.getClass().getSimpleName(), 0,
+                AttachmentV2Exception.CLIENT_PRECONDITION, e);
+        }
+    }
+
+    /** One streaming pass of its own, never inside a retried upload write. */
+    static String sha256Of(Path file) {
+        try (InputStream in = Files.newInputStream(file)) {
+            MessageDigest digest = MessageDigest.getInstance("SHA-256");
+            byte[] buffer = new byte[AttachmentUploadExecutor.READ_BUFFER];
+            int read;
+            while ((read = in.read(buffer)) > 0) {
+                digest.update(buffer, 0, read);
+            }
+            return HexFormat.of().formatHex(digest.digest());
+        } catch (IOException e) {
+            throw new AttachmentV2Exception("cannot digest the file to send: " + e.getClass().getSimpleName(), 0,
+                AttachmentV2Exception.CLIENT_PRECONDITION, e);
+        } catch (NoSuchAlgorithmException e) {
+            throw new IllegalStateException("SHA-256 unavailable", e);
+        }
+    }
+}

--- a/connect-library/src/main/java/com/tsanet/api/facade/AttachmentsV2Facade.java
+++ b/connect-library/src/main/java/com/tsanet/api/facade/AttachmentsV2Facade.java
@@ -1,0 +1,56 @@
+package com.tsanet.api.facade;
+
+import com.tsanet.api.attachments.v2.AttachmentCompleteRequest;
+import com.tsanet.api.attachments.v2.AttachmentCompleteResult;
+import com.tsanet.api.attachments.v2.AttachmentGrant;
+import com.tsanet.api.attachments.v2.AttachmentGrantRequest;
+import com.tsanet.api.attachments.v2.UploadProgressListener;
+import com.tsanet.api.attachments.v2.UploadReceipts;
+import java.nio.file.Path;
+import java.util.UUID;
+
+/**
+ * The sender's side of the V2 attachment contract (tsanetgit/Connect-API-Code#147): the
+ * direct delivery path where the file goes straight into the partner's store and nothing
+ * passes through the Connect API. The four calls are exposed individually for clients that
+ * drive the flow themselves; {@link #send} runs the whole flow.
+ *
+ * <p>Every method reports the platform's recorded outcome, never this client's own
+ * evidence: an upload that sent every byte is still whatever {@code complete} says it is.
+ */
+public interface AttachmentsV2Facade {
+
+    /** Ask the platform for permission and upload instructions for one file on this case. */
+    AttachmentGrant grant(String caseToken, AttachmentGrantRequest request);
+
+    /**
+     * Execute the grant's upload block verbatim against the file. Streams from disk one part
+     * at a time; retries individual parts within the retry budget; never announces anything.
+     */
+    UploadReceipts upload(AttachmentGrant grant, Path file, UploadProgressListener listener);
+
+    /** Report the upload finished; the platform seals it, verifies arrival and records the outcome. */
+    AttachmentCompleteResult complete(String caseToken, UUID grantId, AttachmentCompleteRequest request);
+
+    /** Abandon a grant; any open upload session is aborted and nothing becomes visible. */
+    void abandon(String caseToken, UUID grantId);
+
+    /**
+     * Grant, upload, complete. Abandons the grant on any upload failure and rethrows; on a
+     * complete-time {@code attachment/grant-expired} it re-grants exactly once and uploads
+     * again. {@code withSha256} adds a streaming digest pass before the grant so the platform
+     * can verify content where the target supports it.
+     *
+     * @param contentType the file's media type; {@code application/octet-stream} when null or blank
+     * @param description optional text carried into the case note
+     * @param listener    progress callback, or null
+     */
+    AttachmentCompleteResult send(
+        String caseToken,
+        Path file,
+        String contentType,
+        String description,
+        boolean withSha256,
+        UploadProgressListener listener
+    );
+}

--- a/connect-library/src/main/java/com/tsanet/api/internal/DefaultTsaNetApiSession.java
+++ b/connect-library/src/main/java/com/tsanet/api/internal/DefaultTsaNetApiSession.java
@@ -22,6 +22,7 @@ import com.tsanet.api.connectapi.dto.WebhookInboundResultDto;
 import com.tsanet.api.connectapi.dto.WebhookSubscriptionDto;
 import com.tsanet.api.connectapi.dto.WebhookSubscriptionResponseDto;
 import com.tsanet.api.connectapi.internal.ConnectApiAttachmentsGateway;
+import com.tsanet.api.connectapi.internal.ConnectApiAttachmentsV2Gateway;
 import com.tsanet.api.connectapi.internal.ConnectApiAuthGateway;
 import com.tsanet.api.connectapi.internal.ConnectApiCollaborationGateway;
 import com.tsanet.api.connectapi.internal.ConnectApiFormGateway;
@@ -33,6 +34,7 @@ import com.tsanet.api.connectapi.internal.ConnectApiSessionStore;
 import com.tsanet.api.connectapi.internal.ConnectApiUserGateway;
 import com.tsanet.api.connectapi.internal.ConnectApiWebhooksGateway;
 import com.tsanet.api.facade.AttachmentsFacade;
+import com.tsanet.api.facade.AttachmentsV2Facade;
 import com.tsanet.api.facade.AuthFacade;
 import com.tsanet.api.facade.CaseNotesFacade;
 import com.tsanet.api.facade.CaseResponsesFacade;
@@ -78,6 +80,7 @@ final class DefaultTsaNetApiSession implements TsaNetApiSession, AuthFacade, Col
     private final ConnectApiWebhooksGateway webhooksGateway;
     private final ConnectApiPartnersGateway partnersGateway;
     private final ConnectApiAttachmentsGateway attachmentsGateway;
+    private final ConnectApiAttachmentsV2Gateway attachmentsV2Gateway;
     private final CollaborationRequestStorageService collaborationRequestStorageService;
     private final CollaborationRequestFormStorageService collaborationRequestFormStorageService;
     private final CaseNoteStorageService caseNoteStorageService;
@@ -103,6 +106,7 @@ final class DefaultTsaNetApiSession implements TsaNetApiSession, AuthFacade, Col
         ConnectApiWebhooksGateway webhooksGateway,
         ConnectApiPartnersGateway partnersGateway,
         ConnectApiAttachmentsGateway attachmentsGateway,
+        ConnectApiAttachmentsV2Gateway attachmentsV2Gateway,
         CollaborationRequestStorageService collaborationRequestStorageService,
         CollaborationRequestFormStorageService collaborationRequestFormStorageService,
         CaseNoteStorageService caseNoteStorageService,
@@ -126,6 +130,7 @@ final class DefaultTsaNetApiSession implements TsaNetApiSession, AuthFacade, Col
         this.webhooksGateway = webhooksGateway;
         this.partnersGateway = partnersGateway;
         this.attachmentsGateway = attachmentsGateway;
+        this.attachmentsV2Gateway = attachmentsV2Gateway;
         this.collaborationRequestStorageService = collaborationRequestStorageService;
         this.collaborationRequestFormStorageService = collaborationRequestFormStorageService;
         this.caseNoteStorageService = caseNoteStorageService;
@@ -178,6 +183,11 @@ final class DefaultTsaNetApiSession implements TsaNetApiSession, AuthFacade, Col
     @Override
     public PartnersFacade partners() {
         return this;
+    }
+
+    @Override
+    public AttachmentsV2Facade attachmentsV2() {
+        return attachmentsV2Gateway;
     }
 
     @Override

--- a/connect-library/src/main/java/com/tsanet/api/internal/TsaNetApiRuntime.java
+++ b/connect-library/src/main/java/com/tsanet/api/internal/TsaNetApiRuntime.java
@@ -3,6 +3,8 @@ package com.tsanet.api.internal;
 import com.tsanet.api.TsaNetApiConfiguration;
 import com.tsanet.api.TsaNetApiSession;
 import com.tsanet.api.connectapi.internal.ConnectApiAttachmentsGateway;
+import com.tsanet.api.connectapi.internal.ConnectApiAttachmentsV2Api;
+import com.tsanet.api.connectapi.internal.ConnectApiAttachmentsV2Gateway;
 import com.tsanet.api.connectapi.internal.ConnectApiAuthGateway;
 import com.tsanet.api.connectapi.internal.ConnectApiCollaborationGateway;
 import com.tsanet.api.connectapi.internal.ConnectApiFormGateway;
@@ -167,6 +169,11 @@ public final class TsaNetApiRuntime {
             attachmentForwardResultStorageService
         );
 
+        ConnectApiAttachmentsV2Gateway attachmentsV2Gateway = new ConnectApiAttachmentsV2Gateway(
+            new ConnectApiAttachmentsV2Api(apiClient),
+            sessionStore
+        );
+
         return new DefaultTsaNetApiSession(
             configuration,
             sessionStore,
@@ -180,6 +187,7 @@ public final class TsaNetApiRuntime {
             webhooksGateway,
             partnersGateway,
             attachmentsGateway,
+            attachmentsV2Gateway,
             collaborationRequestStorageService,
             collaborationRequestFormStorageService,
             caseNoteStorageService,

--- a/connect-library/src/main/java/com/tsanet/api/session/AccountScopedTsaNetApiSession.java
+++ b/connect-library/src/main/java/com/tsanet/api/session/AccountScopedTsaNetApiSession.java
@@ -7,6 +7,7 @@ import com.tsanet.api.TsaNetApiSessionFactory;
 import com.tsanet.api.auth.AuthMode;
 import com.tsanet.api.auth.PasswordAuthConfig;
 import com.tsanet.api.facade.AttachmentsFacade;
+import com.tsanet.api.facade.AttachmentsV2Facade;
 import com.tsanet.api.facade.AuthFacade;
 import com.tsanet.api.facade.CaseNotesFacade;
 import com.tsanet.api.facade.CaseResponsesFacade;
@@ -82,6 +83,11 @@ public final class AccountScopedTsaNetApiSession implements TsaNetApiSession, Ac
     @Override
     public AttachmentsFacade attachments() {
         return requireDelegate().attachments();
+    }
+
+    @Override
+    public AttachmentsV2Facade attachmentsV2() {
+        return requireDelegate().attachmentsV2();
     }
 
     private synchronized void activateAccount(ApplicationUserAccount account) {

--- a/connect-library/src/test/java/com/tsanet/api/connectapi/internal/AttachmentUploadExecutorLiveTest.java
+++ b/connect-library/src/test/java/com/tsanet/api/connectapi/internal/AttachmentUploadExecutorLiveTest.java
@@ -1,0 +1,50 @@
+package com.tsanet.api.connectapi.internal;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import com.tsanet.api.attachments.v2.AttachmentGrant;
+import com.tsanet.api.attachments.v2.UploadReceipts;
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.condition.EnabledIfEnvironmentVariable;
+import tools.jackson.databind.json.JsonMapper;
+
+/**
+ * Executes a real grant against real signed URLs. The grant, the file and the output path
+ * arrive through one JSON envelope named by {@code ATTACHMENTS_V2_GRANT_FILE}:
+ * <pre>
+ * {"grant": {...AttachmentGrantDTO as the platform returns it...},
+ *  "file": "/path/to/source",
+ *  "receiptsOut": "/path/to/write/receipts.json"}
+ * </pre>
+ * Whatever produced the grant (the platform, or a receiver-side harness that issues its own
+ * URLs) seals and verifies on its side using the receipts written here. That split keeps
+ * this public repository free of any receiver's interface details.
+ */
+@EnabledIfEnvironmentVariable(named = "ATTACHMENTS_V2_GRANT_FILE", matches = ".+")
+class AttachmentUploadExecutorLiveTest {
+
+    record Envelope(AttachmentGrant grant, String file, String receiptsOut) {
+    }
+
+    @Test
+    void executesTheGrantAndWritesTheReceipts() throws IOException {
+        JsonMapper mapper = JsonMapper.builder().build();
+        Path envelopePath = Path.of(System.getenv("ATTACHMENTS_V2_GRANT_FILE"));
+        Envelope envelope = mapper.readValue(Files.readString(envelopePath), Envelope.class);
+        assertThat(envelope.grant()).isNotNull();
+        assertThat(envelope.file()).isNotBlank();
+
+        UploadReceipts receipts = new AttachmentUploadExecutor().execute(envelope.grant(), Path.of(envelope.file()),
+            progress -> System.out.println("[attachments-v2] " + progress));
+
+        assertThat(receipts.bytesSent()).isEqualTo(Files.size(Path.of(envelope.file())));
+        if (envelope.receiptsOut() != null && !envelope.receiptsOut().isBlank()) {
+            Files.writeString(Path.of(envelope.receiptsOut()), mapper.writeValueAsString(receipts));
+        }
+        System.out.println("[attachments-v2] mode=" + receipts.mode() + " bytes=" + receipts.bytesSent()
+            + " parts=" + receipts.parts().size());
+    }
+}

--- a/connect-library/src/test/java/com/tsanet/api/connectapi/internal/AttachmentUploadExecutorTest.java
+++ b/connect-library/src/test/java/com/tsanet/api/connectapi/internal/AttachmentUploadExecutorTest.java
@@ -346,6 +346,96 @@ class AttachmentUploadExecutorTest {
     }
 
     @Test
+    void retryAfterIsHonoredAndCapped() {
+        AttachmentUploadExecutor slow = new AttachmentUploadExecutor(HttpClient.newHttpClient(), Duration.ofSeconds(1));
+        assertThat(slow.backoff(1, java.util.Optional.of("2"))).isEqualTo(Duration.ofSeconds(2));
+        assertThat(slow.backoff(1, java.util.Optional.of("120"))).isEqualTo(Duration.ofSeconds(30));
+        // A date-formatted or malformed value falls through to exponential backoff with jitter.
+        Duration fallback = slow.backoff(2, java.util.Optional.of("Wed, 21 Oct 2026 07:28:00 GMT"));
+        assertThat(fallback).isBetween(Duration.ofSeconds(2), Duration.ofSeconds(3));
+    }
+
+    @Test
+    void relayRetriesWhenTheConnectionNeverOpens() throws IOException {
+        Path file = file("relay-closed.bin", 100);
+        // A closed port: every attempt fails before any byte flows, so the relay budget applies.
+        assertThatThrownBy(() -> executor.execute(grant(new AttachmentGrant.Upload("relay", "PUT",
+            "http://127.0.0.1:1/relay?sig=SECRET", Map.of(), null)), file, null))
+            .isInstanceOf(AttachmentV2Exception.class)
+            .satisfies(e -> {
+                AttachmentV2Exception ex = (AttachmentV2Exception) e;
+                assertThat(ex.problemType()).isEqualTo(AttachmentV2Exception.UPLOAD_UNREACHABLE);
+                assertThat(ex.getMessage()).contains("relay upload").doesNotContain("SECRET");
+                assertThat(ex.getCause()).isInstanceOf(java.net.ConnectException.class);
+            });
+    }
+
+    @Test
+    void aResumableSessionThatNeverReportsRangeFailsClosed() throws IOException {
+        Path file = file("resume-norange.bin", 4_096);
+        server.removeContext("/");
+        server.createContext("/", exchange -> {
+            attemptsByPath.computeIfAbsent("/norange", k -> new AtomicInteger()).incrementAndGet();
+            exchange.getRequestBody().readAllBytes();
+            exchange.sendResponseHeaders(308, -1); // no Range: nothing committed, by the protocol
+            exchange.close();
+        });
+
+        assertThatThrownBy(() -> executor.execute(grant(new AttachmentGrant.Upload("resumable", "PUT", base + "/norange",
+            Map.of(), null)), file, null))
+            .isInstanceOf(AttachmentV2Exception.class)
+            .satisfies(e -> {
+                AttachmentV2Exception ex = (AttachmentV2Exception) e;
+                assertThat(ex.problemType()).isEqualTo(AttachmentV2Exception.UPLOAD_UNREACHABLE);
+                assertThat(ex.getMessage()).contains("no progress");
+            });
+        assertThat(attemptsByPath.get("/norange").get()).isEqualTo(AttachmentUploadExecutor.MAX_ATTEMPTS);
+    }
+
+    @Test
+    void aResumableChunkAnsweredFiveHundredIsRePutWithTheSameContentRange() throws IOException {
+        int size = 2_048;
+        Path file = file("resume-503.bin", size);
+        failFirstAttemptsWith.put("/resumable/s3", 503);
+
+        UploadReceipts receipts = executor.execute(grant(new AttachmentGrant.Upload("resumable", "PUT",
+            base + "/resumable/s3", Map.of(), null)), file, null);
+
+        assertThat(receipts.bytesSent()).isEqualTo(size);
+        List<String> ranges = hits.stream().map(h -> h.headers().get("Content-Range")).toList();
+        assertThat(ranges).containsExactly("bytes 0-2047/2048", "bytes 0-2047/2048");
+        assertThat(hits.get(1).body()).isEqualTo(Files.readAllBytes(file));
+    }
+
+    @Test
+    void duplicatePartNumbersAreRejectedBeforeAnyRequest() throws IOException {
+        Path file = file("dup.bin", 200);
+
+        assertThatThrownBy(() -> executor.execute(grant(new AttachmentGrant.Upload("multipart", "PUT", null, Map.of(),
+            List.of(new AttachmentGrant.Part(1, base + "/dup/1", 100), new AttachmentGrant.Part(1, base + "/dup/1b", 100)))),
+            file, null))
+            .isInstanceOf(AttachmentV2Exception.class)
+            .hasMessageContaining("repeats a part number");
+        assertThat(hits).isEmpty();
+    }
+
+    @Test
+    void singleModeReportsByteLevelProgressWhileTheBodyStreams() throws IOException {
+        int size = 3 * 1024 * 1024 + 17;
+        Path file = file("single-progress.bin", size);
+        List<UploadProgress> progress = new ArrayList<>();
+
+        executor.execute(grant(new AttachmentGrant.Upload("single", "PUT", base + "/single/progress", Map.of(), null)),
+            file, progress::add);
+
+        assertThat(progress.size()).isGreaterThanOrEqualTo(4);
+        assertThat(progress.get(0).partsDone()).isZero();
+        assertThat(progress.get(0).bytesSent()).isEqualTo(1024 * 1024);
+        assertThat(progress).isSortedAccordingTo(java.util.Comparator.comparingLong(UploadProgress::bytesSent));
+        assertThat(progress.get(progress.size() - 1)).isEqualTo(new UploadProgress("single", 1, 1, size, size));
+    }
+
+    @Test
     void fileRegionPublisherDeclaresItsLengthAndReadsExactlyItsRegion() throws Exception {
         Path file = file("region.bin", 200_000);
         var publisher = new AttachmentUploadExecutor.FileRegionPublisher(file, 70_000, 100_000);

--- a/connect-library/src/test/java/com/tsanet/api/connectapi/internal/AttachmentUploadExecutorTest.java
+++ b/connect-library/src/test/java/com/tsanet/api/connectapi/internal/AttachmentUploadExecutorTest.java
@@ -1,0 +1,386 @@
+package com.tsanet.api.connectapi.internal;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import com.sun.net.httpserver.HttpExchange;
+import com.sun.net.httpserver.HttpServer;
+import com.tsanet.api.attachments.v2.AttachmentGrant;
+import com.tsanet.api.attachments.v2.AttachmentV2Exception;
+import com.tsanet.api.attachments.v2.UploadProgress;
+import com.tsanet.api.attachments.v2.UploadReceipts;
+import java.io.IOException;
+import java.io.InputStream;
+import java.net.InetSocketAddress;
+import java.net.http.HttpClient;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.time.Duration;
+import java.time.OffsetDateTime;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+import java.util.Map;
+import java.util.UUID;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.CopyOnWriteArrayList;
+import java.util.concurrent.atomic.AtomicInteger;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+
+/**
+ * The executor against the JDK's own HTTP server standing in for signed storage URLs. What
+ * the server records is the property under test: headers received verbatim, the wire
+ * {@code Content-Length} equal to the declared size (a body without a length would go
+ * chunked and be refused by a store that signs the length), part order and bytes, receipts
+ * forwarded intact, 4xx never retried, 5xx retried, resumable offsets recovered.
+ */
+class AttachmentUploadExecutorTest {
+
+    /** One received request. */
+    record Hit(String method, String path, Map<String, String> headers, byte[] body) {
+    }
+
+    private HttpServer server;
+    private String base;
+    private final List<Hit> hits = new CopyOnWriteArrayList<>();
+    private final Map<String, AtomicInteger> attemptsByPath = new ConcurrentHashMap<>();
+    private final Map<String, Integer> failFirstAttemptsWith = new ConcurrentHashMap<>();
+    private final Map<String, Boolean> dropFirstAttempt = new ConcurrentHashMap<>();
+    private final AttachmentUploadExecutor executor = new AttachmentUploadExecutor(
+        HttpClient.newBuilder().version(HttpClient.Version.HTTP_1_1).build(), Duration.ZERO);
+
+    @TempDir
+    Path tmp;
+
+    @BeforeEach
+    void startServer() throws IOException {
+        server = HttpServer.create(new InetSocketAddress("127.0.0.1", 0), 0);
+        server.createContext("/", this::handle);
+        server.start();
+        base = "http://127.0.0.1:" + server.getAddress().getPort();
+    }
+
+    @AfterEach
+    void stopServer() {
+        server.stop(0);
+    }
+
+    private void handle(HttpExchange exchange) throws IOException {
+        String path = exchange.getRequestURI().getPath();
+        int attempt = attemptsByPath.computeIfAbsent(path, k -> new AtomicInteger()).incrementAndGet();
+        Map<String, String> headers = new java.util.TreeMap<>(String.CASE_INSENSITIVE_ORDER);
+        exchange.getRequestHeaders().forEach((k, v) -> headers.put(k, String.join(",", v)));
+        byte[] body;
+        try (InputStream in = exchange.getRequestBody()) {
+            body = in.readAllBytes();
+        }
+        hits.add(new Hit(exchange.getRequestMethod(), path, headers, body));
+        if (attempt == 1 && dropFirstAttempt.getOrDefault(path, false)) {
+            exchange.close(); // no response at all: the client sees an I/O failure
+            return;
+        }
+        Integer failWith = failFirstAttemptsWith.get(path);
+        if (failWith != null && attempt == 1) {
+            exchange.sendResponseHeaders(failWith, -1);
+            exchange.close();
+            return;
+        }
+        if (path.startsWith("/resumable")) {
+            handleResumable(exchange, headers, body);
+            return;
+        }
+        exchange.getResponseHeaders().add("ETag", "\"etag-" + path.substring(path.lastIndexOf('/') + 1) + "\"");
+        exchange.sendResponseHeaders(200, -1);
+        exchange.close();
+    }
+
+    private final Map<String, Long> resumableCommitted = new ConcurrentHashMap<>();
+
+    private void handleResumable(HttpExchange exchange, Map<String, String> headers, byte[] body) throws IOException {
+        String path = exchange.getRequestURI().getPath();
+        String range = headers.get("Content-Range");
+        long committed = resumableCommitted.getOrDefault(path, 0L);
+        if (range.startsWith("bytes */")) {
+            // Offset query: report what is committed.
+            if (committed > 0) {
+                exchange.getResponseHeaders().add("Range", "bytes=0-" + (committed - 1));
+            }
+            exchange.sendResponseHeaders(308, -1);
+            exchange.close();
+            return;
+        }
+        String[] spec = range.substring("bytes ".length()).split("/");
+        String[] bounds = spec[0].split("-");
+        long start = Long.parseLong(bounds[0]);
+        long end = Long.parseLong(bounds[1]);
+        long total = Long.parseLong(spec[1]);
+        if (start != committed) {
+            exchange.sendResponseHeaders(400, -1);
+            exchange.close();
+            return;
+        }
+        committed = end + 1;
+        resumableCommitted.put(path, committed);
+        if (committed >= total) {
+            exchange.sendResponseHeaders(200, -1);
+        } else {
+            exchange.getResponseHeaders().add("Range", "bytes=0-" + (committed - 1));
+            exchange.sendResponseHeaders(308, -1);
+        }
+        exchange.close();
+    }
+
+    private Path file(String name, int size) throws IOException {
+        byte[] bytes = new byte[size];
+        for (int i = 0; i < size; i++) {
+            bytes[i] = (byte) (i * 31 + 7);
+        }
+        Path path = tmp.resolve(name);
+        Files.write(path, bytes);
+        return path;
+    }
+
+    private static AttachmentGrant grant(AttachmentGrant.Upload upload) {
+        return new AttachmentGrant(UUID.randomUUID(), "f.bin", OffsetDateTime.now().plusMinutes(15),
+            new AttachmentGrant.Receiver(1L, "s3", null), upload, new AttachmentGrant.Verification("platform"));
+    }
+
+    private static byte[] region(Path file, long offset, int length) throws IOException {
+        byte[] all = Files.readAllBytes(file);
+        return Arrays.copyOfRange(all, (int) offset, (int) offset + length);
+    }
+
+    @Test
+    void singlePutSendsHeadersVerbatimWithTheExactLengthAndBytes() throws IOException {
+        Path file = file("single.bin", 10_000);
+        Map<String, String> headers = Map.of("Content-Type", "application/octet-stream", "x-ms-blob-type", "BlockBlob",
+            "Content-Length", "10000", "Host", "store.example");
+        List<UploadProgress> progress = new ArrayList<>();
+
+        UploadReceipts receipts = executor.execute(grant(new AttachmentGrant.Upload("single", "PUT",
+            base + "/single/obj", headers, null)), file, progress::add);
+
+        assertThat(receipts.mode()).isEqualTo("single");
+        assertThat(receipts.bytesSent()).isEqualTo(10_000);
+        assertThat(receipts.parts()).isEmpty();
+        Hit hit = hits.get(0);
+        assertThat(hit.method()).isEqualTo("PUT");
+        assertThat(hit.headers()).containsEntry("Content-Type", "application/octet-stream")
+            .containsEntry("x-ms-blob-type", "BlockBlob")
+            .containsEntry("Content-Length", "10000")
+            .doesNotContainKey("Transfer-Encoding");
+        assertThat(hit.headers().get("Host")).startsWith("127.0.0.1");
+        assertThat(hit.body()).isEqualTo(Files.readAllBytes(file));
+        assertThat(progress).containsExactly(new UploadProgress("single", 1, 1, 10_000, 10_000));
+    }
+
+    @Test
+    void multipartPutsEachRegionInOrderAndForwardsReceiptsIntact() throws IOException {
+        Path file = file("multi.bin", 7_000);
+        List<AttachmentGrant.Part> parts = List.of(
+            new AttachmentGrant.Part(2, base + "/multi/2", 2_000),
+            new AttachmentGrant.Part(1, base + "/multi/1", 5_000));
+        List<UploadProgress> progress = new ArrayList<>();
+
+        UploadReceipts receipts = executor.execute(grant(new AttachmentGrant.Upload("multipart", "PUT", null,
+            Map.of("Content-Type", "application/octet-stream"), parts)), file, progress::add);
+
+        assertThat(receipts.parts()).extracting(r -> r.partNumber()).containsExactly(1, 2);
+        assertThat(receipts.parts()).extracting(r -> r.receipt()).containsExactly("\"etag-1\"", "\"etag-2\"");
+        assertThat(hits).hasSize(2);
+        assertThat(hits.get(0).path()).isEqualTo("/multi/1");
+        assertThat(hits.get(0).headers()).containsEntry("Content-Length", "5000");
+        assertThat(hits.get(0).body()).isEqualTo(region(file, 0, 5_000));
+        assertThat(hits.get(1).path()).isEqualTo("/multi/2");
+        assertThat(hits.get(1).headers()).containsEntry("Content-Length", "2000");
+        assertThat(hits.get(1).body()).isEqualTo(region(file, 5_000, 2_000));
+        assertThat(progress).containsExactly(
+            new UploadProgress("multipart", 1, 2, 5_000, 7_000),
+            new UploadProgress("multipart", 2, 2, 7_000, 7_000));
+    }
+
+    @Test
+    void aTransientPartFailureIsRetriedWithAFreshBody() throws IOException {
+        Path file = file("retry.bin", 3_000);
+        failFirstAttemptsWith.put("/retry/1", 503);
+
+        UploadReceipts receipts = executor.execute(grant(new AttachmentGrant.Upload("multipart", "PUT", null, Map.of(),
+            List.of(new AttachmentGrant.Part(1, base + "/retry/1", 3_000)))), file, null);
+
+        assertThat(receipts.parts()).hasSize(1);
+        assertThat(attemptsByPath.get("/retry/1").get()).isEqualTo(2);
+        assertThat(hits.get(1).body()).isEqualTo(Files.readAllBytes(file));
+    }
+
+    @Test
+    void aRejectedPartIsNeverRetriedAndTheMessageCarriesNoUrl() throws IOException {
+        Path file = file("forbidden.bin", 100);
+        failFirstAttemptsWith.put("/forbidden/1", 403);
+        // A 403 is what an expired signed URL answers; that is terminal for the executor.
+        failFirstAttemptsWith.put("/forbidden/2", 403);
+
+        assertThatThrownBy(() -> executor.execute(grant(new AttachmentGrant.Upload("multipart", "PUT", null, Map.of(),
+            List.of(new AttachmentGrant.Part(1, base + "/forbidden/1?sig=SECRET", 100)))), file, null))
+            .isInstanceOf(AttachmentV2Exception.class)
+            .satisfies(e -> {
+                AttachmentV2Exception ex = (AttachmentV2Exception) e;
+                assertThat(ex.status()).isEqualTo(403);
+                assertThat(ex.problemType()).isEqualTo(AttachmentV2Exception.UPLOAD_REJECTED);
+                assertThat(ex.getMessage()).doesNotContain("SECRET").doesNotContain("127.0.0.1");
+            });
+        assertThat(attemptsByPath.get("/forbidden/1").get()).isEqualTo(1);
+    }
+
+    @Test
+    void aTransientStatusAfterTheRetryBudgetIsReportedAsRejected() throws IOException {
+        Path file = file("down.bin", 100);
+        // Every attempt answers 503: the budget is exhausted and the last status is reported.
+        server.removeContext("/");
+        server.createContext("/", exchange -> {
+            attemptsByPath.computeIfAbsent("/down", k -> new AtomicInteger()).incrementAndGet();
+            exchange.getRequestBody().readAllBytes();
+            exchange.sendResponseHeaders(503, -1);
+            exchange.close();
+        });
+
+        assertThatThrownBy(() -> executor.execute(grant(new AttachmentGrant.Upload("single", "PUT", base + "/down",
+            Map.of(), null)), file, null))
+            .isInstanceOf(AttachmentV2Exception.class)
+            .satisfies(e -> assertThat(((AttachmentV2Exception) e).status()).isEqualTo(503));
+        assertThat(attemptsByPath.get("/down").get()).isEqualTo(AttachmentUploadExecutor.MAX_ATTEMPTS);
+    }
+
+    @Test
+    void aTargetThatNeverAnswersSurfacesAsUnreachableThroughTheFacadeException() throws IOException {
+        Path file = file("silent.bin", 100);
+        // Every attempt is dropped without a response: the internal I/O signal must become
+        // the facade's UPLOAD_UNREACHABLE, never a private exception type.
+        server.removeContext("/");
+        server.createContext("/", exchange -> {
+            attemptsByPath.computeIfAbsent("/silent", k -> new AtomicInteger()).incrementAndGet();
+            exchange.getRequestBody().readAllBytes();
+            exchange.close();
+        });
+
+        assertThatThrownBy(() -> executor.execute(grant(new AttachmentGrant.Upload("single", "PUT", base + "/silent?sig=SECRET",
+            Map.of(), null)), file, null))
+            .isInstanceOf(AttachmentV2Exception.class)
+            .satisfies(e -> {
+                AttachmentV2Exception ex = (AttachmentV2Exception) e;
+                assertThat(ex.problemType()).isEqualTo(AttachmentV2Exception.UPLOAD_UNREACHABLE);
+                assertThat(ex.status()).isZero();
+                assertThat(ex.getMessage()).doesNotContain("SECRET").doesNotContain("127.0.0.1");
+                assertThat(ex.getCause()).isInstanceOf(IOException.class);
+            });
+        assertThat(attemptsByPath.get("/silent").get()).isEqualTo(AttachmentUploadExecutor.MAX_ATTEMPTS);
+    }
+
+    @Test
+    void relayIsASinglePutThatIsNotRetriedOnceTheReceiverAnswered() throws IOException {
+        Path file = file("relay.bin", 500);
+        failFirstAttemptsWith.put("/relay", 503);
+
+        assertThatThrownBy(() -> executor.execute(grant(new AttachmentGrant.Upload("relay", "PUT", base + "/relay",
+            Map.of("X-Grant-Token", "tok-1", "Content-Type", "application/octet-stream"), null)), file, null))
+            .isInstanceOf(AttachmentV2Exception.class)
+            .satisfies(e -> assertThat(((AttachmentV2Exception) e).status()).isEqualTo(503));
+        assertThat(attemptsByPath.get("/relay").get()).isEqualTo(1);
+        assertThat(hits.get(0).headers()).containsEntry("X-Grant-Token", "tok-1").containsEntry("Content-Length", "500");
+    }
+
+    @Test
+    void resumableSendsChunksWithContentRangeUntilTheLastOneIsAccepted() throws IOException {
+        int size = AttachmentUploadExecutor.RESUMABLE_CHUNK * 2 + 1_234;
+        Path file = file("resumable.bin", size);
+        List<UploadProgress> progress = new ArrayList<>();
+
+        UploadReceipts receipts = executor.execute(grant(new AttachmentGrant.Upload("resumable", "PUT",
+            base + "/resumable/s1", Map.of("Content-Type", "application/octet-stream"), null)), file, progress::add);
+
+        assertThat(receipts.mode()).isEqualTo("resumable");
+        assertThat(receipts.bytesSent()).isEqualTo(size);
+        assertThat(hits).hasSize(3);
+        assertThat(hits.get(0).headers()).containsEntry("Content-Range", "bytes 0-" + (AttachmentUploadExecutor.RESUMABLE_CHUNK - 1) + "/" + size);
+        assertThat(hits.get(2).headers()).containsEntry("Content-Range",
+            "bytes " + (2L * AttachmentUploadExecutor.RESUMABLE_CHUNK) + "-" + (size - 1) + "/" + size);
+        assertThat(hits.get(2).body()).isEqualTo(region(file, 2L * AttachmentUploadExecutor.RESUMABLE_CHUNK, 1_234));
+        assertThat(progress).extracting(UploadProgress::partsDone).containsExactly(1, 2, 3);
+        assertThat(progress.get(2).bytesSent()).isEqualTo(size);
+    }
+
+    @Test
+    void resumableRecoversTheCommittedOffsetAfterALostConnection() throws IOException {
+        int size = AttachmentUploadExecutor.RESUMABLE_CHUNK + 999;
+        Path file = file("resume-lost.bin", size);
+        dropFirstAttempt.put("/resumable/s2", true);
+        // The server takes the first chunk's bytes, then drops the connection without answering.
+        // The executor must ask "bytes */total", learn that nothing was committed, and resend.
+        UploadReceipts receipts = executor.execute(grant(new AttachmentGrant.Upload("resumable", "PUT",
+            base + "/resumable/s2", Map.of(), null)), file, null);
+
+        assertThat(receipts.bytesSent()).isEqualTo(size);
+        List<String> ranges = hits.stream().map(h -> h.headers().get("Content-Range")).toList();
+        assertThat(ranges).containsExactly(
+            "bytes 0-" + (AttachmentUploadExecutor.RESUMABLE_CHUNK - 1) + "/" + size,
+            "bytes */" + size,
+            "bytes 0-" + (AttachmentUploadExecutor.RESUMABLE_CHUNK - 1) + "/" + size,
+            "bytes " + AttachmentUploadExecutor.RESUMABLE_CHUNK + "-" + (size - 1) + "/" + size);
+        assertThat(hits.get(3).body()).isEqualTo(region(file, AttachmentUploadExecutor.RESUMABLE_CHUNK, 999));
+    }
+
+    @Test
+    void unknownModeAndMismatchedPartsFailBeforeAnyRequest() throws IOException {
+        Path file = file("pre.bin", 10);
+
+        assertThatThrownBy(() -> executor.execute(grant(new AttachmentGrant.Upload("torrent", "PUT", base + "/x", Map.of(), null)), file, null))
+            .isInstanceOf(AttachmentV2Exception.class)
+            .satisfies(e -> assertThat(((AttachmentV2Exception) e).problemType()).isEqualTo(AttachmentV2Exception.UNSUPPORTED_UPLOAD_MODE));
+        assertThatThrownBy(() -> executor.execute(grant(new AttachmentGrant.Upload("multipart", "PUT", null, Map.of(),
+            List.of(new AttachmentGrant.Part(1, base + "/x/1", 9)))), file, null))
+            .isInstanceOf(AttachmentV2Exception.class)
+            .hasMessageContaining("parts total 9 bytes but the file is 10 bytes");
+        assertThat(hits).isEmpty();
+    }
+
+    @Test
+    void fileRegionPublisherDeclaresItsLengthAndReadsExactlyItsRegion() throws Exception {
+        Path file = file("region.bin", 200_000);
+        var publisher = new AttachmentUploadExecutor.FileRegionPublisher(file, 70_000, 100_000);
+        assertThat(publisher.contentLength()).isEqualTo(100_000);
+
+        java.io.ByteArrayOutputStream collected = new java.io.ByteArrayOutputStream();
+        var done = new java.util.concurrent.CompletableFuture<Void>();
+        publisher.subscribe(new java.util.concurrent.Flow.Subscriber<>() {
+            java.util.concurrent.Flow.Subscription subscription;
+
+            @Override
+            public void onSubscribe(java.util.concurrent.Flow.Subscription s) {
+                subscription = s;
+                s.request(1);
+            }
+
+            @Override
+            public void onNext(java.nio.ByteBuffer item) {
+                byte[] b = new byte[item.remaining()];
+                item.get(b);
+                collected.writeBytes(b);
+                subscription.request(1);
+            }
+
+            @Override
+            public void onError(Throwable t) {
+                done.completeExceptionally(t);
+            }
+
+            @Override
+            public void onComplete() {
+                done.complete(null);
+            }
+        });
+        done.get(10, java.util.concurrent.TimeUnit.SECONDS);
+        assertThat(collected.toByteArray()).isEqualTo(region(file, 70_000, 100_000));
+    }
+}

--- a/connect-library/src/test/java/com/tsanet/api/connectapi/internal/ConnectApiAttachmentsV2ApiTest.java
+++ b/connect-library/src/test/java/com/tsanet/api/connectapi/internal/ConnectApiAttachmentsV2ApiTest.java
@@ -1,0 +1,191 @@
+package com.tsanet.api.connectapi.internal;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.springframework.test.web.client.match.MockRestRequestMatchers.content;
+import static org.springframework.test.web.client.match.MockRestRequestMatchers.header;
+import static org.springframework.test.web.client.match.MockRestRequestMatchers.method;
+import static org.springframework.test.web.client.match.MockRestRequestMatchers.requestTo;
+import static org.springframework.test.web.client.response.MockRestResponseCreators.withStatus;
+import static org.springframework.test.web.client.response.MockRestResponseCreators.withSuccess;
+
+import com.tsanet.api.attachments.v2.AttachmentCompleteRequest;
+import com.tsanet.api.attachments.v2.AttachmentCompleteResult;
+import com.tsanet.api.attachments.v2.AttachmentGrant;
+import com.tsanet.api.attachments.v2.AttachmentGrantRequest;
+import com.tsanet.api.attachments.v2.AttachmentV2Exception;
+import com.tsanet.api.generated.invoker.ApiClient;
+import java.util.List;
+import java.util.UUID;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.http.HttpMethod;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.MediaType;
+import org.springframework.test.web.client.MockRestServiceServer;
+import org.springframework.web.client.RestTemplate;
+
+/**
+ * The V2 calls through the real {@link ApiClient} and its converters, against a mock server:
+ * the JSON on the wire is the contract's (tsanetgit/Connect-API-Code#147) field for field,
+ * the bearer and idempotency headers ride along, and problem-details answers come back as
+ * value-free {@link AttachmentV2Exception}s.
+ */
+class ConnectApiAttachmentsV2ApiTest {
+
+    private static final String BASE = "https://connect.example";
+    private static final String TOKEN = "case-token-1";
+    private static final UUID GRANT_ID = UUID.fromString("3f2b7e6a-2c1d-4a4e-9b8f-0c1d2e3f4a5b");
+
+    private MockRestServiceServer server;
+    private ConnectApiAttachmentsV2Api api;
+
+    @BeforeEach
+    void setUp() {
+        RestTemplate restTemplate = new RestTemplate();
+        server = MockRestServiceServer.bindTo(restTemplate).build();
+        ApiClient apiClient = new ApiClient(restTemplate);
+        apiClient.setBasePath(BASE);
+        apiClient.setBearerToken(() -> "bearer-123");
+        api = new ConnectApiAttachmentsV2Api(apiClient);
+    }
+
+    @Test
+    void grantSendsTheContractBodyWithBearerAndIdempotencyKeyAndReadsTheGrant() {
+        String expectedBody = "{\"fileName\":\"diag.log\",\"contentType\":\"text/plain\",\"sizeBytes\":12,"
+            + "\"sha256\":\"ab\",\"description\":\"logs\"}";
+        String grantJson = "{\"grantId\":\"" + GRANT_ID + "\",\"fileName\":\"diag.log\","
+            + "\"expiresAt\":\"2026-09-08T10:00:00Z\","
+            + "\"receiver\":{\"companyId\":7,\"targetKind\":\"s3\",\"maxSizeBytes\":5000000000},"
+            + "\"upload\":{\"mode\":\"multipart\",\"method\":\"PUT\","
+            + "\"headers\":{\"Content-Type\":\"application/octet-stream\"},"
+            + "\"parts\":[{\"partNumber\":1,\"url\":\"https://store.example/p1?sig=SECRET\",\"sizeBytes\":8},"
+            + "{\"partNumber\":2,\"url\":\"https://store.example/p2?sig=SECRET\",\"sizeBytes\":4}]},"
+            + "\"verification\":{\"mode\":\"platform\"},\"futureField\":true}";
+        server.expect(requestTo(BASE + "/v2/collaboration-requests/" + TOKEN + "/attachments/grants"))
+            .andExpect(method(HttpMethod.POST))
+            .andExpect(header("Authorization", "Bearer bearer-123"))
+            .andExpect(header("Idempotency-Key", "idem-1"))
+            .andExpect(content().json(expectedBody, true))
+            .andRespond(withStatus(HttpStatus.CREATED).contentType(MediaType.APPLICATION_JSON).body(grantJson));
+
+        AttachmentGrant grant = api.createGrant(TOKEN,
+            new AttachmentGrantRequest("diag.log", "text/plain", 12, "ab", "logs"), "idem-1");
+
+        assertThat(grant.grantId()).isEqualTo(GRANT_ID);
+        assertThat(grant.receiver().targetKind()).isEqualTo("s3");
+        assertThat(grant.upload().mode()).isEqualTo("multipart");
+        assertThat(grant.upload().headers()).containsEntry("Content-Type", "application/octet-stream");
+        assertThat(grant.upload().parts()).hasSize(2);
+        assertThat(grant.upload().parts().get(1).sizeBytes()).isEqualTo(4);
+        assertThat(grant.verification().mode()).isEqualTo("platform");
+        assertThat(grant.toString()).doesNotContain("SECRET").doesNotContain("store.example");
+        server.verify();
+    }
+
+    @Test
+    void grantOmitsAbsentOptionalFields() {
+        server.expect(requestTo(BASE + "/v2/collaboration-requests/" + TOKEN + "/attachments/grants"))
+            .andExpect(content().json("{\"fileName\":\"a.bin\",\"contentType\":\"application/octet-stream\",\"sizeBytes\":1}", true))
+            .andRespond(withStatus(HttpStatus.CREATED).contentType(MediaType.APPLICATION_JSON)
+                .body("{\"grantId\":\"" + GRANT_ID + "\",\"fileName\":\"a.bin\",\"expiresAt\":\"2026-09-08T10:00:00Z\","
+                    + "\"upload\":{\"mode\":\"single\",\"url\":\"https://store.example/a\"},\"verification\":{\"mode\":\"none\"}}"));
+
+        AttachmentGrant grant = api.createGrant(TOKEN,
+            new AttachmentGrantRequest("a.bin", "application/octet-stream", 1, null, null), null);
+
+        assertThat(grant.upload().parts()).isEmpty();
+        assertThat(grant.upload().headers()).isEmpty();
+        server.verify();
+    }
+
+    @Test
+    void completeSendsReceiptsAndReadsTheRecordedOutcome() {
+        server.expect(requestTo(BASE + "/v2/collaboration-requests/" + TOKEN + "/attachments/grants/" + GRANT_ID + "/complete"))
+            .andExpect(method(HttpMethod.POST))
+            .andExpect(content().json("{\"sizeBytes\":12,\"parts\":[{\"partNumber\":1,\"receipt\":\"\\\"etag-1\\\"\"},"
+                + "{\"partNumber\":2,\"receipt\":\"\\\"etag-2\\\"\"}]}", true))
+            .andRespond(withSuccess("{\"grantId\":\"" + GRANT_ID + "\",\"fileName\":\"diag.log\",\"status\":\"DELIVERED\","
+                + "\"verification\":{\"method\":\"HEAD\",\"verifiedAt\":\"2026-09-08T10:01:00Z\",\"sizeMatched\":true},"
+                + "\"noteId\":501,\"message\":\"stored\"}", MediaType.APPLICATION_JSON));
+
+        AttachmentCompleteResult result = api.complete(TOKEN, GRANT_ID, new AttachmentCompleteRequest(12, null,
+            List.of(new AttachmentCompleteRequest.PartReceipt(1, "\"etag-1\""),
+                new AttachmentCompleteRequest.PartReceipt(2, "\"etag-2\""))));
+
+        assertThat(result.delivered()).isTrue();
+        assertThat(result.verification().sizeMatched()).isTrue();
+        assertThat(result.noteId()).isEqualTo(501L);
+        server.verify();
+    }
+
+    @Test
+    void singleModeCompleteCarriesOnlyTheSize() {
+        server.expect(requestTo(BASE + "/v2/collaboration-requests/" + TOKEN + "/attachments/grants/" + GRANT_ID + "/complete"))
+            .andExpect(content().json("{\"sizeBytes\":3}", true))
+            .andRespond(withSuccess("{\"grantId\":\"" + GRANT_ID + "\",\"fileName\":\"a\",\"status\":\"DELIVERED_UNVERIFIED\"}",
+                MediaType.APPLICATION_JSON));
+
+        AttachmentCompleteResult result = api.complete(TOKEN, GRANT_ID, new AttachmentCompleteRequest(3, null, List.of()));
+
+        assertThat(result.deliveredUnverified()).isTrue();
+        assertThat(result.delivered()).isFalse();
+        server.verify();
+    }
+
+    @Test
+    void abandonIsADeleteOnTheGrant() {
+        server.expect(requestTo(BASE + "/v2/collaboration-requests/" + TOKEN + "/attachments/grants/" + GRANT_ID))
+            .andExpect(method(HttpMethod.DELETE))
+            .andRespond(withStatus(HttpStatus.NO_CONTENT));
+
+        api.abandon(TOKEN, GRANT_ID);
+
+        server.verify();
+    }
+
+    @Test
+    void problemDetailsBecomeATypedValueFreeException() {
+        server.expect(requestTo(BASE + "/v2/collaboration-requests/" + TOKEN + "/attachments/grants/" + GRANT_ID + "/complete"))
+            .andRespond(withStatus(HttpStatus.CONFLICT).contentType(MediaType.APPLICATION_PROBLEM_JSON)
+                .body("{\"type\":\"attachment/grant-expired\",\"title\":\"Grant expired\",\"status\":409,"
+                    + "\"detail\":\"The grant expired before completion\"}"));
+
+        assertThatThrownBy(() -> api.complete(TOKEN, GRANT_ID, new AttachmentCompleteRequest(3, null, List.of())))
+            .isInstanceOf(AttachmentV2Exception.class)
+            .satisfies(e -> {
+                AttachmentV2Exception ex = (AttachmentV2Exception) e;
+                assertThat(ex.status()).isEqualTo(409);
+                assertThat(ex.problemType()).isEqualTo("attachment/grant-expired");
+                assertThat(ex.isProblem(AttachmentV2Exception.GRANT_EXPIRED)).isTrue();
+                assertThat(ex.getMessage()).contains("HTTP 409").contains("Grant expired").contains("before completion");
+            });
+    }
+
+    @Test
+    void aNonProblemErrorBodyYieldsTheStatusAlone() {
+        server.expect(requestTo(BASE + "/v2/collaboration-requests/" + TOKEN + "/attachments/grants"))
+            .andRespond(withStatus(HttpStatus.BAD_GATEWAY).contentType(MediaType.TEXT_HTML).body("<html>gateway sig=SECRET</html>"));
+
+        assertThatThrownBy(() -> api.createGrant(TOKEN,
+            new AttachmentGrantRequest("a", "text/plain", 1, null, null), "k"))
+            .isInstanceOf(AttachmentV2Exception.class)
+            .satisfies(e -> {
+                AttachmentV2Exception ex = (AttachmentV2Exception) e;
+                assertThat(ex.status()).isEqualTo(502);
+                assertThat(ex.problemType()).isNull();
+                assertThat(ex.getMessage()).contains("HTTP 502").doesNotContain("SECRET");
+            });
+    }
+
+    @Test
+    void aGrantWithoutAnUploadBlockIsRejectedClientSide() {
+        server.expect(requestTo(BASE + "/v2/collaboration-requests/" + TOKEN + "/attachments/grants"))
+            .andRespond(withStatus(HttpStatus.CREATED).contentType(MediaType.APPLICATION_JSON)
+                .body("{\"grantId\":\"" + GRANT_ID + "\",\"fileName\":\"a\"}"));
+
+        assertThatThrownBy(() -> api.createGrant(TOKEN, new AttachmentGrantRequest("a", "text/plain", 1, null, null), null))
+            .isInstanceOf(AttachmentV2Exception.class)
+            .hasMessageContaining("upload block");
+    }
+}

--- a/connect-library/src/test/java/com/tsanet/api/connectapi/internal/ConnectApiAttachmentsV2ApiTest.java
+++ b/connect-library/src/test/java/com/tsanet/api/connectapi/internal/ConnectApiAttachmentsV2ApiTest.java
@@ -179,13 +179,34 @@ class ConnectApiAttachmentsV2ApiTest {
     }
 
     @Test
-    void aGrantWithoutAnUploadBlockIsRejectedClientSide() {
+    void aGrantWithoutAnUploadBlockIsRejectedClientSideWithTheRealStatus() {
         server.expect(requestTo(BASE + "/v2/collaboration-requests/" + TOKEN + "/attachments/grants"))
             .andRespond(withStatus(HttpStatus.CREATED).contentType(MediaType.APPLICATION_JSON)
                 .body("{\"grantId\":\"" + GRANT_ID + "\",\"fileName\":\"a\"}"));
 
         assertThatThrownBy(() -> api.createGrant(TOKEN, new AttachmentGrantRequest("a", "text/plain", 1, null, null), null))
             .isInstanceOf(AttachmentV2Exception.class)
-            .hasMessageContaining("upload block");
+            .hasMessageContaining("upload block")
+            .satisfies(e -> assertThat(((AttachmentV2Exception) e).status()).isEqualTo(201));
+    }
+
+    @Test
+    void aConnectivityFailureNeverEchoesTheCaseTokenThatRidesInTheUrl() {
+        // A real RestTemplate against a closed port: Spring's own message carries the expanded
+        // request URL, and the V2 paths carry the case token in that URL.
+        ApiClient dead = new ApiClient(new RestTemplate());
+        dead.setBasePath("http://127.0.0.1:1");
+        dead.setBearerToken(() -> "bearer-123");
+        ConnectApiAttachmentsV2Api deadApi = new ConnectApiAttachmentsV2Api(dead);
+
+        assertThatThrownBy(() -> deadApi.createGrant("CASETOKEN-MARKER",
+            new AttachmentGrantRequest("a", "text/plain", 1, null, null), "k"))
+            .isInstanceOf(AttachmentV2Exception.class)
+            .satisfies(e -> {
+                AttachmentV2Exception ex = (AttachmentV2Exception) e;
+                assertThat(ex.problemType()).isEqualTo(AttachmentV2Exception.CONNECTIVITY);
+                assertThat(ex.status()).isZero();
+                assertThat(ex.getMessage()).doesNotContain("MARKER").doesNotContain("127.0.0.1");
+            });
     }
 }

--- a/connect-library/src/test/java/com/tsanet/api/connectapi/internal/ConnectApiAttachmentsV2GatewayTest.java
+++ b/connect-library/src/test/java/com/tsanet/api/connectapi/internal/ConnectApiAttachmentsV2GatewayTest.java
@@ -58,7 +58,8 @@ class ConnectApiAttachmentsV2GatewayTest {
 
     @BeforeEach
     void setUp() throws Exception {
-        gateway = new ConnectApiAttachmentsV2Gateway(api, GatewayTestSupport.authenticatedSessionStore(), executor);
+        gateway = new ConnectApiAttachmentsV2Gateway(api, GatewayTestSupport.authenticatedSessionStore(), executor,
+            java.time.Duration.ZERO);
         file = tmp.resolve("diag.log");
         Files.write(file, "hello attachments".getBytes(StandardCharsets.UTF_8));
     }
@@ -200,7 +201,7 @@ class ConnectApiAttachmentsV2GatewayTest {
     @Test
     void everyCallRequiresALogin() {
         ConnectApiAttachmentsV2Gateway loggedOut =
-            new ConnectApiAttachmentsV2Gateway(api, new ConnectApiSessionStore(), executor);
+            new ConnectApiAttachmentsV2Gateway(api, new ConnectApiSessionStore(), executor, java.time.Duration.ZERO);
 
         assertThatThrownBy(() -> loggedOut.grant(TOKEN, new AttachmentGrantRequest("a", "b", 1, null, null)))
             .isInstanceOf(IllegalStateException.class);

--- a/connect-library/src/test/java/com/tsanet/api/connectapi/internal/ConnectApiAttachmentsV2GatewayTest.java
+++ b/connect-library/src/test/java/com/tsanet/api/connectapi/internal/ConnectApiAttachmentsV2GatewayTest.java
@@ -1,0 +1,218 @@
+package com.tsanet.api.connectapi.internal;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.doThrow;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import com.tsanet.api.attachments.v2.AttachmentCompleteRequest;
+import com.tsanet.api.attachments.v2.AttachmentCompleteResult;
+import com.tsanet.api.attachments.v2.AttachmentGrant;
+import com.tsanet.api.attachments.v2.AttachmentGrantRequest;
+import com.tsanet.api.attachments.v2.AttachmentV2Exception;
+import com.tsanet.api.attachments.v2.UploadReceipts;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.time.OffsetDateTime;
+import java.util.List;
+import java.util.Map;
+import java.util.UUID;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.junit.jupiter.api.io.TempDir;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+/**
+ * The flow rules, with the Connect API seam and the executor mocked: abandon on upload
+ * failure, one re-grant on a complete-time grant-expired, complete retried on transient
+ * failure, the platform's outcome returned unchanged, and the digest computed only on
+ * request.
+ */
+@ExtendWith(MockitoExtension.class)
+class ConnectApiAttachmentsV2GatewayTest {
+
+    private static final String TOKEN = "case-1";
+    private static final UUID GRANT_A = UUID.randomUUID();
+    private static final UUID GRANT_B = UUID.randomUUID();
+
+    @Mock
+    private AttachmentsV2Api api;
+    @Mock
+    private AttachmentUploadExecutor executor;
+
+    private ConnectApiAttachmentsV2Gateway gateway;
+    private Path file;
+
+    @TempDir
+    Path tmp;
+
+    @BeforeEach
+    void setUp() throws Exception {
+        gateway = new ConnectApiAttachmentsV2Gateway(api, GatewayTestSupport.authenticatedSessionStore(), executor);
+        file = tmp.resolve("diag.log");
+        Files.write(file, "hello attachments".getBytes(StandardCharsets.UTF_8));
+    }
+
+    private static AttachmentGrant grant(UUID id) {
+        return new AttachmentGrant(id, "diag.log", OffsetDateTime.now().plusMinutes(15), null,
+            new AttachmentGrant.Upload("single", "PUT", "https://store.example/x", Map.of(), null),
+            new AttachmentGrant.Verification("platform"));
+    }
+
+    private static AttachmentCompleteResult outcome(UUID id, String status) {
+        return new AttachmentCompleteResult(id, "diag.log", status, null, 9L, null);
+    }
+
+    @Test
+    void sendGrantsUploadsAndCompletesWithTheReceiptsAndReturnsThePlatformsOutcome() {
+        when(api.createGrant(eq(TOKEN), any(), anyString())).thenReturn(grant(GRANT_A));
+        when(executor.execute(any(), eq(file), any())).thenReturn(new UploadReceipts("multipart", 17,
+            List.of(new AttachmentCompleteRequest.PartReceipt(1, "\"e1\""))));
+        when(api.complete(eq(TOKEN), eq(GRANT_A), any())).thenReturn(outcome(GRANT_A, "DELIVERED_UNVERIFIED"));
+
+        AttachmentCompleteResult result = gateway.send(TOKEN, file, "text/plain", "  logs ", false, null);
+
+        assertThat(result.status()).isEqualTo("DELIVERED_UNVERIFIED");
+        ArgumentCaptor<AttachmentGrantRequest> request = ArgumentCaptor.forClass(AttachmentGrantRequest.class);
+        verify(api).createGrant(eq(TOKEN), request.capture(), anyString());
+        assertThat(request.getValue().fileName()).isEqualTo("diag.log");
+        assertThat(request.getValue().contentType()).isEqualTo("text/plain");
+        assertThat(request.getValue().sizeBytes()).isEqualTo(17);
+        assertThat(request.getValue().sha256()).isNull();
+        assertThat(request.getValue().description()).isEqualTo("logs");
+        ArgumentCaptor<AttachmentCompleteRequest> complete = ArgumentCaptor.forClass(AttachmentCompleteRequest.class);
+        verify(api).complete(eq(TOKEN), eq(GRANT_A), complete.capture());
+        assertThat(complete.getValue().sizeBytes()).isEqualTo(17);
+        assertThat(complete.getValue().parts()).extracting(AttachmentCompleteRequest.PartReceipt::receipt).containsExactly("\"e1\"");
+        verify(api, never()).abandon(any(), any());
+    }
+
+    @Test
+    void sendComputesTheDigestOnlyWhenAskedAndForwardsItOnGrantAndComplete() {
+        when(api.createGrant(eq(TOKEN), any(), anyString())).thenReturn(grant(GRANT_A));
+        when(executor.execute(any(), eq(file), any())).thenReturn(new UploadReceipts("single", 17, List.of()));
+        when(api.complete(eq(TOKEN), eq(GRANT_A), any())).thenReturn(outcome(GRANT_A, "DELIVERED"));
+
+        gateway.send(TOKEN, file, null, null, true, null);
+
+        String expected = ConnectApiAttachmentsV2Gateway.sha256Of(file);
+        assertThat(expected).hasSize(64);
+        ArgumentCaptor<AttachmentGrantRequest> request = ArgumentCaptor.forClass(AttachmentGrantRequest.class);
+        verify(api).createGrant(eq(TOKEN), request.capture(), anyString());
+        assertThat(request.getValue().sha256()).isEqualTo(expected);
+        assertThat(request.getValue().contentType()).isEqualTo(ConnectApiAttachmentsV2Gateway.DEFAULT_CONTENT_TYPE);
+        ArgumentCaptor<AttachmentCompleteRequest> complete = ArgumentCaptor.forClass(AttachmentCompleteRequest.class);
+        verify(api).complete(eq(TOKEN), eq(GRANT_A), complete.capture());
+        assertThat(complete.getValue().sha256()).isEqualTo(expected);
+    }
+
+    @Test
+    void anUploadFailureAbandonsTheGrantAndNeverCompletes() {
+        when(api.createGrant(eq(TOKEN), any(), anyString())).thenReturn(grant(GRANT_A));
+        AttachmentV2Exception rejected = new AttachmentV2Exception("part 1 was rejected", 403, AttachmentV2Exception.UPLOAD_REJECTED);
+        when(executor.execute(any(), eq(file), any())).thenThrow(rejected);
+
+        assertThatThrownBy(() -> gateway.send(TOKEN, file, "text/plain", null, false, null)).isSameAs(rejected);
+
+        verify(api).abandon(TOKEN, GRANT_A);
+        verify(api, never()).complete(any(), any(), any());
+    }
+
+    @Test
+    void anAbandonFailureRidesAsSuppressedOnTheUploadFailure() {
+        when(api.createGrant(eq(TOKEN), any(), anyString())).thenReturn(grant(GRANT_A));
+        when(executor.execute(any(), eq(file), any()))
+            .thenThrow(new AttachmentV2Exception("unreachable", 0, AttachmentV2Exception.UPLOAD_UNREACHABLE));
+        doThrow(new AttachmentV2Exception("abandon failed", 503, null)).when(api).abandon(TOKEN, GRANT_A);
+
+        assertThatThrownBy(() -> gateway.send(TOKEN, file, "text/plain", null, false, null))
+            .isInstanceOf(AttachmentV2Exception.class)
+            .hasMessage("unreachable")
+            .satisfies(e -> assertThat(e.getSuppressed()).hasSize(1)
+                .allSatisfy(s -> assertThat(s.getMessage()).isEqualTo("abandon failed")));
+    }
+
+    @Test
+    void aGrantExpiredOnCompleteRegrantsExactlyOnce() {
+        when(api.createGrant(eq(TOKEN), any(), anyString())).thenReturn(grant(GRANT_A), grant(GRANT_B));
+        when(executor.execute(any(), eq(file), any())).thenReturn(new UploadReceipts("single", 17, List.of()));
+        when(api.complete(eq(TOKEN), eq(GRANT_A), any()))
+            .thenThrow(new AttachmentV2Exception("expired", 409, AttachmentV2Exception.GRANT_EXPIRED));
+        when(api.complete(eq(TOKEN), eq(GRANT_B), any())).thenReturn(outcome(GRANT_B, "DELIVERED"));
+
+        AttachmentCompleteResult result = gateway.send(TOKEN, file, "text/plain", null, false, null);
+
+        assertThat(result.grantId()).isEqualTo(GRANT_B);
+        verify(api, times(2)).createGrant(eq(TOKEN), any(), anyString());
+        verify(executor, times(2)).execute(any(), eq(file), any());
+    }
+
+    @Test
+    void aSecondGrantExpiredIsNotRetriedAgain() {
+        when(api.createGrant(eq(TOKEN), any(), anyString())).thenReturn(grant(GRANT_A), grant(GRANT_B));
+        when(executor.execute(any(), eq(file), any())).thenReturn(new UploadReceipts("single", 17, List.of()));
+        when(api.complete(eq(TOKEN), any(), any()))
+            .thenThrow(new AttachmentV2Exception("expired", 409, AttachmentV2Exception.GRANT_EXPIRED));
+
+        assertThatThrownBy(() -> gateway.send(TOKEN, file, "text/plain", null, false, null))
+            .isInstanceOf(AttachmentV2Exception.class)
+            .satisfies(e -> assertThat(((AttachmentV2Exception) e).isProblem(AttachmentV2Exception.GRANT_EXPIRED)).isTrue());
+        verify(api, times(2)).createGrant(eq(TOKEN), any(), anyString());
+    }
+
+    @Test
+    void completeIsRetriedOnTransientFailureBecauseItIsIdempotent() {
+        when(api.createGrant(eq(TOKEN), any(), anyString())).thenReturn(grant(GRANT_A));
+        when(executor.execute(any(), eq(file), any())).thenReturn(new UploadReceipts("single", 17, List.of()));
+        when(api.complete(eq(TOKEN), eq(GRANT_A), any()))
+            .thenThrow(new AttachmentV2Exception("gateway", 502, null))
+            .thenThrow(new AttachmentV2Exception("down", 0, AttachmentV2Exception.CONNECTIVITY))
+            .thenReturn(outcome(GRANT_A, "FAILED"));
+
+        AttachmentCompleteResult result = gateway.send(TOKEN, file, "text/plain", null, false, null);
+
+        assertThat(result.status()).isEqualTo("FAILED");
+        verify(api, times(3)).complete(eq(TOKEN), eq(GRANT_A), any());
+    }
+
+    @Test
+    void aFourHundredOnCompleteIsNotRetried() {
+        when(api.createGrant(eq(TOKEN), any(), anyString())).thenReturn(grant(GRANT_A));
+        when(executor.execute(any(), eq(file), any())).thenReturn(new UploadReceipts("single", 17, List.of()));
+        when(api.complete(eq(TOKEN), eq(GRANT_A), any()))
+            .thenThrow(new AttachmentV2Exception("size mismatch", 422, AttachmentV2Exception.SIZE_MISMATCH));
+
+        assertThatThrownBy(() -> gateway.send(TOKEN, file, "text/plain", null, false, null))
+            .isInstanceOf(AttachmentV2Exception.class);
+        verify(api, times(1)).complete(eq(TOKEN), eq(GRANT_A), any());
+    }
+
+    @Test
+    void everyCallRequiresALogin() {
+        ConnectApiAttachmentsV2Gateway loggedOut =
+            new ConnectApiAttachmentsV2Gateway(api, new ConnectApiSessionStore(), executor);
+
+        assertThatThrownBy(() -> loggedOut.grant(TOKEN, new AttachmentGrantRequest("a", "b", 1, null, null)))
+            .isInstanceOf(IllegalStateException.class);
+        assertThatThrownBy(() -> loggedOut.send(TOKEN, file, null, null, false, null))
+            .isInstanceOf(IllegalStateException.class);
+        assertThatThrownBy(() -> loggedOut.abandon(TOKEN, GRANT_A)).isInstanceOf(IllegalStateException.class);
+    }
+
+    @Test
+    void sendRejectsAMissingFileBeforeGranting() {
+        assertThatThrownBy(() -> gateway.send(TOKEN, tmp.resolve("missing.bin"), null, null, false, null))
+            .isInstanceOf(IllegalArgumentException.class);
+        verify(api, never()).createGrant(any(), any(), any());
+    }
+}

--- a/connect-library/src/test/java/com/tsanet/api/internal/DefaultTsaNetApiSessionCreateRequestTest.java
+++ b/connect-library/src/test/java/com/tsanet/api/internal/DefaultTsaNetApiSessionCreateRequestTest.java
@@ -67,6 +67,7 @@ class DefaultTsaNetApiSessionCreateRequestTest {
             mock(ConnectApiWebhooksGateway.class),
             mock(ConnectApiPartnersGateway.class),
             mock(ConnectApiAttachmentsGateway.class),
+            mock(com.tsanet.api.connectapi.internal.ConnectApiAttachmentsV2Gateway.class),
             mock(CollaborationRequestStorageService.class),
             mock(CollaborationRequestFormStorageService.class),
             mock(CaseNoteStorageService.class),

--- a/demo-ui/src/main/java/com/tsanet/demo/web/AttachmentsController.java
+++ b/demo-ui/src/main/java/com/tsanet/demo/web/AttachmentsController.java
@@ -87,8 +87,7 @@ public class AttachmentsController {
         AttachmentsV2Facade attachments = guard.session().attachmentsV2();
         // The browser's file name is client input; keep only its last segment before it
         // becomes a path under the temp directory.
-        String original = file.getOriginalFilename() != null && !file.getOriginalFilename().isBlank()
-            ? Path.of(file.getOriginalFilename()).getFileName().toString() : "attachment";
+        String original = lastSegmentOrDefault(file.getOriginalFilename());
         Path temp;
         try {
             temp = Files.createTempDirectory("tsanet-demo-deliver").resolve(original);
@@ -122,8 +121,18 @@ public class AttachmentsController {
         deliveries.shutdownNow();
     }
 
+    /** The browser's file name reduced to its last segment; a bare separator or blank becomes a default. */
+    static String lastSegmentOrDefault(String name) {
+        if (name == null || name.isBlank()) {
+            return "attachment";
+        }
+        Path last = Path.of(name).getFileName();
+        return last == null || last.toString().isBlank() ? "attachment" : last.toString();
+    }
+
     @GetMapping("/api/uploads/{uploadId}")
     public UploadState uploadState(@PathVariable String uploadId) {
+        guard.session(); // same login requirement as every other case endpoint
         UploadState state = uploads.get(uploadId);
         if (state == null) {
             throw new ResponseStatusException(HttpStatus.NOT_FOUND, "unknown upload");

--- a/demo-ui/src/main/java/com/tsanet/demo/web/AttachmentsController.java
+++ b/demo-ui/src/main/java/com/tsanet/demo/web/AttachmentsController.java
@@ -1,27 +1,134 @@
 package com.tsanet.demo.web;
 
+import com.tsanet.api.attachments.v2.AttachmentCompleteResult;
+import com.tsanet.api.attachments.v2.UploadProgress;
 import com.tsanet.api.connectapi.dto.AttachmentConfigDto;
 import com.tsanet.api.connectapi.dto.AttachmentForwardResultDto;
+import com.tsanet.api.facade.AttachmentsV2Facade;
+import jakarta.annotation.PreDestroy;
 import java.io.IOException;
 import java.io.UncheckedIOException;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Map;
+import java.util.UUID;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import org.springframework.http.HttpStatus;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 import org.springframework.web.multipart.MultipartFile;
+import org.springframework.web.server.ResponseStatusException;
 
 @RestController
 public class AttachmentsController {
 
     private final SessionGuard guard;
+    /** In-flight and finished V2 deliveries, keyed by upload id; demo-side state only. */
+    private final Map<String, UploadState> uploads = new ConcurrentHashMap<>();
+    private final ExecutorService deliveries = Executors.newVirtualThreadPerTaskExecutor();
 
     public AttachmentsController(SessionGuard guard) {
         this.guard = guard;
+    }
+
+    /**
+     * What the page polls: phase, the grant's mode, parts done of total, bytes sent of total,
+     * and once finished the platform's recorded outcome or the failure message. The outcome
+     * is the facade's return value verbatim; the demo never synthesizes a status.
+     */
+    public record UploadState(
+        String uploadId,
+        String fileName,
+        String phase,
+        String mode,
+        int partsDone,
+        int partsTotal,
+        long bytesSent,
+        long bytesTotal,
+        AttachmentCompleteResult outcome,
+        String error
+    ) {
+        UploadState progressed(UploadProgress p) {
+            return new UploadState(uploadId, fileName, "uploading", p.mode(), p.partsDone(), p.partsTotal(),
+                p.bytesSent(), p.bytesTotal(), null, null);
+        }
+
+        UploadState finished(AttachmentCompleteResult result) {
+            return new UploadState(uploadId, fileName, "done", mode, partsDone, partsTotal, bytesSent, bytesTotal, result, null);
+        }
+
+        UploadState failed(String message) {
+            return new UploadState(uploadId, fileName, "failed", mode, partsDone, partsTotal, bytesSent, bytesTotal, null, message);
+        }
+    }
+
+    /**
+     * Direct delivery (V2): the file goes from this demo straight into the partner's store
+     * under the platform's instructions, then the platform verifies and posts the note. Runs
+     * on a background thread because a large file takes a while; the page polls
+     * {@link #uploadState}.
+     */
+    @PostMapping("/api/requests/{token}/attachments/v2")
+    public Map<String, String> deliver(
+        @PathVariable String token,
+        @RequestParam("file") MultipartFile file,
+        @RequestParam(value = "description", required = false) String description,
+        @RequestParam(value = "sha256", defaultValue = "false") boolean sha256
+    ) {
+        // Resolve the facade here, on the request thread: an account-scoped session picks its
+        // delegate per call, and a delivery must not follow an account switch made mid-flight.
+        AttachmentsV2Facade attachments = guard.session().attachmentsV2();
+        // The browser's file name is client input; keep only its last segment before it
+        // becomes a path under the temp directory.
+        String original = file.getOriginalFilename() != null && !file.getOriginalFilename().isBlank()
+            ? Path.of(file.getOriginalFilename()).getFileName().toString() : "attachment";
+        Path temp;
+        try {
+            temp = Files.createTempDirectory("tsanet-demo-deliver").resolve(original);
+            file.transferTo(temp);
+        } catch (IOException e) {
+            throw new UncheckedIOException(e);
+        }
+        String uploadId = UUID.randomUUID().toString();
+        uploads.put(uploadId, new UploadState(uploadId, original, "starting", null, 0, 0, 0, file.getSize(), null, null));
+        deliveries.submit(() -> {
+            try {
+                AttachmentCompleteResult outcome = attachments.send(token, temp, file.getContentType(),
+                    description, sha256, progress -> uploads.computeIfPresent(uploadId, (k, v) -> v.progressed(progress)));
+                uploads.computeIfPresent(uploadId, (k, v) -> v.finished(outcome));
+            } catch (RuntimeException e) {
+                uploads.computeIfPresent(uploadId, (k, v) -> v.failed(e.getMessage()));
+            } finally {
+                try {
+                    Files.deleteIfExists(temp);
+                    Files.deleteIfExists(temp.getParent());
+                } catch (IOException ignored) {
+                    // best-effort temp cleanup
+                }
+            }
+        });
+        return Map.of("uploadId", uploadId);
+    }
+
+    @PreDestroy
+    void shutdownDeliveries() {
+        deliveries.shutdownNow();
+    }
+
+    @GetMapping("/api/uploads/{uploadId}")
+    public UploadState uploadState(@PathVariable String uploadId) {
+        UploadState state = uploads.get(uploadId);
+        if (state == null) {
+            throw new ResponseStatusException(HttpStatus.NOT_FOUND, "unknown upload");
+        }
+        return state;
     }
 
     @GetMapping("/api/requests/{token}/attachments/config")

--- a/demo-ui/src/main/resources/application.yml
+++ b/demo-ui/src/main/resources/application.yml
@@ -8,6 +8,13 @@ spring:
       # this is a deliberate contract change, not an upgrade side effect.
       fail-on-null-for-primitives: false
 
+  servlet:
+    multipart:
+      # The direct-delivery (V2) demo hands a file to the SDK to stream into the
+      # partner's store; the default 1 MB cap would stop it before the first grant.
+      max-file-size: 20GB
+      max-request-size: 20GB
+
 server:
   port: 8090
 

--- a/demo-ui/src/main/resources/static/app.js
+++ b/demo-ui/src/main/resources/static/app.js
@@ -562,6 +562,63 @@ document.getElementById('attach-form').addEventListener('submit', async (event) 
     }
 });
 
+// ---------- attachments: direct delivery (V2) ----------
+
+function formatBytes(n) {
+    if (n < 1024) return `${n} B`;
+    if (n < 1024 * 1024) return `${(n / 1024).toFixed(1)} KiB`;
+    if (n < 1024 * 1024 * 1024) return `${(n / 1024 / 1024).toFixed(1)} MiB`;
+    return `${(n / 1024 / 1024 / 1024).toFixed(2)} GiB`;
+}
+
+function renderUploadState(status, s) {
+    if (s.phase === 'starting') {
+        status.textContent = `Requesting a grant for ${s.fileName}...`;
+        return;
+    }
+    if (s.phase === 'uploading') {
+        status.textContent = `${s.mode}: ${s.partsDone}/${s.partsTotal} parts, `
+            + `${formatBytes(s.bytesSent)} of ${formatBytes(s.bytesTotal)}`;
+        return;
+    }
+    if (s.phase === 'failed') {
+        status.textContent = `Failed: ${s.error}`;
+        return;
+    }
+    const o = s.outcome || {};
+    const verified = o.verification ? ` (${o.verification.method || 'no method'}`
+        + `${o.verification.sizeMatched === true ? ', size matched' : ''}`
+        + `${o.verification.checksumMatched === true ? ', checksum matched' : ''})` : '';
+    const note = o.noteId ? `, note ${o.noteId}` : '';
+    const message = o.message ? ` — ${o.message}` : '';
+    status.textContent = `Platform outcome: ${o.status}${verified}${note}${message}`;
+}
+
+document.getElementById('attach-v2-form').addEventListener('submit', async (event) => {
+    event.preventDefault();
+    const form = event.target;
+    const status = document.getElementById('attach-v2-status');
+    const data = new FormData();
+    data.append('file', form.file.files[0]);
+    if (form.description.value) data.append('description', form.description.value);
+    data.append('sha256', form.sha256.checked ? 'true' : 'false');
+    status.textContent = 'Uploading to the demo...';
+    try {
+        const {uploadId} = await fetchJson(
+            `/api/requests/${encodeURIComponent(state.currentCaseToken)}/attachments/v2`,
+            {method: 'POST', body: data});
+        form.reset();
+        const poll = async () => {
+            const s = await fetchJson(`/api/uploads/${encodeURIComponent(uploadId)}`);
+            renderUploadState(status, s);
+            if (s.phase !== 'done' && s.phase !== 'failed') setTimeout(poll, 500);
+        };
+        await poll();
+    } catch (err) {
+        status.textContent = `Failed: ${err.message}`;
+    }
+});
+
 // ---------- new collaboration ----------
 
 document.getElementById('partner-search-form').addEventListener('submit', async (event) => {

--- a/demo-ui/src/main/resources/static/index.html
+++ b/demo-ui/src/main/resources/static/index.html
@@ -98,6 +98,21 @@
                 <button type="submit">Forward Attachments</button>
             </form>
             <p id="attach-status" class="status"></p>
+            <h4>Direct delivery (V2)</h4>
+            <p class="muted">The file goes straight into the partner's store under the platform's instructions; the platform verifies arrival and posts the case note. Nothing passes through the Connect API.</p>
+            <form id="attach-v2-form">
+                <label>Description
+                    <input type="text" name="description">
+                </label>
+                <label>File
+                    <input type="file" name="file" required>
+                </label>
+                <label class="inline">
+                    <input type="checkbox" name="sha256"> Send a SHA-256 for verification
+                </label>
+                <button type="submit">Deliver directly (V2)</button>
+            </form>
+            <p id="attach-v2-status" class="status"></p>
         </section>
     </div>
 

--- a/docs/attachments-v2-client.md
+++ b/docs/attachments-v2-client.md
@@ -1,0 +1,155 @@
+# Sending an attachment on the direct path (V2)
+
+This page is for a member implementing the sender's side of the V2 attachment contract
+(`tsanetgit/Connect-API-Code#147`), with or without the Connect SDK. The SDK's
+`AttachmentsV2Facade` in `connect-library` is the reference implementation; every request
+and response below is the shape that implementation sends and expects, taken from its test
+double. The contract is a draft until it lands in the Connect OpenAPI spec; field names here
+follow it exactly.
+
+## The idea in one paragraph
+
+The sender asks the platform for a **grant** for one file on one case. The platform resolves
+the partner's delivery target and answers with an `upload` block: where to put the bytes and
+how. The sender executes that block **verbatim**, never branching on who the partner is or
+what store they use. Then the sender calls **complete** with what it uploaded; the platform
+seals the upload where sealing is its job, verifies arrival where it can, records the
+attachment, posts the case note and emits the webhook event. The file never passes through
+the platform, so its size is bounded by the partner's store, not by the API's ingress.
+**Abandon** exists for the case where the sender gives up after a grant; nothing ever becomes
+visible from an abandoned or expired grant.
+
+The sender reports the platform's recorded outcome, never its own evidence. An upload that
+sent every byte without error is still whatever `complete` says it is.
+
+## With the SDK
+
+```java
+TsaNetApiSession session = ...;                       // logged in as usual
+AttachmentCompleteResult outcome = session.attachmentsV2().send(
+    caseToken,
+    Path.of("diag.tar.gz"),
+    "application/gzip",
+    "Diagnostics from the failing node",              // optional, goes into the case note
+    true,                                             // compute and send a SHA-256
+    progress -> log.info("{} {}/{} parts, {} of {} bytes",
+        progress.mode(), progress.partsDone(), progress.partsTotal(),
+        progress.bytesSent(), progress.bytesTotal()));
+
+switch (outcome.status()) {
+    case "DELIVERED"            -> ...;              // verified by the platform
+    case "DELIVERED_UNVERIFIED" -> ...;              // sender-reported; the note says so
+    case "FAILED", "EXPIRED"    -> ...;              // nothing was announced to the partner
+}
+```
+
+`send` grants, uploads, completes; on any upload failure it abandons the grant and throws
+`AttachmentV2Exception`; on a complete-time `attachment/grant-expired` it re-grants exactly
+once and uploads again. The four calls are also available individually (`grant`, `upload`,
+`complete`, `abandon`) for a client that drives the flow itself.
+
+The SDK streams from disk one part at a time and retries individual parts (three attempts,
+exponential backoff, on I/O failures, 5xx and 429). A `403` from a signed URL
+that expired mid-upload is terminal: the SDK abandons the grant and throws, and the caller
+decides whether to run `send` again.
+
+## Without the SDK: the three calls
+
+All three go to the Connect API with the usual bearer token. Errors are
+`application/problem+json`; the `type` values are listed at the end.
+
+### 1. Grant
+
+```http
+POST /v2/collaboration-requests/{token}/attachments/grants
+Authorization: Bearer ...
+Idempotency-Key: 3f1c...                           (optional; repeats return the same grant)
+Content-Type: application/json
+
+{"fileName": "diag.tar.gz", "contentType": "application/gzip",
+ "sizeBytes": 734003200, "sha256": "9f86d0...", "description": "Diagnostics from the failing node"}
+```
+
+```http
+201 Created
+{"grantId": "3f2b7e6a-2c1d-4a4e-9b8f-0c1d2e3f4a5b", "fileName": "diag.tar.gz",
+ "expiresAt": "2026-09-09T10:00:00Z",
+ "receiver": {"companyId": 7, "targetKind": "s3", "maxSizeBytes": 5000000000},
+ "upload": {"mode": "multipart", "method": "PUT",
+            "headers": {"Content-Type": "application/octet-stream"},
+            "parts": [{"partNumber": 1, "url": "https://...signed...", "sizeBytes": 104857600},
+                      {"partNumber": 2, "url": "https://...signed...", "sizeBytes": 104857600},
+                      ...]},
+ "verification": {"mode": "platform"}}
+```
+
+Per the contract draft, expiry is 15 minutes for `single` and `relay` and 24 hours for
+`multipart` and `resumable`, and `sizeBytes` is enforced by the signed URLs: a PUT of a
+different length is refused.
+
+### 2. Upload, exactly as instructed
+
+Send the `headers` block on every request, unchanged, and add nothing else. Do not set
+ACL headers. Each mode:
+
+| `mode` | What to do | What to keep for `complete` |
+|---|---|---|
+| `single` | One `PUT url` with the whole file as the body, `Content-Length` = `sizeBytes`. | nothing |
+| `multipart` | One `PUT parts[i].url` per part, in `partNumber` order, body = that part's byte range of the file (sizes are fixed by the platform). | each response's `ETag`, exactly as received (quotes included), with its `partNumber` |
+| `resumable` | Sequential `PUT url` of chunks (the SDK uses 8 MiB, a multiple of 256 KiB) with `Content-Range: bytes start-end/total`; expect `308` with `Range: bytes=0-N` (N+1 bytes committed) until the last chunk answers `200`/`201`. A `308` without `Range` means nothing is committed: resend. After a lost connection, `PUT url` with `Content-Range: bytes */total` and an empty body asks the session where it stands. | nothing |
+| `relay` | One streamed `PUT url` with the whole file; the `headers` block carries the relay's grant token. The relay pushes to the partner as the bytes arrive, so do not re-send after the relay has answered. | nothing |
+
+Any non-2xx from a signed URL (other than the resumable `308`) means the upload failed:
+abandon the grant (or let it expire) and start over with a new grant.
+
+### 3. Complete
+
+```http
+POST /v2/collaboration-requests/{token}/attachments/grants/{grantId}/complete
+Content-Type: application/json
+
+{"sizeBytes": 734003200, "sha256": "9f86d0...",
+ "parts": [{"partNumber": 1, "receipt": "\"a1b2...\""}, {"partNumber": 2, "receipt": "\"c3d4...\""}, ...]}
+```
+
+`parts` is present in `multipart` mode only. A `single` or `relay` complete carries just
+`sizeBytes` (and `sha256` when one was granted).
+
+```http
+200 OK
+{"grantId": "3f2b7e6a-...", "fileName": "diag.tar.gz", "status": "DELIVERED",
+ "verification": {"method": "HEAD", "verifiedAt": "2026-09-08T10:12:31Z", "sizeMatched": true, "checksumMatched": true},
+ "noteId": 501}
+```
+
+`status` is the platform's word: `DELIVERED` (verified), `DELIVERED_UNVERIFIED` (the platform
+could not read the object back; the case note says arrival was not verified), `FAILED` or
+`EXPIRED`. Complete is idempotent on `grantId`: a repeat returns the recorded outcome, so it
+is safe to retry on a connection failure or a 5xx.
+
+### Abandon
+
+```http
+DELETE /v2/collaboration-requests/{token}/attachments/grants/{grantId}
+```
+
+`204 No Content`. Any open upload session is aborted and nothing becomes visible.
+
+## Problem types
+
+| `type` | When | What to do |
+|---|---|---|
+| `attachment/receiver-not-configured` | the partner has no delivery target | nothing to send; tell the user |
+| `attachment/receiver-config-invalid` | the partner's target is misconfigured | as above |
+| `attachment/size-exceeds-receiver-limit` | larger than the partner accepts | as above; `receiver.maxSizeBytes` on a grant tells the limit |
+| `attachment/grant-expired` | complete after expiry | re-grant once and upload again |
+| `attachment/grant-already-completed` | complete repeated after a different outcome | read the recorded outcome |
+| `attachment/upload-not-found` | complete before any bytes arrived | the upload did not happen; start over |
+| `attachment/size-mismatch`, `attachment/checksum-mismatch` | the sealed object disagrees with the declaration | the file changed under you, or bytes were lost; start over |
+| `attachment/relay-unavailable` | the relay host is down | try later |
+
+## What never to do
+
+- Never log or echo a signed URL, the `headers` block, or a grant token; they are credentials.
+- Never announce the attachment to the partner yourself; the platform posts the case note after verifying.
+- Never treat your own upload success as delivery. Read `status`.

--- a/skills/connect-sdk-deploy/references/consume-artifact.md
+++ b/skills/connect-sdk-deploy/references/consume-artifact.md
@@ -80,7 +80,7 @@ session.auth().login("<MEMBER_USERNAME>", "<MEMBER_PASSWORD>");
 ```
 
 Facades hang off the session: `auth()`, `collaborationRequests()`, `caseNotes()`,
-`caseResponses()`, `users()`, `webhooks()`, `partners()`, `attachments()`. Remote calls
+`caseResponses()`, `users()`, `webhooks()`, `partners()`, `attachments()`, `attachmentsV2()` (the direct-delivery attachment client; see `docs/attachments-v2-client.md`). Remote calls
 before a successful login throw `IllegalStateException: Not logged in`.
 
 Every remote read and successful write upserts into the SQLite cache;


### PR DESCRIPTION
Closes `tsanetgit/Connect_SDK#76`. Serves `tsanetgit/Connect-API-Code#147` (the V2 grant and complete contract, a draft until agreed). The receiver-side stand-in this was designed against is `tsanetgit/Connect-API-Code#148`; nothing of that receiver's interface appears here, this repo being public.

## What this adds

The sender's side of the V2 attachment contract, so a connector adopts the direct delivery path by upgrading `connect-library`, and a member writing its own client has a working implementation to read.

**Library.** `AttachmentsV2Facade` on `TsaNetApiSession` (`attachmentsV2()`): `grant`, `upload`, `complete`, `abandon`, and `send`, which runs the flow. Behind it:

- `ConnectApiAttachmentsV2Api` makes the three core calls through the generated `ApiClient.invokeAPI` with the `bearerAuth` scheme, so the bearer supplier and the 401 re-auth interceptor apply exactly as they do to V1. The V2 paths are not in the OpenAPI spec yet, which is the only reason the DTOs are hand-written records; they mirror the `#147` schemas field for field and sit in one package for the swap to generated classes.
- `AttachmentUploadExecutor` executes the grant's `upload` block verbatim on the JDK `HttpClient`, all four modes. It is not on `RestTemplate` because the library's template wraps a `BufferingClientHttpRequestFactory`, which would hold a whole part in memory. `Content-Length` is a restricted header in the JDK client, so it is filtered from the pass-through and guaranteed by a `FileRegionPublisher` with an exact `contentLength`; a body without one goes chunked and a store that signs the length refuses it. The wire header is the value the grant carried.
- `ConnectApiAttachmentsV2Gateway` owns the flow rules: abandon on any upload failure (best effort, the upload failure stays primary), complete retried on transient failure because it is idempotent on the grant id, one re-grant on a complete-time `attachment/grant-expired`, and the platform's recorded outcome returned unchanged.
- `AttachmentV2Exception` is value-free by construction: status, problem type, and the platform's own title and detail. Every record carrying a URL or headers has a redacted `toString`, and tests assert no URL, host or signature reaches a message.

**Demo.** A "Deliver directly (V2)" form on the case page. The file is handed to the SDK on a virtual thread; the page polls a state endpoint (login required, like every case endpoint) and shows the grant's mode, parts done of total, bytes sent of total (byte-level while a single or relay body streams, per part otherwise), then the platform's outcome in the platform's words. The facade is resolved on the request thread so an account switch mid-flight cannot redirect a delivery; the browser's file name is reduced to its last segment before it becomes a temp path; the multipart cap is raised to 20 GB so a large file reaches the SDK at all.

**Console.** `deliver-attachment` with the same progress and outcome lines; `help` lists it through the registry.

**Doc.** `docs/attachments-v2-client.md`: one full sequence per mode for members implementing the three calls without the SDK, shapes taken from the SDK's test double. The deploy skill's facade list gains `attachmentsV2()`.

## Policies worth knowing

| Situation | What the client does |
|---|---|
| I/O failure, 5xx, 429 on a signed URL | retry, three attempts, exponential backoff with jitter, `Retry-After` honored and capped |
| any other 4xx, including a 403 from an expired signed URL | terminal; abandon, throw; the caller decides whether to run `send` again |
| relay PUT | retried only when the connection never opened; once the receiver answered, never re-sent |
| resumable 308 without `Range` | counts as no progress and the chunk is resent; a session that never reports `Range` fails closed after the budget. The contract draft does not pin chunk semantics; this is the fail-closed reading and it is stated in the doc |
| resumable chunk answered 5xx | re-PUT with the same `Content-Range`; if the session had committed before failing the re-PUT is refused terminally. Fine while `#147` keeps chunk commits transactional |
| complete answers 5xx or connectivity | retried up to three times with backoff (idempotent on `grantId`) |
| complete answers `attachment/grant-expired` | one fresh grant, one more upload; a second expiry throws |
| `verification.mode` is `none` | the platform records `DELIVERED_UNVERIFIED`; the client returns that word unchanged and never branches on the mode |

## Verification

- Reactor, `mvn test`: **connect-library 131 run, 0 failures, 1 skipped** (35 new offline tests and the one env-gated live test; the rest unchanged), **attachment-receiver 182 / 0 / 40**, **demo-ui 15 / 0**, **console 33 / 0**, **demo 6 / 0**. The demo script passes a syntax check.
- `ConnectApiAttachmentsV2ApiTest` (9): the three calls through the real `ApiClient` converters against `MockRestServiceServer`, plus a real `RestTemplate` against a closed port asserting a connectivity failure never echoes the case token that rides in the URL. Golden JSON both ways with strict matching, `Authorization` and `Idempotency-Key` on the wire, optional fields omitted, single-mode complete carrying only the size, problem details mapped to a typed exception, a non-problem error body yielding the status alone with nothing echoed, a grant without an upload block rejected.
- `AttachmentUploadExecutorTest` (17) against the JDK's own `HttpServer`: headers received verbatim, wire `Content-Length` equal to the declared or part size, part order and bytes, ETags forwarded intact, a 503 part retried with a fresh body, a 403 terminal with one attempt and no URL in the message, budget exhaustion, a target that never answers surfacing as `UPLOAD_UNREACHABLE` through the facade exception, relay not retried after a 503, the three-chunk resumable flow, resumable recovery after a dropped connection (`bytes */total` query, resend), unsupported mode and part-size mismatch before any request, the publisher reading exactly its region, `Retry-After` honored and capped, relay retrying when the connection never opens, a resumable session that never reports `Range` failing closed, a 5xx resumable chunk re-PUT with the same `Content-Range`, duplicate part numbers rejected, and byte-level progress on a single upload.
- `ConnectApiAttachmentsV2GatewayTest` (10) with the seam and executor mocked: the flow rules above, digest computed only on request and forwarded on grant and complete, login required, missing file rejected before granting.
- **Live coverage, stated plainly.** The core's V2 endpoints do not exist yet, so grant, complete and abandon have no live target; they are proven through the real client converters against the mock server. The upload executor has an env-gated live test that reads an `AttachmentGrantDTO` envelope from a file (`ATTACHMENTS_V2_GRANT_FILE`: grant, source path, receipts output) and executes it against real signed URLs; whatever issued the grant seals and verifies on its side from the receipts. That split keeps every receiver's interface out of this repository. Not run in this PR: no grant issuer is wired to this machine yet.

## Prose claims and the lines that make them true

| claim | line |
|---|---|
| wire `Content-Length` equals the declared size, never chunked | `FileRegionPublisher.contentLength()`; executor test asserts the header and no `Transfer-Encoding` |
| headers sent verbatim, restricted ones filtered | `passThrough`; single-PUT test asserts custom headers present and `Host` rewritten |
| 403 terminal, one attempt | `sendWithRetry` non-transient branch; `aRejectedPartIsNeverRetried…` |
| I/O exhaustion surfaces as `UPLOAD_UNREACHABLE` | `execute()` boundary catch; `aTargetThatNeverAnswers…` |
| relay never re-sent after an answer | `RetryScope.CONNECT_ONLY` excluded from the transient-status branch; relay test |
| 308 without `Range` is no progress | `committedOffset(response, offset)` plus the stall counter; `aResumableSessionThatNeverReportsRangeFailsClosed` |
| a 5xx resumable chunk is re-PUT with the same `Content-Range` | `TRANSIENT_STATUS_ONLY` keeps transient statuses in the retry branch; `aResumableChunkAnsweredFiveHundredIsRePut…` |
| a connectivity failure names a cause type, never the URL | `invoke`'s `ResourceAccessException` branch; `aConnectivityFailureNeverEchoesTheCaseToken…` |
| abandon on upload failure, failure stays primary | `uploadOrAbandon`; two gateway tests |
| one re-grant on grant-expired | `send`; `aGrantExpiredOnCompleteRegrantsExactlyOnce`, `aSecondGrantExpiredIsNotRetriedAgain` |
| outcome is the platform's | `send` returns `api.complete`'s result; gateway test returns `FAILED` unchanged |
| no URL or token in any message | redacted `toString`s; `doesNotContain("SECRET")` assertions in both test classes |

## Blast radius (`pre-pr-artifacts.py`, base `origin/main`)

No mechanical detector fired. Judgment lines:

- **Positional contract.** `DefaultTsaNetApiSession`'s constructor gained a parameter. Consumers by command, `grep -rn 'new DefaultTsaNetApiSession('`: the runtime and one test, both updated. `TsaNetApiSession` gained a method; implementors by command, `grep -rln 'implements TsaNetApiSession'`: the default and account-scoped sessions, both updated.
- **Vocabulary gained a member.** The facade list in the deploy skill's reference now names `attachmentsV2()`; the console `help` output is generated from the registry. Repo grep for other enumerations of facades or commands: none.
- **Guard vs representation.** The demo's filename sanitization is a guard on client input; the representation alternative (never using the client name at all) would lose the name the partner sees. The `Content-Length` handling is a representation change: the length lives on the body publisher instead of a header.
- **Newly reachable failures.** Every new failure surfaces as `AttachmentV2Exception` toward the caller; the demo renders it as a failed state, the console as an error line. The one pre-existing catch-all in the console command still catches anything else.
- **Schema / stored shape.** None. No SQLite table, no new dependency; the JDK client and its test server are in the platform.
- **Abstraction introduced.** `AttachmentsV2Api` centralizes the three core calls; there was no old form to sweep, the endpoints are new.
- **URL scheme on upload URLs, a decision rather than a check.** The executor accepts what the platform returns, `http` included, because the contract's rule is verbatim execution and the URLs are per-grant, short-lived and issued by the authenticated platform, unlike the operator-pasted SAS URLs this repo rejects on `http` in `#72` and `#74`. Stated in the executor javadoc.

## Gate dispositions (CONCERNS, first run)

- *File size read twice, once for the grant and once in the executor.* Noted. A file that changes between the two reads fails at the platform's signed-length enforcement or at complete's size check; the executor's own part-sum check is against the file it is about to send, which is the property that matters for the PUT. No change.
- *`cancel()` closing the channel while a read is in flight.* Noted. The outcome is a spurious `onError` after cancel, which the JDK client tolerates. No change; revisit if flakiness ever appears.
- *The 20 GB multipart cap applies to every demo form, not only V2.* Correct, and stated here. The V1 form benefits equally; the demo has no other multipart endpoint.

## Follow-ups (not in this PR)

- **Pre-existing in the demo, security-adjacent:** the V1 `forward` endpoint resolves `file.getOriginalFilename()` under its temp directory without the last-segment reduction this PR gives the V2 endpoint. Same one-line fix; out of this PR's scope.
- Replace the hand-written records and the `AttachmentsV2Api` seam with generated classes once `#147` lands in `openapi.yaml`.
- Live gateway coverage (grant, complete, abandon) once the core endpoint exists; wire a grant issuer to the env-gated executor test in the private harness.
- The demo's in-memory upload state map is unbounded; fine for a demo, a TTL if it ever hosts more than demos.

## Advisor and gate

Advisor consulted twice. Orientation: implement resumable rather than defer it, put the progress callback in the facade, the JDK client is mandatory not optional, the `Content-Length` restricted-header trap, relay connect-only retry, one PR. Pre-done: found the internal I/O signal escaping the executor for three of four modes (fixed at the `execute` boundary, with a test that drops every attempt) and the demo's unsanitized filename (fixed), and asked for the 308-without-`Range` reading to be resolved fail-closed rather than from memory (done, stated above). Pre-PR gate: **CONCERNS** on the first run, dispositions above; second and last run on the QA delta: **CONCERNS** with two notes answered in the disposition comment (the adversarial one-byte-progress stall, and the implementer set, which `git grep -ln "implements TsaNetApiSession"` settles at two, both in the diff). Review is CI plus a QA-persona pass from a separate session.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
