### PR TITLE
connect-library + apps: connection hardening — classified API errors, password-mode renewal, /v1/me on login, https default (#20)

### DIFF
--- a/TSANet-integration-app/src/main/java/com/tsanet/facade/config/ConnectFacadeConfiguration.java
+++ b/TSANet-integration-app/src/main/java/com/tsanet/facade/config/ConnectFacadeConfiguration.java
@@ -15,10 +15,31 @@ import org.springframework.context.annotation.Configuration;
 public class ConnectFacadeConfiguration {
     @Bean
     TsaNetApiSessionFactory tsaNetApiSessionFactory(ConnectFacadeProperties properties) {
+        requireHttps(properties.api());
         return TsaNetApi.sessionFactory(TsaNetApiConnectionSettings.of(
             properties.api().baseUrl(),
             properties.storage() != null ? properties.storage().sqlitePath() : "data.db"
         ));
+    }
+
+    /**
+     * A bearer over plain http is a credential on the wire. Fail at startup, with the fix in
+     * the message, rather than at the first request.
+     */
+    static void requireHttps(ConnectFacadeProperties.Api api) {
+        String baseUrl = api == null ? null : api.baseUrl();
+        if (baseUrl == null || baseUrl.isBlank()) {
+            throw new IllegalStateException("tsanet.api.base-url is required");
+        }
+        if (baseUrl.regionMatches(true, 0, "https://", 0, 8)) {
+            return;
+        }
+        if (api.insecureHttpAllowed()) {
+            return;
+        }
+        throw new IllegalStateException("tsanet.api.base-url must use https; the Connect API is HTTPS-only in every real "
+            + "environment and a bearer token must not travel in plain text. Set tsanet.api.allow-insecure-http=true "
+            + "only for a local mock.");
     }
 
     @Bean

--- a/TSANet-integration-app/src/main/java/com/tsanet/facade/config/ConnectFacadeProperties.java
+++ b/TSANet-integration-app/src/main/java/com/tsanet/facade/config/ConnectFacadeProperties.java
@@ -13,7 +13,14 @@ public record ConnectFacadeProperties(
     Storage storage,
     List<ApplicationUserAccountConfig> accounts
 ) {
-    public record Api(String baseUrl) {
+    /**
+     * @param baseUrl           the Connect API base URL; https in every real environment
+     * @param allowInsecureHttp opt-out of the https requirement for a local mock; null means false
+     */
+    public record Api(String baseUrl, Boolean allowInsecureHttp) {
+        public boolean insecureHttpAllowed() {
+            return Boolean.TRUE.equals(allowInsecureHttp);
+        }
     }
 
     public record Auth(String username, String password) {

--- a/TSANet-integration-app/src/main/resources/application.yml
+++ b/TSANet-integration-app/src/main/resources/application.yml
@@ -10,7 +10,11 @@ spring:
 
 tsanet:
   api:
-    base-url: "http://localhost:8080"
+    # The Connect API is HTTPS-only in every real environment; this default is the BETA
+    # host, the same default the demo-ui uses. A plain-http base URL is rejected at startup
+    # unless allow-insecure-http is true, which exists for a local mock and nothing else.
+    base-url: "https://connect2.tsanet.net"
+    allow-insecure-http: false
   storage:
     sqlite-path: "${user.home}/.tsanet-client-demo"
   # No accounts are configured here. This is a public repository, so credentials

--- a/TSANet-integration-app/src/main/resources/application.yml
+++ b/TSANet-integration-app/src/main/resources/application.yml
@@ -12,7 +12,8 @@ tsanet:
   api:
     # The Connect API is HTTPS-only in every real environment; this default is the BETA
     # host, the same default the demo-ui uses. A plain-http base URL is rejected at startup
-    # unless allow-insecure-http is true, which exists for a local mock and nothing else.
+    # unless allow-insecure-http is true. That switch exists for a local mock; it admits any
+    # non-https host, so it stays false everywhere else.
     base-url: "https://connect2.tsanet.net"
     allow-insecure-http: false
   storage:

--- a/TSANet-integration-app/src/test/java/com/tsanet/facade/config/ConnectFacadeConfigurationTest.java
+++ b/TSANet-integration-app/src/test/java/com/tsanet/facade/config/ConnectFacadeConfigurationTest.java
@@ -1,0 +1,40 @@
+package com.tsanet.facade.config;
+
+import static org.assertj.core.api.Assertions.assertThatCode;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import org.junit.jupiter.api.Test;
+
+/** The startup guard: no bearer over plain http unless the operator said so, in the config, on purpose. */
+class ConnectFacadeConfigurationTest {
+
+    @Test
+    void anHttpsBaseUrlPasses() {
+        assertThatCode(() -> ConnectFacadeConfiguration.requireHttps(
+            new ConnectFacadeProperties.Api("https://connect2.tsanet.net", null))).doesNotThrowAnyException();
+        assertThatCode(() -> ConnectFacadeConfiguration.requireHttps(
+            new ConnectFacadeProperties.Api("HTTPS://connect2.tsanet.net", false))).doesNotThrowAnyException();
+    }
+
+    @Test
+    void aPlainHttpBaseUrlFailsAtStartupWithTheFixInTheMessage() {
+        assertThatThrownBy(() -> ConnectFacadeConfiguration.requireHttps(
+            new ConnectFacadeProperties.Api("http://connect2.tsanet.net", null)))
+            .isInstanceOf(IllegalStateException.class)
+            .hasMessageContaining("https")
+            .hasMessageContaining("tsanet.api.allow-insecure-http");
+    }
+
+    @Test
+    void theOptOutAdmitsALocalMockOnly() {
+        assertThatCode(() -> ConnectFacadeConfiguration.requireHttps(
+            new ConnectFacadeProperties.Api("http://localhost:8080", true))).doesNotThrowAnyException();
+    }
+
+    @Test
+    void aMissingBaseUrlIsItsOwnError() {
+        assertThatThrownBy(() -> ConnectFacadeConfiguration.requireHttps(new ConnectFacadeProperties.Api(" ", true)))
+            .isInstanceOf(IllegalStateException.class)
+            .hasMessageContaining("required");
+    }
+}

--- a/TSANet-integration-app/src/test/resources/application.yml
+++ b/TSANet-integration-app/src/test/resources/application.yml
@@ -5,6 +5,8 @@ spring:
 tsanet:
   api:
     base-url: "http://localhost:8080"
+    # Test-only: the context test points at a local mock that speaks plain http.
+    allow-insecure-http: true
   storage:
     sqlite-path: "${java.io.tmpdir}/tsanet-test"
   accounts:

--- a/TSANet-integration-demo/src/main/resources/application.yml
+++ b/TSANet-integration-demo/src/main/resources/application.yml
@@ -13,7 +13,8 @@ server:
 
 tsanet:
   api:
-    base-url: "http://localhost:8080"
+    # HTTPS-only in every real environment; BETA is the shipped default (see the console app).
+    base-url: "https://connect2.tsanet.net"
   storage:
     sqlite-path: "${user.home}/.tsanet-client-demo"
   # No accounts are configured here. This is a public repository, so credentials

--- a/connect-library/src/main/java/com/tsanet/api/ConnectApiException.java
+++ b/connect-library/src/main/java/com/tsanet/api/ConnectApiException.java
@@ -21,7 +21,9 @@ package com.tsanet.api;
  * </ul>
  *
  * <p>The message is value-free by construction: status, kind, the API's own title and detail,
- * never the URL, a header or a token.
+ * never the request URL, a header or a token. The request URL and its path are scrubbed from
+ * any echoed body before an excerpt is taken; a body that spells out an identifier on its own
+ * is not recognized as such.
  *
  * <p>Note for anyone raising the generated client's retry count: its retry loop catches
  * Spring's {@code HttpServerErrorException}, which this handler no longer throws, so that loop
@@ -61,7 +63,11 @@ public class ConnectApiException extends RuntimeException {
         return kind;
     }
 
-    /** HTTP status of the answer, or 0 for {@link Kind#CONNECTIVITY}. */
+    /**
+     * The status the API asserted: for {@link Kind#PROBLEM} the body's own {@code status} when it
+     * carries one (which can differ from the wire status, see tsanetgit/Connect-API-Code#122),
+     * otherwise the wire status; 0 for {@link Kind#CONNECTIVITY}. Not a transport-level fact.
+     */
     public int status() {
         return status;
     }

--- a/connect-library/src/main/java/com/tsanet/api/ConnectApiException.java
+++ b/connect-library/src/main/java/com/tsanet/api/ConnectApiException.java
@@ -1,0 +1,128 @@
+package com.tsanet.api;
+
+/**
+ * A Connect API call failed, in a form the caller can act on. Thrown from every call the
+ * library makes through its HTTP client, replacing Spring's transport exceptions (whose
+ * messages carry the request URL, and the URL carries the case token for most endpoints).
+ *
+ * <p>{@link #kind()} says what the API answered with:
+ * <ul>
+ *   <li>{@link Kind#PROBLEM}: an RFC 7807 body ({@code type}, {@code title}, {@code status},
+ *       {@code detail}, {@code instance}), which the API returns for the documented 4xx codes
+ *       because the library sends {@code Accept: application/json, application/problem+json}.</li>
+ *   <li>{@link Kind#LEGACY}: the API's default {@code {"message": ...}} body, usually with a
+ *       500 where a 4xx belongs (tsanetgit/Connect-API-Code#122; kept for backward
+ *       compatibility). Classified by the body, not the status, so it never reads as an
+ *       unknown server error.</li>
+ *   <li>{@link Kind#CONNECTIVITY}: the API could not be reached; {@link #detail()} names the
+ *       failure's class only.</li>
+ *   <li>{@link Kind#OTHER}: a non-2xx with no recognizable body; {@link #detail()} carries at
+ *       most a short excerpt of it.</li>
+ * </ul>
+ *
+ * <p>The message is value-free by construction: status, kind, the API's own title and detail,
+ * never the URL, a header or a token.
+ *
+ * <p>Note for anyone raising the generated client's retry count: its retry loop catches
+ * Spring's {@code HttpServerErrorException}, which this handler no longer throws, so that loop
+ * is inert. Retries belong in the caller that knows the operation is idempotent.
+ */
+public class ConnectApiException extends RuntimeException {
+
+    public enum Kind { PROBLEM, LEGACY, CONNECTIVITY, OTHER }
+
+    private final Kind kind;
+    private final int status;
+    private final String type;
+    private final String title;
+    private final String detail;
+    private final String instance;
+
+    public ConnectApiException(Kind kind, int status, String type, String title, String detail, String instance,
+                               Throwable cause) {
+        super(format(kind, status, type, title, detail), cause);
+        this.kind = kind;
+        this.status = status;
+        this.type = type;
+        this.title = title;
+        this.detail = detail;
+        this.instance = instance;
+    }
+
+    public static ConnectApiException connectivity(Throwable cause) {
+        Throwable root = cause;
+        while (root.getCause() != null && root.getCause() != root) {
+            root = root.getCause();
+        }
+        return new ConnectApiException(Kind.CONNECTIVITY, 0, null, null, root.getClass().getSimpleName(), null, cause);
+    }
+
+    public Kind kind() {
+        return kind;
+    }
+
+    /** HTTP status of the answer, or 0 for {@link Kind#CONNECTIVITY}. */
+    public int status() {
+        return status;
+    }
+
+    /** The RFC 7807 {@code type} URI, or null. */
+    public String type() {
+        return type;
+    }
+
+    public String title() {
+        return title;
+    }
+
+    /** The API's {@code detail}, the legacy {@code message}, the cause class, or a body excerpt. */
+    public String detail() {
+        return detail;
+    }
+
+    public String instance() {
+        return instance;
+    }
+
+    /** Whether the problem {@code type} ends with the given segment, for example {@code authentication-error}. */
+    public boolean isProblem(String typeSuffix) {
+        return type != null && (type.equals(typeSuffix) || type.endsWith("/" + typeSuffix));
+    }
+
+    private static String format(Kind kind, int status, String type, String title, String detail) {
+        StringBuilder message = new StringBuilder();
+        switch (kind) {
+            case CONNECTIVITY -> message.append("cannot reach the Connect API (").append(detail).append(')');
+            case PROBLEM -> {
+                message.append("HTTP ").append(status);
+                if (title != null && !title.isBlank()) {
+                    message.append(' ').append(title);
+                }
+                if (type != null && !type.isBlank()) {
+                    message.append(" (").append(lastSegment(type)).append(')');
+                }
+                if (detail != null && !detail.isBlank()) {
+                    message.append(": ").append(detail);
+                }
+            }
+            case LEGACY -> {
+                message.append("HTTP ").append(status).append(" (legacy error)");
+                if (detail != null && !detail.isBlank()) {
+                    message.append(": ").append(detail);
+                }
+            }
+            case OTHER -> {
+                message.append("HTTP ").append(status).append(" from the Connect API");
+                if (detail != null && !detail.isBlank()) {
+                    message.append(": ").append(detail);
+                }
+            }
+        }
+        return message.toString();
+    }
+
+    private static String lastSegment(String type) {
+        int slash = type.lastIndexOf('/');
+        return slash < 0 || slash == type.length() - 1 ? type : type.substring(slash + 1);
+    }
+}

--- a/connect-library/src/main/java/com/tsanet/api/connectapi/internal/ConnectApiAttachmentsV2Api.java
+++ b/connect-library/src/main/java/com/tsanet/api/connectapi/internal/ConnectApiAttachmentsV2Api.java
@@ -4,6 +4,7 @@ import com.tsanet.api.attachments.v2.AttachmentCompleteRequest;
 import com.tsanet.api.attachments.v2.AttachmentCompleteResult;
 import com.tsanet.api.attachments.v2.AttachmentGrant;
 import com.tsanet.api.attachments.v2.AttachmentGrantRequest;
+import com.tsanet.api.ConnectApiException;
 import com.tsanet.api.attachments.v2.AttachmentV2Exception;
 import com.tsanet.api.generated.invoker.ApiClient;
 import java.util.List;
@@ -93,6 +94,10 @@ public final class ConnectApiAttachmentsV2Api implements AttachmentsV2Api {
             return apiClient.invokeAPI(path, method, pathParams, new LinkedMultiValueMap<>(),
                 body, headers, new LinkedMultiValueMap<>(), new LinkedMultiValueMap<>(), accept, contentType,
                 AUTH_NAMES, returnType);
+        } catch (ConnectApiException e) {
+            // The runtime's client already classified the answer; keep its words and its type.
+            String type = e.kind() == ConnectApiException.Kind.CONNECTIVITY ? AttachmentV2Exception.CONNECTIVITY : e.type();
+            throw new AttachmentV2Exception(operation + " failed: " + e.getMessage(), e.status(), type, e);
         } catch (HttpStatusCodeException e) {
             throw translate(operation, e);
         } catch (ResourceAccessException e) {

--- a/connect-library/src/main/java/com/tsanet/api/connectapi/internal/ConnectApiAuthGateway.java
+++ b/connect-library/src/main/java/com/tsanet/api/connectapi/internal/ConnectApiAuthGateway.java
@@ -11,12 +11,17 @@ public class ConnectApiAuthGateway {
         this.identityApi = identityApi;
     }
 
-    public String login(String username, String password) {
+    /**
+     * Unauthenticated by nature: this gateway must sit on the runtime's login client, the one
+     * without the bearer supplier and the 401 re-auth interceptor, or a re-login on an expired
+     * token would recurse into itself.
+     */
+    public PasswordLogin login(String username, String password) {
         LoginRequestDTO request = new LoginRequestDTO().username(username).password(password);
         TokenDTO response = identityApi.login(request);
         if (response == null || response.getAccessToken() == null || response.getAccessToken().isBlank()) {
             throw new IllegalStateException("Login succeeded but accessToken is missing");
         }
-        return response.getAccessToken();
+        return new PasswordLogin(response.getAccessToken(), response.getExpiresIn());
     }
 }

--- a/connect-library/src/main/java/com/tsanet/api/connectapi/internal/ConnectApiConnectivityInterceptor.java
+++ b/connect-library/src/main/java/com/tsanet/api/connectapi/internal/ConnectApiConnectivityInterceptor.java
@@ -1,0 +1,28 @@
+package com.tsanet.api.connectapi.internal;
+
+import com.tsanet.api.ConnectApiException;
+import java.io.IOException;
+import org.springframework.http.HttpRequest;
+import org.springframework.http.client.ClientHttpRequestExecution;
+import org.springframework.http.client.ClientHttpRequestInterceptor;
+import org.springframework.http.client.ClientHttpResponse;
+
+/**
+ * Turns a transport failure into {@link ConnectApiException} of kind {@code CONNECTIVITY}
+ * before it can leave the interceptor chain: once an {@link IOException} reaches
+ * {@code RestTemplate} it becomes a {@code ResourceAccessException} whose message embeds the
+ * request URL, and the URL carries the case token. Installed first, so it also wraps the
+ * 401 re-auth retry.
+ */
+public final class ConnectApiConnectivityInterceptor implements ClientHttpRequestInterceptor {
+
+    @Override
+    public ClientHttpResponse intercept(HttpRequest request, byte[] body, ClientHttpRequestExecution execution)
+        throws IOException {
+        try {
+            return execution.execute(request, body);
+        } catch (IOException e) {
+            throw ConnectApiException.connectivity(e);
+        }
+    }
+}

--- a/connect-library/src/main/java/com/tsanet/api/connectapi/internal/ConnectApiResponseErrorHandler.java
+++ b/connect-library/src/main/java/com/tsanet/api/connectapi/internal/ConnectApiResponseErrorHandler.java
@@ -1,0 +1,127 @@
+package com.tsanet.api.connectapi.internal;
+
+import com.tsanet.api.ConnectApiException;
+import java.io.IOException;
+import java.io.InputStream;
+import java.net.URI;
+import java.nio.charset.StandardCharsets;
+import java.util.ArrayList;
+import java.util.List;
+import org.springframework.http.HttpMethod;
+import org.springframework.http.client.ClientHttpResponse;
+import org.springframework.web.client.ResponseErrorHandler;
+import tools.jackson.databind.JsonNode;
+import tools.jackson.databind.json.JsonMapper;
+
+/**
+ * Turns every non-2xx answer into a {@link ConnectApiException}, classified by the body
+ * alone (tsanetgit/Connect_SDK#20): RFC 7807 fields mean {@code PROBLEM}; a {@code message}
+ * field means the API's legacy shape, even on a 500 (tsanetgit/Connect-API-Code#122); anything
+ * else is the status plus a short excerpt. The URL and method Spring passes in are never
+ * used in the message.
+ */
+public final class ConnectApiResponseErrorHandler implements ResponseErrorHandler {
+
+    static final int EXCERPT_LENGTH = 200;
+
+    private final JsonMapper mapper = JsonMapper.builder().build();
+
+    @Override
+    public boolean hasError(ClientHttpResponse response) throws IOException {
+        return response.getStatusCode().isError();
+    }
+
+    @Override
+    public void handleError(URI url, HttpMethod method, ClientHttpResponse response) throws IOException {
+        int status = response.getStatusCode().value();
+        String body;
+        try (InputStream in = response.getBody()) {
+            body = in == null ? "" : new String(in.readAllBytes(), StandardCharsets.UTF_8);
+        } catch (IOException e) {
+            body = "";
+        }
+        throw classify(status, scrub(body, url));
+    }
+
+    /**
+     * An intermediary's error page (a proxy 404, a gateway 502) commonly echoes the request
+     * URI, and the URI carries the case token. Remove the URL and its path before the body can
+     * become an excerpt.
+     */
+    static String scrub(String body, URI url) {
+        if (body == null || url == null) {
+            return body;
+        }
+        String scrubbed = body;
+        if (url.toString() != null && !url.toString().isBlank()) {
+            scrubbed = scrubbed.replace(url.toString(), "<request-url>");
+        }
+        if (url.getRawPath() != null && !url.getRawPath().isBlank()) {
+            scrubbed = scrubbed.replace(url.getRawPath(), "<request-path>");
+        }
+        if (url.getPath() != null && !url.getPath().isBlank()) {
+            scrubbed = scrubbed.replace(url.getPath(), "<request-path>");
+        }
+        return scrubbed;
+    }
+
+    /** Package-visible so the classification is testable without a transport. */
+    ConnectApiException classify(int status, String body) {
+        if (body != null && !body.isBlank()) {
+            JsonNode node = null;
+            try {
+                node = mapper.readTree(body);
+            } catch (RuntimeException ignored) {
+                // Not JSON; fall through to the excerpt.
+            }
+            if (node != null && node.isObject()) {
+                String type = text(node, "type");
+                String title = text(node, "title");
+                String detail = text(node, "detail");
+                if (type != null || title != null || detail != null) {
+                    int bodyStatus = node.has("status") && node.get("status").isInt() ? node.get("status").asInt() : status;
+                    return new ConnectApiException(ConnectApiException.Kind.PROBLEM, bodyStatus, type, title, detail,
+                        text(node, "instance"), null);
+                }
+                String message = text(node, "message");
+                if (message != null) {
+                    return new ConnectApiException(ConnectApiException.Kind.LEGACY, status, null, null,
+                        withValidationErrors(message, node), null, null);
+                }
+            }
+        }
+        return new ConnectApiException(ConnectApiException.Kind.OTHER, status, null, null, excerpt(body), null, null);
+    }
+
+    private static String withValidationErrors(String message, JsonNode node) {
+        JsonNode errors = node.get("validationErrors");
+        if (errors == null || !errors.isArray() || errors.isEmpty()) {
+            return message;
+        }
+        List<String> items = new ArrayList<>();
+        for (JsonNode error : errors) {
+            String field = text(error, "field");
+            String text = text(error, "message");
+            if (text == null) {
+                text = text(error, "defaultMessage");
+            }
+            if (text != null) {
+                items.add(field == null ? text : field + ": " + text);
+            }
+        }
+        return items.isEmpty() ? message : message + " [" + String.join("; ", items) + "]";
+    }
+
+    private static String excerpt(String body) {
+        if (body == null || body.isBlank()) {
+            return null;
+        }
+        String collapsed = body.replaceAll("\\s+", " ").strip();
+        return collapsed.length() <= EXCERPT_LENGTH ? collapsed : collapsed.substring(0, EXCERPT_LENGTH) + "…";
+    }
+
+    private static String text(JsonNode node, String field) {
+        JsonNode value = node.get(field);
+        return value == null || value.isNull() ? null : value.asString();
+    }
+}

--- a/connect-library/src/main/java/com/tsanet/api/connectapi/internal/ConnectApiRestTemplates.java
+++ b/connect-library/src/main/java/com/tsanet/api/connectapi/internal/ConnectApiRestTemplates.java
@@ -1,0 +1,28 @@
+package com.tsanet.api.connectapi.internal;
+
+import org.springframework.http.client.BufferingClientHttpRequestFactory;
+import org.springframework.http.client.SimpleClientHttpRequestFactory;
+import org.springframework.web.client.RestTemplate;
+
+/**
+ * The one way this library builds a {@link RestTemplate} for the Connect API: buffered
+ * request bodies (the 401 re-auth retry re-sends the body), the response error handler that
+ * yields {@code ConnectApiException}, and the connectivity interceptor. The runtime builds
+ * two: an unauthenticated one for login, and the session one that additionally carries the
+ * bearer supplier and the 401 retry. Tests build theirs here too, so what they exercise is
+ * what production runs.
+ */
+public final class ConnectApiRestTemplates {
+
+    private ConnectApiRestTemplates() {
+    }
+
+    public static RestTemplate create() {
+        RestTemplate restTemplate = new RestTemplate(
+            new BufferingClientHttpRequestFactory(new SimpleClientHttpRequestFactory())
+        );
+        restTemplate.setErrorHandler(new ConnectApiResponseErrorHandler());
+        restTemplate.getInterceptors().add(new ConnectApiConnectivityInterceptor());
+        return restTemplate;
+    }
+}

--- a/connect-library/src/main/java/com/tsanet/api/connectapi/internal/ConnectApiSessionStore.java
+++ b/connect-library/src/main/java/com/tsanet/api/connectapi/internal/ConnectApiSessionStore.java
@@ -3,6 +3,7 @@ package com.tsanet.api.connectapi.internal;
 import com.tsanet.api.connectapi.dto.UserContextDto;
 import com.tsanet.api.auth.AuthMode;
 import java.time.Instant;
+import java.util.Objects;
 import java.util.Optional;
 
 public class ConnectApiSessionStore {
@@ -19,11 +20,11 @@ public class ConnectApiSessionStore {
 
     /** {@code expiresAt} null means the API stated no lifetime; expiry then surfaces only as a 401. */
     public void savePassword(String username, String bearerToken, Instant expiresAt) {
+        forgetUserContextUnlessSamePrincipal(AuthMode.CONNECT1_PASSWORD, username);
         this.username = username;
         this.bearerToken = bearerToken;
         this.authMode = AuthMode.CONNECT1_PASSWORD;
         this.expiresAt = expiresAt;
-        this.userContext = null;
     }
 
     /** The company and user behind the session, fetched from {@code /v1/me} right after login. */
@@ -36,12 +37,23 @@ public class ConnectApiSessionStore {
     }
 
     public void saveOAuth(String accountId, String bearerToken, Instant expiresAt) {
+        forgetUserContextUnlessSamePrincipal(AuthMode.CLIENT_CREDENTIALS, accountId);
         this.accountId = accountId;
         this.username = accountId;
         this.bearerToken = bearerToken;
         this.authMode = AuthMode.CLIENT_CREDENTIALS;
         this.expiresAt = expiresAt;
-        this.userContext = null;
+    }
+
+    /**
+     * A renewed bearer for the same principal (the configured user re-logged in, or a fresh
+     * client-credentials token) leaves the {@code /v1/me} context in place: it describes the
+     * principal, not the token. Only a different principal, or a change of mode, invalidates it.
+     */
+    private void forgetUserContextUnlessSamePrincipal(AuthMode mode, String principal) {
+        if (this.authMode != mode || !Objects.equals(this.username, principal)) {
+            this.userContext = null;
+        }
     }
 
     public Optional<String> getBearerToken() {

--- a/connect-library/src/main/java/com/tsanet/api/connectapi/internal/ConnectApiSessionStore.java
+++ b/connect-library/src/main/java/com/tsanet/api/connectapi/internal/ConnectApiSessionStore.java
@@ -1,5 +1,6 @@
 package com.tsanet.api.connectapi.internal;
 
+import com.tsanet.api.connectapi.dto.UserContextDto;
 import com.tsanet.api.auth.AuthMode;
 import java.time.Instant;
 import java.util.Optional;
@@ -10,12 +11,28 @@ public class ConnectApiSessionStore {
     private volatile String accountId;
     private volatile AuthMode authMode;
     private volatile Instant expiresAt;
+    private volatile UserContextDto userContext;
 
     public void savePassword(String username, String bearerToken) {
+        savePassword(username, bearerToken, null);
+    }
+
+    /** {@code expiresAt} null means the API stated no lifetime; expiry then surfaces only as a 401. */
+    public void savePassword(String username, String bearerToken, Instant expiresAt) {
         this.username = username;
         this.bearerToken = bearerToken;
         this.authMode = AuthMode.CONNECT1_PASSWORD;
-        this.expiresAt = null;
+        this.expiresAt = expiresAt;
+        this.userContext = null;
+    }
+
+    /** The company and user behind the session, fetched from {@code /v1/me} right after login. */
+    public void saveUserContext(UserContextDto userContext) {
+        this.userContext = userContext;
+    }
+
+    public Optional<UserContextDto> getUserContext() {
+        return Optional.ofNullable(userContext);
     }
 
     public void saveOAuth(String accountId, String bearerToken, Instant expiresAt) {
@@ -24,6 +41,7 @@ public class ConnectApiSessionStore {
         this.bearerToken = bearerToken;
         this.authMode = AuthMode.CLIENT_CREDENTIALS;
         this.expiresAt = expiresAt;
+        this.userContext = null;
     }
 
     public Optional<String> getBearerToken() {
@@ -63,5 +81,6 @@ public class ConnectApiSessionStore {
         this.accountId = null;
         this.authMode = null;
         this.expiresAt = null;
+        this.userContext = null;
     }
 }

--- a/connect-library/src/main/java/com/tsanet/api/connectapi/internal/PasswordLogin.java
+++ b/connect-library/src/main/java/com/tsanet/api/connectapi/internal/PasswordLogin.java
@@ -1,0 +1,9 @@
+package com.tsanet.api.connectapi.internal;
+
+/**
+ * What a password login returns: the bearer and, when the API states one, its lifetime.
+ * {@code expiresInSeconds} is null when the API omitted it; the session then relies on the
+ * 401 path alone.
+ */
+public record PasswordLogin(String accessToken, Integer expiresInSeconds) {
+}

--- a/connect-library/src/main/java/com/tsanet/api/connectapi/internal/TokenManager.java
+++ b/connect-library/src/main/java/com/tsanet/api/connectapi/internal/TokenManager.java
@@ -53,22 +53,50 @@ public final class TokenManager {
         };
     }
 
+    /** The bearer for the next request, renewed first when the session knows it has expired. */
     public String ensureValidAccessToken() {
-        if (authConfig.mode() == AuthMode.CLIENT_CREDENTIALS && sessionStore.isExpired(clock.instant())) {
+        if (sessionStore.isExpired(clock.instant())) {
             return refreshAccessToken();
         }
         return sessionStore.getBearerToken().orElseThrow(() -> new IllegalStateException("Not authenticated"));
     }
 
+    /**
+     * Renews the bearer: a fresh client-credentials token, or a transparent re-login with the
+     * configured password. The platform has no refresh endpoint, so re-login is the strategy,
+     * and it is offered only when the session belongs to the configured user; a session opened
+     * by an interactively typed password is never renewed silently, because that password was
+     * never retained.
+     */
     public String refreshAccessToken() {
-        if (authConfig.mode() != AuthMode.CLIENT_CREDENTIALS) {
-            throw new IllegalStateException("Token refresh is only supported for client-credentials auth");
-        }
-        return authenticateClientCredentials((ClientCredentialsAuthConfig) authConfig);
+        return switch (authConfig.mode()) {
+            case CLIENT_CREDENTIALS -> authenticateClientCredentials((ClientCredentialsAuthConfig) authConfig);
+            case CONNECT1_PASSWORD -> {
+                if (!canReloginWithConfiguredPassword()) {
+                    throw new IllegalStateException(
+                        "Session expired and cannot be renewed with the configured credentials; log in again");
+                }
+                yield authenticatePassword((PasswordAuthConfig) authConfig);
+            }
+        };
     }
 
     public boolean supportsRefresh() {
-        return authConfig.mode() == AuthMode.CLIENT_CREDENTIALS;
+        return authConfig.mode() == AuthMode.CLIENT_CREDENTIALS || canReloginWithConfiguredPassword();
+    }
+
+    /** An interactive login with the given credentials, with the same expiry tracking as a configured one. */
+    public String loginWithPassword(String username, String password) {
+        return authenticatePassword(new PasswordAuthConfig(username, password));
+    }
+
+    private boolean canReloginWithConfiguredPassword() {
+        if (!(authConfig instanceof PasswordAuthConfig configured)
+            || configured.username() == null || configured.username().isBlank()
+            || configured.password() == null || configured.password().isBlank()) {
+            return false;
+        }
+        return sessionStore.getUsername().map(configured.username()::equals).orElse(false);
     }
 
     public AuthMode authMode() {
@@ -87,8 +115,9 @@ public final class TokenManager {
     }
 
     private String authenticatePassword(PasswordAuthConfig config) {
-        String token = passwordAuthGateway.login(config.username(), config.password());
-        sessionStore.savePassword(config.username(), token);
-        return token;
+        PasswordLogin login = passwordAuthGateway.login(config.username(), config.password());
+        Instant expiresAt = login.expiresInSeconds() == null ? null : clock.instant().plusSeconds(login.expiresInSeconds());
+        sessionStore.savePassword(config.username(), login.accessToken(), expiresAt);
+        return login.accessToken();
     }
 }

--- a/connect-library/src/main/java/com/tsanet/api/connectapi/internal/TokenManager.java
+++ b/connect-library/src/main/java/com/tsanet/api/connectapi/internal/TokenManager.java
@@ -109,15 +109,27 @@ public final class TokenManager {
 
     private String authenticateClientCredentials(ClientCredentialsAuthConfig config) {
         OAuthAccessToken token = oauthTokenGateway.fetchClientCredentialsToken(config);
-        Instant expiresAt = clock.instant().plusSeconds(token.expiresInSeconds());
-        sessionStore.saveOAuth(accountId, token.accessToken(), expiresAt);
+        sessionStore.saveOAuth(accountId, token.accessToken(), expiryFrom(token.expiresInSeconds()));
         return token.accessToken();
     }
 
     private String authenticatePassword(PasswordAuthConfig config) {
         PasswordLogin login = passwordAuthGateway.login(config.username(), config.password());
-        Instant expiresAt = login.expiresInSeconds() == null ? null : clock.instant().plusSeconds(login.expiresInSeconds());
-        sessionStore.savePassword(config.username(), login.accessToken(), expiresAt);
+        Long lifetime = login.expiresInSeconds() == null ? null : login.expiresInSeconds().longValue();
+        sessionStore.savePassword(config.username(), login.accessToken(), expiryFrom(lifetime));
         return login.accessToken();
+    }
+
+    /**
+     * When the stated lifetime is at or below {@link #EXPIRY_SKEW} the token would count as
+     * expired the moment it arrived, and every request would open with a login (or, for an
+     * interactively typed password, fail as "log in again" right after a successful login).
+     * Such a lifetime is treated as unstated: no expiry is tracked and the 401 path handles it.
+     */
+    private Instant expiryFrom(Long lifetimeSeconds) {
+        if (lifetimeSeconds == null || lifetimeSeconds <= EXPIRY_SKEW.getSeconds()) {
+            return null;
+        }
+        return clock.instant().plusSeconds(lifetimeSeconds);
     }
 }

--- a/connect-library/src/main/java/com/tsanet/api/facade/AuthFacade.java
+++ b/connect-library/src/main/java/com/tsanet/api/facade/AuthFacade.java
@@ -1,5 +1,6 @@
 package com.tsanet.api.facade;
 
+import com.tsanet.api.connectapi.dto.UserContextDto;
 import com.tsanet.api.auth.AuthMode;
 import java.time.Instant;
 import java.util.Optional;
@@ -22,6 +23,9 @@ public interface AuthFacade {
     Optional<Instant> tokenExpiresAt();
 
     Optional<String> currentBearerToken();
+
+    /** The company and user behind the session, fetched from {@code /v1/me} on login; empty when logged out. */
+    Optional<UserContextDto> currentUserContext();
 
     void logout();
 }

--- a/connect-library/src/main/java/com/tsanet/api/internal/DefaultTsaNetApiSession.java
+++ b/connect-library/src/main/java/com/tsanet/api/internal/DefaultTsaNetApiSession.java
@@ -197,7 +197,9 @@ final class DefaultTsaNetApiSession implements TsaNetApiSession, AuthFacade, Col
 
     @Override
     public String authenticate() {
-        return tokenManager.authenticate();
+        String token = tokenManager.authenticate();
+        completeLogin();
+        return token;
     }
 
     @Override
@@ -205,9 +207,30 @@ final class DefaultTsaNetApiSession implements TsaNetApiSession, AuthFacade, Col
         if (configuration.auth().mode() != AuthMode.CONNECT1_PASSWORD) {
             throw new IllegalStateException("Password login is not configured for this session. Use authenticate().");
         }
-        String token = authGateway.login(username, password);
-        sessionStore.savePassword(username, token);
+        String token = tokenManager.loginWithPassword(username, password);
+        completeLogin();
         return token;
+    }
+
+    /**
+     * Every login ends the same way: {@code /v1/me} is fetched through the session client,
+     * which proves the bearer against a protected call and yields the company and user the
+     * session routes for. If that call fails the login has failed: the store is cleared so
+     * nothing downstream can run half-authenticated, and the failure surfaces as it is.
+     */
+    private void completeLogin() {
+        try {
+            UserContextDto context = userGateway.getCurrentUser();
+            sessionStore.saveUserContext(context);
+        } catch (RuntimeException e) {
+            sessionStore.clear();
+            throw e;
+        }
+    }
+
+    @Override
+    public Optional<UserContextDto> currentUserContext() {
+        return sessionStore.getUserContext();
     }
 
     @Override

--- a/connect-library/src/main/java/com/tsanet/api/internal/TsaNetApiRuntime.java
+++ b/connect-library/src/main/java/com/tsanet/api/internal/TsaNetApiRuntime.java
@@ -1,9 +1,11 @@
 package com.tsanet.api.internal;
 
+import com.tsanet.api.ConnectApiException;
 import com.tsanet.api.TsaNetApiConfiguration;
 import com.tsanet.api.TsaNetApiSession;
 import com.tsanet.api.connectapi.internal.ConnectApiAttachmentsGateway;
 import com.tsanet.api.connectapi.internal.ConnectApiAttachmentsV2Api;
+import com.tsanet.api.connectapi.internal.ConnectApiRestTemplates;
 import com.tsanet.api.connectapi.internal.ConnectApiAttachmentsV2Gateway;
 import com.tsanet.api.connectapi.internal.ConnectApiAuthGateway;
 import com.tsanet.api.connectapi.internal.ConnectApiCollaborationGateway;
@@ -51,8 +53,6 @@ import com.tsanet.api.connectapi.internal.OAuthTokenGateway;
 import com.tsanet.api.connectapi.internal.TokenManager;
 import java.nio.file.Files;
 import java.nio.file.Path;
-import org.springframework.http.client.BufferingClientHttpRequestFactory;
-import org.springframework.http.client.SimpleClientHttpRequestFactory;
 import org.springframework.web.client.RestTemplate;
 import org.springframework.jdbc.core.JdbcTemplate;
 import org.sqlite.SQLiteDataSource;
@@ -64,14 +64,17 @@ public final class TsaNetApiRuntime {
     public static TsaNetApiSession create(TsaNetApiConfiguration configuration) {
         ConnectApiSessionStore sessionStore = new ConnectApiSessionStore();
 
-        RestTemplate restTemplate = new RestTemplate(
-            new BufferingClientHttpRequestFactory(new SimpleClientHttpRequestFactory())
-        );
+        // Login rides an unauthenticated client of its own: no bearer supplier, no 401 retry.
+        // On the session client a re-login would recurse into itself through both.
+        ApiClient loginApiClient = new ApiClient(ConnectApiRestTemplates.create());
+        loginApiClient.setBasePath(configuration.apiBaseUrl());
+        ConnectApiAuthGateway authGateway = new ConnectApiAuthGateway(new IdentityApi(loginApiClient));
+
+        RestTemplate restTemplate = ConnectApiRestTemplates.create();
         ApiClient apiClient = new ApiClient(restTemplate);
         apiClient.setBasePath(configuration.apiBaseUrl());
 
         IdentityApi identityApi = new IdentityApi(apiClient);
-        ConnectApiAuthGateway authGateway = new ConnectApiAuthGateway(identityApi);
         OAuthTokenGateway oauthTokenGateway = new OAuthTokenGateway();
         TokenManager tokenManager = new TokenManager(
             sessionStore,
@@ -80,9 +83,8 @@ public final class TsaNetApiRuntime {
             configuration.accountId(),
             configuration.auth()
         );
-        if (configuration.auth().mode() == AuthMode.CLIENT_CREDENTIALS) {
-            restTemplate.getInterceptors().add(new OAuth401RetryInterceptor(tokenManager));
-        }
+        // Both modes: the interceptor asks the token manager whether a renewal is possible.
+        restTemplate.getInterceptors().add(new OAuth401RetryInterceptor(tokenManager));
         apiClient.setBearerToken(() -> bearerTokenForRequest(sessionStore, tokenManager, configuration));
 
         CollaborationRequestsApi collaborationRequestsApi = new CollaborationRequestsApi(apiClient);
@@ -201,7 +203,7 @@ public final class TsaNetApiRuntime {
         );
     }
 
-    private static String bearerTokenForRequest(
+    static String bearerTokenForRequest(
         ConnectApiSessionStore sessionStore,
         TokenManager tokenManager,
         TsaNetApiConfiguration configuration
@@ -209,10 +211,15 @@ public final class TsaNetApiRuntime {
         if (!sessionStore.getBearerToken().isPresent()) {
             return null;
         }
-        if (configuration.auth().mode() == AuthMode.CLIENT_CREDENTIALS) {
+        try {
             return tokenManager.ensureValidAccessToken();
+        } catch (IllegalStateException expired) {
+            // The supplier runs outside the interceptor chain, so this is the one place an
+            // expired session that cannot be renewed gets the same classified shape as every
+            // other failure; both the console and the demo already render that shape.
+            throw new ConnectApiException(ConnectApiException.Kind.OTHER, 401, null, "Session expired",
+                expired.getMessage(), null, expired);
         }
-        return sessionStore.getBearerToken().orElse(null);
     }
 
     private static JdbcTemplate createJdbcTemplate(String sqlitePath) {

--- a/connect-library/src/main/java/com/tsanet/api/session/AccountScopedTsaNetApiSession.java
+++ b/connect-library/src/main/java/com/tsanet/api/session/AccountScopedTsaNetApiSession.java
@@ -6,6 +6,7 @@ import com.tsanet.api.TsaNetApiSession;
 import com.tsanet.api.TsaNetApiSessionFactory;
 import com.tsanet.api.auth.AuthMode;
 import com.tsanet.api.auth.PasswordAuthConfig;
+import com.tsanet.api.connectapi.dto.UserContextDto;
 import com.tsanet.api.facade.AttachmentsFacade;
 import com.tsanet.api.facade.AttachmentsV2Facade;
 import com.tsanet.api.facade.AuthFacade;
@@ -181,6 +182,14 @@ public final class AccountScopedTsaNetApiSession implements TsaNetApiSession, Ac
                 return Optional.empty();
             }
             return delegate.auth().currentBearerToken();
+        }
+
+        @Override
+        public Optional<UserContextDto> currentUserContext() {
+            if (delegate == null) {
+                return Optional.empty();
+            }
+            return delegate.auth().currentUserContext();
         }
 
         @Override

--- a/connect-library/src/test/java/com/tsanet/api/connectapi/internal/ConnectApiAttachmentsV2ApiTest.java
+++ b/connect-library/src/test/java/com/tsanet/api/connectapi/internal/ConnectApiAttachmentsV2ApiTest.java
@@ -13,6 +13,7 @@ import com.tsanet.api.attachments.v2.AttachmentCompleteRequest;
 import com.tsanet.api.attachments.v2.AttachmentCompleteResult;
 import com.tsanet.api.attachments.v2.AttachmentGrant;
 import com.tsanet.api.attachments.v2.AttachmentGrantRequest;
+import com.tsanet.api.ConnectApiException;
 import com.tsanet.api.attachments.v2.AttachmentV2Exception;
 import com.tsanet.api.generated.invoker.ApiClient;
 import java.util.List;
@@ -188,6 +189,31 @@ class ConnectApiAttachmentsV2ApiTest {
             .isInstanceOf(AttachmentV2Exception.class)
             .hasMessageContaining("upload block")
             .satisfies(e -> assertThat(((AttachmentV2Exception) e).status()).isEqualTo(201));
+    }
+
+    @Test
+    void theRuntimesClassifiedAnswerKeepsItsTypeThroughTheAttachmentException() {
+        // Through the library's own RestTemplate, as production runs: the response error handler
+        // yields ConnectApiException first, and the V2 client must carry its type and words.
+        RestTemplate runtimeTemplate = ConnectApiRestTemplates.create();
+        MockRestServiceServer runtimeServer = MockRestServiceServer.bindTo(runtimeTemplate).build();
+        ApiClient runtimeClient = new ApiClient(runtimeTemplate);
+        runtimeClient.setBasePath(BASE);
+        runtimeClient.setBearerToken(() -> "bearer-123");
+        runtimeServer.expect(requestTo(BASE + "/v2/collaboration-requests/" + TOKEN + "/attachments/grants/" + GRANT_ID + "/complete"))
+            .andRespond(withStatus(HttpStatus.CONFLICT).contentType(MediaType.APPLICATION_PROBLEM_JSON)
+                .body("{\"type\":\"attachment/grant-expired\",\"title\":\"Grant expired\",\"status\":409,\"detail\":\"expired\"}"));
+
+        assertThatThrownBy(() -> new ConnectApiAttachmentsV2Api(runtimeClient)
+            .complete(TOKEN, GRANT_ID, new AttachmentCompleteRequest(3, null, List.of())))
+            .isInstanceOf(AttachmentV2Exception.class)
+            .satisfies(e -> {
+                AttachmentV2Exception ex = (AttachmentV2Exception) e;
+                assertThat(ex.status()).isEqualTo(409);
+                assertThat(ex.isProblem(AttachmentV2Exception.GRANT_EXPIRED)).isTrue();
+                assertThat(ex.getMessage()).contains("Grant expired").contains("expired");
+                assertThat(ex.getCause()).isInstanceOf(ConnectApiException.class);
+            });
     }
 
     @Test

--- a/connect-library/src/test/java/com/tsanet/api/connectapi/internal/ConnectApiAuthGatewayTest.java
+++ b/connect-library/src/test/java/com/tsanet/api/connectapi/internal/ConnectApiAuthGatewayTest.java
@@ -27,7 +27,9 @@ class ConnectApiAuthGatewayTest {
 
         ConnectApiAuthGateway gateway = new ConnectApiAuthGateway(identityApi);
 
-        assertThat(gateway.login("api@test.com", "secret")).isEqualTo("jwt-token-123");
+        PasswordLogin login = gateway.login("api@test.com", "secret");
+        assertThat(login.accessToken()).isEqualTo("jwt-token-123");
+        assertThat(login.expiresInSeconds()).isNull();
 
         ArgumentCaptor<LoginRequestDTO> captor = ArgumentCaptor.forClass(LoginRequestDTO.class);
         verify(identityApi).login(captor.capture());

--- a/connect-library/src/test/java/com/tsanet/api/connectapi/internal/ConnectApiResponseErrorHandlerTest.java
+++ b/connect-library/src/test/java/com/tsanet/api/connectapi/internal/ConnectApiResponseErrorHandlerTest.java
@@ -1,0 +1,174 @@
+package com.tsanet.api.connectapi.internal;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.springframework.test.web.client.match.MockRestRequestMatchers.requestTo;
+import static org.springframework.test.web.client.response.MockRestResponseCreators.withStatus;
+
+import com.tsanet.api.ConnectApiException;
+import com.tsanet.api.generated.api.CaseResponsesApi;
+import com.tsanet.api.generated.api.IdentityApi;
+import com.tsanet.api.generated.invoker.ApiClient;
+import com.tsanet.api.generated.model.LoginRequestDTO;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.MediaType;
+import org.springframework.test.web.client.MockRestServiceServer;
+import org.springframework.web.client.RestTemplate;
+
+/**
+ * The classification, driven through the generated client on the library's own
+ * {@link RestTemplate} so what is tested is what production runs. The shapes are the ones
+ * recorded on tsanetgit/Connect-API-Code#122 (2026-07-10): problem+json with the documented
+ * 4xx when the client sends the Accept header the library sends, and the legacy 500 body.
+ * Every request path carries a marker token, and no message may carry it back.
+ */
+class ConnectApiResponseErrorHandlerTest {
+
+    private static final String BASE = "https://connect.example";
+    private static final String TOKEN = "CASETOKEN-MARKER";
+
+    private MockRestServiceServer server;
+    private CaseResponsesApi requests;
+    private IdentityApi identity;
+
+    @BeforeEach
+    void setUp() {
+        RestTemplate restTemplate = ConnectApiRestTemplates.create();
+        server = MockRestServiceServer.bindTo(restTemplate).build();
+        ApiClient apiClient = new ApiClient(restTemplate);
+        apiClient.setBasePath(BASE);
+        apiClient.setBearerToken(() -> "bearer-1");
+        requests = new CaseResponsesApi(apiClient);
+        identity = new IdentityApi(apiClient);
+    }
+
+    @Test
+    void aProblemDetailsAnswerBecomesATypedProblemWithTheApisOwnWords() {
+        server.expect(requestTo(BASE + "/v1/collaboration-requests/" + TOKEN + "/closure"))
+            .andRespond(withStatus(HttpStatus.UNPROCESSABLE_CONTENT).contentType(MediaType.APPLICATION_PROBLEM_JSON)
+                .body("{\"type\":\"https://connect.example/problems/case-update-error\",\"title\":\"Unprocessable Entity\","
+                    + "\"status\":422,\"detail\":\"OPEN cases cannot be closed.\",\"instance\":\"/v1/collaboration-requests/" + TOKEN + "/closure\"}"));
+
+        assertThatThrownBy(() -> requests.closeCollaborationRequest(TOKEN))
+            .isInstanceOf(ConnectApiException.class)
+            .satisfies(e -> {
+                ConnectApiException ex = (ConnectApiException) e;
+                assertThat(ex.kind()).isEqualTo(ConnectApiException.Kind.PROBLEM);
+                assertThat(ex.status()).isEqualTo(422);
+                assertThat(ex.title()).isEqualTo("Unprocessable Entity");
+                assertThat(ex.detail()).isEqualTo("OPEN cases cannot be closed.");
+                assertThat(ex.isProblem("case-update-error")).isTrue();
+                assertThat(ex.getMessage()).isEqualTo("HTTP 422 Unprocessable Entity (case-update-error): OPEN cases cannot be closed.");
+                assertThat(ex.getMessage()).doesNotContain("MARKER");
+            });
+    }
+
+    @Test
+    void theLegacyFiveHundredWithAMessageBodyIsClassifiedByTheBodyNotTheStatus() {
+        server.expect(requestTo(BASE + "/v1/collaboration-requests/" + TOKEN + "/closure"))
+            .andRespond(withStatus(HttpStatus.INTERNAL_SERVER_ERROR).contentType(MediaType.APPLICATION_JSON)
+                .body("{\"message\":\"OPEN cases cannot be closed.\"}"));
+
+        assertThatThrownBy(() -> requests.closeCollaborationRequest(TOKEN))
+            .isInstanceOf(ConnectApiException.class)
+            .satisfies(e -> {
+                ConnectApiException ex = (ConnectApiException) e;
+                assertThat(ex.kind()).isEqualTo(ConnectApiException.Kind.LEGACY);
+                assertThat(ex.status()).isEqualTo(500);
+                assertThat(ex.detail()).isEqualTo("OPEN cases cannot be closed.");
+                assertThat(ex.getMessage()).isEqualTo("HTTP 500 (legacy error): OPEN cases cannot be closed.");
+            });
+    }
+
+    @Test
+    void legacyValidationErrorsAreFoldedIntoTheDetail() {
+        server.expect(requestTo(BASE + "/v1/collaboration-requests/" + TOKEN + "/closure"))
+            .andRespond(withStatus(HttpStatus.BAD_REQUEST).contentType(MediaType.APPLICATION_JSON)
+                .body("{\"message\":\"Validation failed\",\"validationErrors\":[{\"field\":\"engineerEmail\",\"message\":\"must be on the member domain\"}]}"));
+
+        assertThatThrownBy(() -> requests.closeCollaborationRequest(TOKEN))
+            .isInstanceOf(ConnectApiException.class)
+            .satisfies(e -> assertThat(((ConnectApiException) e).detail())
+                .isEqualTo("Validation failed [engineerEmail: must be on the member domain]"));
+    }
+
+    @Test
+    void anUnrecognizedBodyYieldsTheStatusAndAShortExcerptAndNeverTheUrl() {
+        server.expect(requestTo(BASE + "/v1/collaboration-requests/" + TOKEN + "/closure"))
+            .andRespond(withStatus(HttpStatus.BAD_GATEWAY).contentType(MediaType.TEXT_HTML)
+                .body("<html><body>  gateway   timeout   </body></html>"));
+
+        assertThatThrownBy(() -> requests.closeCollaborationRequest(TOKEN))
+            .isInstanceOf(ConnectApiException.class)
+            .satisfies(e -> {
+                ConnectApiException ex = (ConnectApiException) e;
+                assertThat(ex.kind()).isEqualTo(ConnectApiException.Kind.OTHER);
+                assertThat(ex.status()).isEqualTo(502);
+                assertThat(ex.detail()).isEqualTo("<html><body> gateway timeout </body></html>");
+                assertThat(ex.getMessage()).doesNotContain("MARKER").doesNotContain("connect.example");
+            });
+    }
+
+    @Test
+    void aBadLoginIsAFourOhOneProblemNotAServerError() {
+        server.expect(requestTo(BASE + "/v1/login"))
+            .andRespond(withStatus(HttpStatus.UNAUTHORIZED).contentType(MediaType.APPLICATION_PROBLEM_JSON)
+                .body("{\"type\":\"https://connect.example/problems/authentication-error\",\"title\":\"Authentication Failed\",\"status\":401,\"detail\":\"Bad credentials\"}"));
+
+        assertThatThrownBy(() -> identity.login(new LoginRequestDTO().username("u").password("p")))
+            .isInstanceOf(ConnectApiException.class)
+            .satisfies(e -> {
+                ConnectApiException ex = (ConnectApiException) e;
+                assertThat(ex.status()).isEqualTo(401);
+                assertThat(ex.isProblem("authentication-error")).isTrue();
+                assertThat(ex.getMessage()).startsWith("HTTP 401 Authentication Failed");
+            });
+    }
+
+    @Test
+    void aTransportFailureIsClassifiedAsConnectivityWithoutTheUrl() {
+        ApiClient dead = new ApiClient(ConnectApiRestTemplates.create());
+        dead.setBasePath("http://127.0.0.1:1");
+        dead.setBearerToken(() -> "bearer-1");
+
+        assertThatThrownBy(() -> new CaseResponsesApi(dead).closeCollaborationRequest(TOKEN))
+            .isInstanceOf(ConnectApiException.class)
+            .satisfies(e -> {
+                ConnectApiException ex = (ConnectApiException) e;
+                assertThat(ex.kind()).isEqualTo(ConnectApiException.Kind.CONNECTIVITY);
+                assertThat(ex.status()).isZero();
+                assertThat(ex.detail()).isNotBlank();
+                assertThat(ex.getMessage()).doesNotContain("MARKER").doesNotContain("127.0.0.1");
+            });
+    }
+
+    @Test
+    void anIntermediaryErrorPageThatEchoesTheRequestPathLosesItBeforeTheExcerpt() {
+        server.expect(requestTo(BASE + "/v1/collaboration-requests/" + TOKEN + "/closure"))
+            .andRespond(withStatus(HttpStatus.NOT_FOUND).contentType(MediaType.TEXT_HTML)
+                .body("<html><body>The requested URL /v1/collaboration-requests/" + TOKEN + "/closure was not found on this server.</body></html>"));
+
+        assertThatThrownBy(() -> requests.closeCollaborationRequest(TOKEN))
+            .isInstanceOf(ConnectApiException.class)
+            .satisfies(e -> {
+                ConnectApiException ex = (ConnectApiException) e;
+                assertThat(ex.kind()).isEqualTo(ConnectApiException.Kind.OTHER);
+                assertThat(ex.detail()).contains("<request-path>").doesNotContain("MARKER");
+                assertThat(ex.getMessage()).doesNotContain("MARKER");
+            });
+    }
+
+    @Test
+    void classificationIsByBodyFirstEvenWhenAProblemBodyRidesOnAFiveHundred() {
+        ConnectApiResponseErrorHandler handler = new ConnectApiResponseErrorHandler();
+        ConnectApiException problemOn500 = handler.classify(500,
+            "{\"type\":\"about:blank\",\"title\":\"Forbidden\",\"status\":403,\"detail\":\"Only the receiving partner can approve a case.\"}");
+        assertThat(problemOn500.kind()).isEqualTo(ConnectApiException.Kind.PROBLEM);
+        assertThat(problemOn500.status()).isEqualTo(403);
+        assertThat(handler.classify(404, "").kind()).isEqualTo(ConnectApiException.Kind.OTHER);
+        assertThat(handler.classify(404, "").detail()).isNull();
+        assertThat(handler.classify(503, "not json at all").detail()).isEqualTo("not json at all");
+    }
+}

--- a/connect-library/src/test/java/com/tsanet/api/connectapi/internal/ConnectApiSessionStoreTest.java
+++ b/connect-library/src/test/java/com/tsanet/api/connectapi/internal/ConnectApiSessionStoreTest.java
@@ -3,6 +3,7 @@ package com.tsanet.api.connectapi.internal;
 import static org.assertj.core.api.Assertions.assertThat;
 
 import com.tsanet.api.auth.AuthMode;
+import com.tsanet.api.connectapi.dto.UserContextDto;
 import java.time.Instant;
 import org.junit.jupiter.api.Test;
 
@@ -29,6 +30,41 @@ class ConnectApiSessionStoreTest {
         assertThat(store.getAccountId()).contains("production");
         assertThat(store.isExpired(expiresAt.minusSeconds(TokenManager.EXPIRY_SKEW.getSeconds() - 1))).isTrue();
         assertThat(store.isExpired(expiresAt.minusSeconds(TokenManager.EXPIRY_SKEW.getSeconds() + 30))).isFalse();
+    }
+
+    @Test
+    void aRenewedBearerForTheSamePrincipalKeepsTheUserContext() {
+        UserContextDto context = new UserContextDto(7L, "Acme", 42L, "api@test.com", "api@test.com", "A", "Pi");
+
+        ConnectApiSessionStore password = new ConnectApiSessionStore();
+        password.savePassword("api@test.com", "t1", Instant.parse("2026-01-01T12:00:00Z"));
+        password.saveUserContext(context);
+        password.savePassword("api@test.com", "t2", Instant.parse("2026-01-01T13:00:00Z"));
+        assertThat(password.getUserContext()).contains(context);
+        assertThat(password.getBearerToken()).contains("t2");
+
+        ConnectApiSessionStore oauth = new ConnectApiSessionStore();
+        oauth.saveOAuth("production", "o1", Instant.parse("2026-01-01T12:00:00Z"));
+        oauth.saveUserContext(context);
+        oauth.saveOAuth("production", "o2", Instant.parse("2026-01-01T13:00:00Z"));
+        assertThat(oauth.getUserContext()).contains(context);
+    }
+
+    @Test
+    void aBearerForADifferentPrincipalDropsTheUserContext() {
+        UserContextDto context = new UserContextDto(7L, "Acme", 42L, "api@test.com", "api@test.com", "A", "Pi");
+
+        ConnectApiSessionStore otherUser = new ConnectApiSessionStore();
+        otherUser.savePassword("api@test.com", "t1");
+        otherUser.saveUserContext(context);
+        otherUser.savePassword("other@test.com", "t2");
+        assertThat(otherUser.getUserContext()).isEmpty();
+
+        ConnectApiSessionStore otherMode = new ConnectApiSessionStore();
+        otherMode.savePassword("production", "t1");
+        otherMode.saveUserContext(context);
+        otherMode.saveOAuth("production", "o1", Instant.parse("2026-01-01T12:00:00Z"));
+        assertThat(otherMode.getUserContext()).isEmpty();
     }
 
     @Test

--- a/connect-library/src/test/java/com/tsanet/api/connectapi/internal/OAuth401RetryInterceptorTest.java
+++ b/connect-library/src/test/java/com/tsanet/api/connectapi/internal/OAuth401RetryInterceptorTest.java
@@ -1,0 +1,76 @@
+package com.tsanet.api.connectapi.internal;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import java.io.IOException;
+import java.net.URI;
+import org.junit.jupiter.api.Test;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.HttpMethod;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.client.ClientHttpRequestExecution;
+import org.springframework.http.client.ClientHttpResponse;
+import org.springframework.mock.http.client.MockClientHttpRequest;
+import org.springframework.mock.http.client.MockClientHttpResponse;
+
+/**
+ * The 401 retry, now in front of both auth modes: when the token manager can renew, the
+ * request is re-sent once with the new bearer; when it cannot (an interactively typed
+ * password), the 401 passes through to the error handler, which is the "clear error" half.
+ */
+class OAuth401RetryInterceptorTest {
+
+    @Test
+    void aFourOhOneIsRetriedOnceWithTheRenewedBearerWhenRenewalIsPossible() throws IOException {
+        TokenManager tokenManager = mock(TokenManager.class);
+        when(tokenManager.supportsRefresh()).thenReturn(true);
+        when(tokenManager.refreshAccessToken()).thenReturn("fresh");
+        ClientHttpRequestExecution execution = mock(ClientHttpRequestExecution.class);
+        when(execution.execute(any(), any()))
+            .thenReturn(new MockClientHttpResponse(new byte[0], HttpStatus.UNAUTHORIZED))
+            .thenReturn(new MockClientHttpResponse(new byte[0], HttpStatus.OK));
+        MockClientHttpRequest request = new MockClientHttpRequest(HttpMethod.GET, URI.create("https://connect.example/v1/me"));
+        request.getHeaders().set(HttpHeaders.AUTHORIZATION, "Bearer stale");
+
+        ClientHttpResponse response = new OAuth401RetryInterceptor(tokenManager).intercept(request, new byte[0], execution);
+
+        assertThat(response.getStatusCode()).isEqualTo(HttpStatus.OK);
+        assertThat(request.getHeaders().getFirst(HttpHeaders.AUTHORIZATION)).isEqualTo("Bearer fresh");
+        verify(execution, times(2)).execute(any(), any());
+        verify(tokenManager).refreshAccessToken();
+    }
+
+    @Test
+    void aFourOhOnePassesThroughWhenRenewalIsNotPossible() throws IOException {
+        TokenManager tokenManager = mock(TokenManager.class);
+        when(tokenManager.supportsRefresh()).thenReturn(false);
+        ClientHttpRequestExecution execution = mock(ClientHttpRequestExecution.class);
+        when(execution.execute(any(), any())).thenReturn(new MockClientHttpResponse(new byte[0], HttpStatus.UNAUTHORIZED));
+        MockClientHttpRequest request = new MockClientHttpRequest(HttpMethod.GET, URI.create("https://connect.example/v1/me"));
+
+        ClientHttpResponse response = new OAuth401RetryInterceptor(tokenManager).intercept(request, new byte[0], execution);
+
+        assertThat(response.getStatusCode()).isEqualTo(HttpStatus.UNAUTHORIZED);
+        verify(execution, times(1)).execute(any(), any());
+        verify(tokenManager, never()).refreshAccessToken();
+    }
+
+    @Test
+    void aNonFourOhOneIsNeverRetried() throws IOException {
+        TokenManager tokenManager = mock(TokenManager.class);
+        ClientHttpRequestExecution execution = mock(ClientHttpRequestExecution.class);
+        when(execution.execute(any(), any())).thenReturn(new MockClientHttpResponse(new byte[0], HttpStatus.FORBIDDEN));
+        MockClientHttpRequest request = new MockClientHttpRequest(HttpMethod.GET, URI.create("https://connect.example/v1/me"));
+
+        ClientHttpResponse response = new OAuth401RetryInterceptor(tokenManager).intercept(request, new byte[0], execution);
+
+        assertThat(response.getStatusCode()).isEqualTo(HttpStatus.FORBIDDEN);
+        verify(tokenManager, never()).refreshAccessToken();
+    }
+}

--- a/connect-library/src/test/java/com/tsanet/api/connectapi/internal/TokenManagerTest.java
+++ b/connect-library/src/test/java/com/tsanet/api/connectapi/internal/TokenManagerTest.java
@@ -182,12 +182,82 @@ class TokenManagerTest {
     void anInteractiveLoginTracksExpiryToo() {
         ConnectApiSessionStore sessionStore = new ConnectApiSessionStore();
         ConnectApiAuthGateway authGateway = mock(ConnectApiAuthGateway.class);
-        when(authGateway.login("typed@test.com", "pw")).thenReturn(new PasswordLogin("typed-token", 60));
+        when(authGateway.login("typed@test.com", "pw")).thenReturn(new PasswordLogin("typed-token", 900));
         TokenManager tokenManager = new TokenManager(sessionStore, authGateway, mock(OAuthTokenGateway.class),
             "default", new PasswordAuthConfig("user@test.com", "secret"), CLOCK);
 
         assertThat(tokenManager.loginWithPassword("typed@test.com", "pw")).isEqualTo("typed-token");
         assertThat(sessionStore.getUsername()).contains("typed@test.com");
-        assertThat(sessionStore.getExpiresAt()).contains(NOW.plusSeconds(60));
+        assertThat(sessionStore.getExpiresAt()).contains(NOW.plusSeconds(900));
+    }
+
+    @Test
+    void aLifetimeAtOrBelowTheSkewIsNotTrackedSoTheTokenIsNotBornExpired() {
+        ConnectApiSessionStore sessionStore = new ConnectApiSessionStore();
+        ConnectApiAuthGateway authGateway = mock(ConnectApiAuthGateway.class);
+        when(authGateway.login("typed@test.com", "pw"))
+            .thenReturn(new PasswordLogin("short-lived", (int) TokenManager.EXPIRY_SKEW.getSeconds()));
+        TokenManager tokenManager = new TokenManager(sessionStore, authGateway, mock(OAuthTokenGateway.class),
+            "default", new PasswordAuthConfig("user@test.com", "secret"), CLOCK);
+
+        tokenManager.loginWithPassword("typed@test.com", "pw");
+
+        assertThat(sessionStore.getExpiresAt()).isEmpty();
+        assertThat(sessionStore.isExpired(NOW)).isFalse();
+        // The first call after a successful typed login must not fail as "log in again".
+        assertThat(tokenManager.ensureValidAccessToken()).isEqualTo("short-lived");
+        verify(authGateway, times(1)).login(any(), any());
+    }
+
+    @Test
+    void aLifetimeJustAboveTheSkewIsTrackedAndValidOnArrival() {
+        ConnectApiSessionStore sessionStore = new ConnectApiSessionStore();
+        ConnectApiAuthGateway authGateway = mock(ConnectApiAuthGateway.class);
+        int lifetime = (int) TokenManager.EXPIRY_SKEW.getSeconds() + 1;
+        when(authGateway.login("user@test.com", "secret")).thenReturn(new PasswordLogin("t1", lifetime));
+        TokenManager tokenManager = new TokenManager(sessionStore, authGateway, mock(OAuthTokenGateway.class),
+            "default", new PasswordAuthConfig("user@test.com", "secret"), CLOCK);
+
+        tokenManager.authenticate();
+
+        assertThat(sessionStore.getExpiresAt()).contains(NOW.plusSeconds(lifetime));
+        assertThat(sessionStore.isExpired(NOW)).isFalse();
+        assertThat(tokenManager.ensureValidAccessToken()).isEqualTo("t1");
+        verify(authGateway, times(1)).login(any(), any());
+    }
+
+    @Test
+    void aShortLivedClientCredentialsTokenIsNotBornExpiredEither() {
+        ConnectApiSessionStore sessionStore = new ConnectApiSessionStore();
+        OAuthTokenGateway oauthTokenGateway = mock(OAuthTokenGateway.class);
+        ClientCredentialsAuthConfig config = new ClientCredentialsAuthConfig(
+            "tenant", null, "client-id", "client-secret", "api://audience", null);
+        when(oauthTokenGateway.fetchClientCredentialsToken(config))
+            .thenReturn(new OAuthAccessToken("brief", TokenManager.EXPIRY_SKEW.getSeconds()));
+        TokenManager tokenManager = new TokenManager(sessionStore, mock(ConnectApiAuthGateway.class),
+            oauthTokenGateway, "production", config, CLOCK);
+
+        tokenManager.authenticate();
+
+        assertThat(sessionStore.getExpiresAt()).isEmpty();
+        assertThat(tokenManager.ensureValidAccessToken()).isEqualTo("brief");
+        verify(oauthTokenGateway, times(1)).fetchClientCredentialsToken(any());
+    }
+
+    @Test
+    void aRenewalKeepsTheUserContextOfTheSamePrincipal() {
+        ConnectApiSessionStore sessionStore = new ConnectApiSessionStore();
+        sessionStore.savePassword("user@test.com", "stale", NOW.minusSeconds(1));
+        com.tsanet.api.connectapi.dto.UserContextDto context =
+            new com.tsanet.api.connectapi.dto.UserContextDto(7L, "Acme", 42L, "user@test.com", "user@test.com", "U", "Ser");
+        sessionStore.saveUserContext(context);
+        ConnectApiAuthGateway authGateway = mock(ConnectApiAuthGateway.class);
+        when(authGateway.login("user@test.com", "secret")).thenReturn(new PasswordLogin("fresh", 3600));
+        TokenManager tokenManager = new TokenManager(sessionStore, authGateway, mock(OAuthTokenGateway.class),
+            "default", new PasswordAuthConfig("user@test.com", "secret"), CLOCK);
+
+        assertThat(tokenManager.ensureValidAccessToken()).isEqualTo("fresh");
+
+        assertThat(sessionStore.getUserContext()).contains(context);
     }
 }

--- a/connect-library/src/test/java/com/tsanet/api/connectapi/internal/TokenManagerTest.java
+++ b/connect-library/src/test/java/com/tsanet/api/connectapi/internal/TokenManagerTest.java
@@ -4,6 +4,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
@@ -25,7 +26,7 @@ class TokenManagerTest {
     void itAuthenticatesWithConfiguredPassword() {
         ConnectApiSessionStore sessionStore = new ConnectApiSessionStore();
         ConnectApiAuthGateway authGateway = mock(ConnectApiAuthGateway.class);
-        when(authGateway.login("user@test.com", "secret")).thenReturn("password-token");
+        when(authGateway.login("user@test.com", "secret")).thenReturn(new PasswordLogin("password-token", 3600));
 
         TokenManager tokenManager = new TokenManager(
             sessionStore,
@@ -101,7 +102,7 @@ class TokenManagerTest {
     }
 
     @Test
-    void itRejectsRefreshForPasswordAuth() {
+    void itRejectsPasswordRefreshWhenNoSessionBelongsToTheConfiguredUser() {
         TokenManager tokenManager = new TokenManager(
             new ConnectApiSessionStore(),
             mock(ConnectApiAuthGateway.class),
@@ -111,8 +112,82 @@ class TokenManagerTest {
             CLOCK
         );
 
+        assertThat(tokenManager.supportsRefresh()).isFalse();
         assertThatThrownBy(tokenManager::refreshAccessToken)
             .isInstanceOf(IllegalStateException.class)
-            .hasMessageContaining("client-credentials");
+            .hasMessageContaining("log in again");
+    }
+
+    @Test
+    void itTracksPasswordExpiryFromTheLoginResponse() {
+        ConnectApiSessionStore sessionStore = new ConnectApiSessionStore();
+        ConnectApiAuthGateway authGateway = mock(ConnectApiAuthGateway.class);
+        when(authGateway.login("user@test.com", "secret")).thenReturn(new PasswordLogin("t1", 1800));
+        TokenManager tokenManager = new TokenManager(sessionStore, authGateway, mock(OAuthTokenGateway.class),
+            "default", new PasswordAuthConfig("user@test.com", "secret"), CLOCK);
+
+        tokenManager.authenticate();
+
+        assertThat(sessionStore.getExpiresAt()).contains(NOW.plusSeconds(1800));
+        assertThat(sessionStore.isExpired(NOW.plusSeconds(1800 - 61))).isFalse();
+        assertThat(sessionStore.isExpired(NOW.plusSeconds(1800 - 59))).isTrue();
+    }
+
+    @Test
+    void itStoresNoExpiryWhenTheLoginResponseStatesNone() {
+        ConnectApiSessionStore sessionStore = new ConnectApiSessionStore();
+        ConnectApiAuthGateway authGateway = mock(ConnectApiAuthGateway.class);
+        when(authGateway.login("user@test.com", "secret")).thenReturn(new PasswordLogin("t1", null));
+        TokenManager tokenManager = new TokenManager(sessionStore, authGateway, mock(OAuthTokenGateway.class),
+            "default", new PasswordAuthConfig("user@test.com", "secret"), CLOCK);
+
+        tokenManager.authenticate();
+
+        assertThat(sessionStore.getExpiresAt()).isEmpty();
+        assertThat(tokenManager.ensureValidAccessToken()).isEqualTo("t1");
+        verify(authGateway, times(1)).login(any(), any());
+    }
+
+    @Test
+    void itReloginsTransparentlyWhenTheConfiguredUsersPasswordTokenExpired() {
+        ConnectApiSessionStore sessionStore = new ConnectApiSessionStore();
+        sessionStore.savePassword("user@test.com", "stale", NOW.minusSeconds(1));
+        ConnectApiAuthGateway authGateway = mock(ConnectApiAuthGateway.class);
+        when(authGateway.login("user@test.com", "secret")).thenReturn(new PasswordLogin("fresh", 3600));
+        TokenManager tokenManager = new TokenManager(sessionStore, authGateway, mock(OAuthTokenGateway.class),
+            "default", new PasswordAuthConfig("user@test.com", "secret"), CLOCK);
+
+        assertThat(tokenManager.supportsRefresh()).isTrue();
+        assertThat(tokenManager.ensureValidAccessToken()).isEqualTo("fresh");
+        assertThat(sessionStore.getBearerToken()).contains("fresh");
+        assertThat(sessionStore.getExpiresAt()).contains(NOW.plusSeconds(3600));
+    }
+
+    @Test
+    void itNeverRenewsASessionOpenedByADifferentTypedUser() {
+        ConnectApiSessionStore sessionStore = new ConnectApiSessionStore();
+        sessionStore.savePassword("other@test.com", "stale", NOW.minusSeconds(1));
+        ConnectApiAuthGateway authGateway = mock(ConnectApiAuthGateway.class);
+        TokenManager tokenManager = new TokenManager(sessionStore, authGateway, mock(OAuthTokenGateway.class),
+            "default", new PasswordAuthConfig("user@test.com", "secret"), CLOCK);
+
+        assertThat(tokenManager.supportsRefresh()).isFalse();
+        assertThatThrownBy(tokenManager::ensureValidAccessToken)
+            .isInstanceOf(IllegalStateException.class)
+            .hasMessageContaining("log in again");
+        verify(authGateway, never()).login(any(), any());
+    }
+
+    @Test
+    void anInteractiveLoginTracksExpiryToo() {
+        ConnectApiSessionStore sessionStore = new ConnectApiSessionStore();
+        ConnectApiAuthGateway authGateway = mock(ConnectApiAuthGateway.class);
+        when(authGateway.login("typed@test.com", "pw")).thenReturn(new PasswordLogin("typed-token", 60));
+        TokenManager tokenManager = new TokenManager(sessionStore, authGateway, mock(OAuthTokenGateway.class),
+            "default", new PasswordAuthConfig("user@test.com", "secret"), CLOCK);
+
+        assertThat(tokenManager.loginWithPassword("typed@test.com", "pw")).isEqualTo("typed-token");
+        assertThat(sessionStore.getUsername()).contains("typed@test.com");
+        assertThat(sessionStore.getExpiresAt()).contains(NOW.plusSeconds(60));
     }
 }

--- a/connect-library/src/test/java/com/tsanet/api/internal/DefaultTsaNetApiSessionLoginTest.java
+++ b/connect-library/src/test/java/com/tsanet/api/internal/DefaultTsaNetApiSessionLoginTest.java
@@ -1,0 +1,176 @@
+package com.tsanet.api.internal;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import com.tsanet.api.ConnectApiException;
+import com.tsanet.api.TsaNetApiConfiguration;
+import com.tsanet.api.auth.ClientCredentialsAuthConfig;
+import com.tsanet.api.auth.PasswordAuthConfig;
+import com.tsanet.api.connectapi.dto.UserContextDto;
+import com.tsanet.api.connectapi.internal.ConnectApiAttachmentsGateway;
+import com.tsanet.api.connectapi.internal.ConnectApiAttachmentsV2Gateway;
+import com.tsanet.api.connectapi.internal.ConnectApiAuthGateway;
+import com.tsanet.api.connectapi.internal.ConnectApiCollaborationGateway;
+import com.tsanet.api.connectapi.internal.ConnectApiFormGateway;
+import com.tsanet.api.connectapi.internal.ConnectApiNotesGateway;
+import com.tsanet.api.connectapi.internal.ConnectApiPartnersGateway;
+import com.tsanet.api.connectapi.internal.ConnectApiResponsesGateway;
+import com.tsanet.api.connectapi.internal.ConnectApiSessionStore;
+import com.tsanet.api.connectapi.internal.ConnectApiUserGateway;
+import com.tsanet.api.connectapi.internal.ConnectApiWebhooksGateway;
+import com.tsanet.api.connectapi.internal.TokenManager;
+import com.tsanet.api.storage.AttachmentConfigStorageService;
+import com.tsanet.api.storage.AttachmentForwardResultStorageService;
+import com.tsanet.api.storage.CaseNoteStorageService;
+import com.tsanet.api.storage.CaseResponseStorageService;
+import com.tsanet.api.storage.CollaborationRequestFormStorageService;
+import com.tsanet.api.storage.CollaborationRequestStorageService;
+import com.tsanet.api.storage.PartnerSelectionStorageService;
+import com.tsanet.api.storage.UserContextStorageService;
+import com.tsanet.api.storage.WebhookInboundEventStorageService;
+import com.tsanet.api.storage.WebhookSubscriptionStorageService;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+/**
+ * Every login ends with {@code /v1/me}: the context is kept for the session, and a failure
+ * there fails the login and clears the store rather than leaving a half-authenticated session.
+ */
+class DefaultTsaNetApiSessionLoginTest {
+
+    private static final UserContextDto CONTEXT = new UserContextDto(7L, "Acme", 42L, "user@test.com", "user@test.com", "U", "Ser");
+
+    private ConnectApiSessionStore sessionStore;
+    private TokenManager tokenManager;
+    private ConnectApiUserGateway userGateway;
+    private DefaultTsaNetApiSession session;
+
+    @BeforeEach
+    void setUp() {
+        sessionStore = new ConnectApiSessionStore();
+        tokenManager = mock(TokenManager.class);
+        userGateway = mock(ConnectApiUserGateway.class);
+        TsaNetApiConfiguration configuration = mock(TsaNetApiConfiguration.class);
+        when(configuration.auth()).thenReturn(new PasswordAuthConfig("user@test.com", "secret"));
+        session = new DefaultTsaNetApiSession(
+            configuration,
+            sessionStore,
+            tokenManager,
+            mock(ConnectApiAuthGateway.class),
+            mock(ConnectApiCollaborationGateway.class),
+            mock(ConnectApiFormGateway.class),
+            mock(ConnectApiNotesGateway.class),
+            mock(ConnectApiResponsesGateway.class),
+            userGateway,
+            mock(ConnectApiWebhooksGateway.class),
+            mock(ConnectApiPartnersGateway.class),
+            mock(ConnectApiAttachmentsGateway.class),
+            mock(ConnectApiAttachmentsV2Gateway.class),
+            mock(CollaborationRequestStorageService.class),
+            mock(CollaborationRequestFormStorageService.class),
+            mock(CaseNoteStorageService.class),
+            mock(CaseResponseStorageService.class),
+            mock(UserContextStorageService.class),
+            mock(WebhookSubscriptionStorageService.class),
+            mock(WebhookInboundEventStorageService.class),
+            mock(PartnerSelectionStorageService.class),
+            mock(AttachmentConfigStorageService.class),
+            mock(AttachmentForwardResultStorageService.class)
+        );
+    }
+
+    @Test
+    void interactiveLoginFetchesTheCurrentUserAndKeepsTheContext() {
+        when(tokenManager.loginWithPassword("user@test.com", "secret")).thenAnswer(inv -> {
+            sessionStore.savePassword("user@test.com", "token-1");
+            return "token-1";
+        });
+        when(userGateway.getCurrentUser()).thenReturn(CONTEXT);
+
+        assertThat(session.login("user@test.com", "secret")).isEqualTo("token-1");
+
+        assertThat(session.currentUserContext()).contains(CONTEXT);
+        assertThat(session.currentUserContext().map(UserContextDto::companyId)).contains(7L);
+        verify(userGateway).getCurrentUser();
+    }
+
+    @Test
+    void configuredLoginFetchesTheCurrentUserToo() {
+        when(tokenManager.authenticate()).thenAnswer(inv -> {
+            sessionStore.savePassword("user@test.com", "token-2");
+            return "token-2";
+        });
+        when(userGateway.getCurrentUser()).thenReturn(CONTEXT);
+
+        assertThat(session.authenticate()).isEqualTo("token-2");
+
+        assertThat(session.currentUserContext()).contains(CONTEXT);
+    }
+
+    @Test
+    void aFailingCurrentUserCallFailsTheLoginAndClearsTheStore() {
+        when(tokenManager.loginWithPassword("user@test.com", "secret")).thenAnswer(inv -> {
+            sessionStore.savePassword("user@test.com", "token-3");
+            return "token-3";
+        });
+        ConnectApiException forbidden = new ConnectApiException(ConnectApiException.Kind.PROBLEM, 403, "about:blank",
+            "Forbidden", "no role", null, null);
+        when(userGateway.getCurrentUser()).thenThrow(forbidden);
+
+        assertThatThrownBy(() -> session.login("user@test.com", "secret")).isSameAs(forbidden);
+
+        assertThat(sessionStore.getBearerToken()).isEmpty();
+        assertThat(session.currentUserContext()).isEmpty();
+        assertThat(session.isAuthorized()).isFalse();
+    }
+
+    @Test
+    void aClientCredentialsLoginFetchesTheCurrentUserAsWell() {
+        // /v1/me answers a client-credentials token (it is not role-gated; BETA probe 2026-09-07),
+        // so the machine identity's company is known to the session too.
+        TsaNetApiConfiguration oauthConfiguration = mock(TsaNetApiConfiguration.class);
+        when(oauthConfiguration.auth()).thenReturn(new ClientCredentialsAuthConfig("tenant", null, "client-id",
+            "client-secret", "api://audience", null));
+        DefaultTsaNetApiSession oauthSession = new DefaultTsaNetApiSession(
+            oauthConfiguration, sessionStore, tokenManager, mock(ConnectApiAuthGateway.class),
+            mock(ConnectApiCollaborationGateway.class), mock(ConnectApiFormGateway.class),
+            mock(ConnectApiNotesGateway.class), mock(ConnectApiResponsesGateway.class), userGateway,
+            mock(ConnectApiWebhooksGateway.class), mock(ConnectApiPartnersGateway.class),
+            mock(ConnectApiAttachmentsGateway.class), mock(ConnectApiAttachmentsV2Gateway.class),
+            mock(CollaborationRequestStorageService.class), mock(CollaborationRequestFormStorageService.class),
+            mock(CaseNoteStorageService.class), mock(CaseResponseStorageService.class),
+            mock(UserContextStorageService.class), mock(WebhookSubscriptionStorageService.class),
+            mock(WebhookInboundEventStorageService.class), mock(PartnerSelectionStorageService.class),
+            mock(AttachmentConfigStorageService.class), mock(AttachmentForwardResultStorageService.class));
+        when(tokenManager.authenticate()).thenAnswer(inv -> {
+            sessionStore.saveOAuth("production", "oauth-token", java.time.Instant.now().plusSeconds(3600));
+            return "oauth-token";
+        });
+        when(userGateway.getCurrentUser()).thenReturn(CONTEXT);
+
+        assertThat(oauthSession.authenticate()).isEqualTo("oauth-token");
+
+        assertThat(oauthSession.currentUserContext()).contains(CONTEXT);
+        assertThat(oauthSession.isAuthorized()).isTrue();
+    }
+
+    @Test
+    void logoutForgetsTheContext() {
+        when(tokenManager.authenticate()).thenAnswer(inv -> {
+            sessionStore.savePassword("user@test.com", "token-4");
+            return "token-4";
+        });
+        when(userGateway.getCurrentUser()).thenReturn(CONTEXT);
+        session.authenticate();
+
+        session.logout();
+
+        assertThat(session.currentUserContext()).isEmpty();
+        verify(tokenManager, never()).refreshAccessToken();
+    }
+}

--- a/connect-library/src/test/java/com/tsanet/api/internal/DefaultTsaNetApiSessionLoginTest.java
+++ b/connect-library/src/test/java/com/tsanet/api/internal/DefaultTsaNetApiSessionLoginTest.java
@@ -160,6 +160,24 @@ class DefaultTsaNetApiSessionLoginTest {
     }
 
     @Test
+    void aTokenRenewalDuringTheSessionKeepsTheContext() {
+        // Issue 20's acceptance: the context is available to subsequent commands, and a renewal
+        // (401 retry or expiry) happens during those commands, for the same principal.
+        when(tokenManager.authenticate()).thenAnswer(inv -> {
+            sessionStore.savePassword("user@test.com", "token-5", java.time.Instant.now().plusSeconds(1800));
+            return "token-5";
+        });
+        when(userGateway.getCurrentUser()).thenReturn(CONTEXT);
+        session.authenticate();
+
+        sessionStore.savePassword("user@test.com", "token-5-renewed", java.time.Instant.now().plusSeconds(1800));
+
+        assertThat(sessionStore.getBearerToken()).contains("token-5-renewed");
+        assertThat(session.currentUserContext()).contains(CONTEXT);
+        verify(userGateway).getCurrentUser();
+    }
+
+    @Test
     void logoutForgetsTheContext() {
         when(tokenManager.authenticate()).thenAnswer(inv -> {
             sessionStore.savePassword("user@test.com", "token-4");

--- a/connect-library/src/test/java/com/tsanet/api/internal/TsaNetApiRuntimeBearerTest.java
+++ b/connect-library/src/test/java/com/tsanet/api/internal/TsaNetApiRuntimeBearerTest.java
@@ -1,0 +1,50 @@
+package com.tsanet.api.internal;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+import com.tsanet.api.ConnectApiException;
+import com.tsanet.api.TsaNetApiConfiguration;
+import com.tsanet.api.connectapi.internal.ConnectApiSessionStore;
+import com.tsanet.api.connectapi.internal.TokenManager;
+import org.junit.jupiter.api.Test;
+
+/** The bearer supplier: absent token means no header; a renewable token is renewed; an unrenewable expiry is a classified 401. */
+class TsaNetApiRuntimeBearerTest {
+
+    @Test
+    void noSessionMeansNoBearer() {
+        assertThat(TsaNetApiRuntime.bearerTokenForRequest(new ConnectApiSessionStore(), mock(TokenManager.class),
+            mock(TsaNetApiConfiguration.class))).isNull();
+    }
+
+    @Test
+    void aRenewableSessionYieldsTheManagersToken() {
+        ConnectApiSessionStore store = new ConnectApiSessionStore();
+        store.savePassword("user@test.com", "stale");
+        TokenManager tokenManager = mock(TokenManager.class);
+        when(tokenManager.ensureValidAccessToken()).thenReturn("fresh");
+
+        assertThat(TsaNetApiRuntime.bearerTokenForRequest(store, tokenManager, mock(TsaNetApiConfiguration.class))).isEqualTo("fresh");
+    }
+
+    @Test
+    void anExpiredSessionThatCannotBeRenewedIsAClassifiedFourOhOne() {
+        ConnectApiSessionStore store = new ConnectApiSessionStore();
+        store.savePassword("typed@test.com", "stale");
+        TokenManager tokenManager = mock(TokenManager.class);
+        when(tokenManager.ensureValidAccessToken())
+            .thenThrow(new IllegalStateException("Session expired and cannot be renewed with the configured credentials; log in again"));
+
+        assertThatThrownBy(() -> TsaNetApiRuntime.bearerTokenForRequest(store, tokenManager, mock(TsaNetApiConfiguration.class)))
+            .isInstanceOf(ConnectApiException.class)
+            .satisfies(e -> {
+                ConnectApiException ex = (ConnectApiException) e;
+                assertThat(ex.status()).isEqualTo(401);
+                assertThat(ex.title()).isEqualTo("Session expired");
+                assertThat(ex.getMessage()).contains("log in again");
+            });
+    }
+}

--- a/demo-ui/src/main/java/com/tsanet/demo/web/ApiErrorHandler.java
+++ b/demo-ui/src/main/java/com/tsanet/demo/web/ApiErrorHandler.java
@@ -1,5 +1,7 @@
 package com.tsanet.demo.web;
 
+import com.tsanet.api.ConnectApiException;
+import java.util.LinkedHashMap;
 import java.util.Map;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
@@ -20,6 +22,25 @@ public class ApiErrorHandler {
     public ResponseEntity<Map<String, String>> handleStatus(ResponseStatusException e) {
         return ResponseEntity.status(e.getStatusCode())
             .body(Map.of("error", e.getReason() != null ? e.getReason() : e.getMessage()));
+    }
+
+    /**
+     * The SDK's classified answer: the upstream status passes through (502 when the API could
+     * not be reached), and the page gets the API's own title and detail plus the problem type.
+     */
+    @ExceptionHandler(ConnectApiException.class)
+    public ResponseEntity<Map<String, String>> handleConnectApi(ConnectApiException e) {
+        int status = e.kind() == ConnectApiException.Kind.CONNECTIVITY || e.status() < 400 ? 502 : e.status();
+        Map<String, String> body = new LinkedHashMap<>();
+        body.put("error", e.title() != null ? e.title() : e.getMessage());
+        if (e.detail() != null) {
+            body.put("detail", e.detail());
+        }
+        if (e.type() != null) {
+            body.put("type", e.type());
+        }
+        body.put("kind", e.kind().name());
+        return ResponseEntity.status(status).body(body);
     }
 
     @ExceptionHandler(RestClientResponseException.class)

--- a/demo-ui/src/test/java/com/tsanet/demo/web/ApiErrorHandlerTest.java
+++ b/demo-ui/src/test/java/com/tsanet/demo/web/ApiErrorHandlerTest.java
@@ -1,0 +1,52 @@
+package com.tsanet.demo.web;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import com.tsanet.api.ConnectApiException;
+import java.util.Map;
+import org.junit.jupiter.api.Test;
+import org.springframework.http.ResponseEntity;
+
+/** The SDK's classified answer reaches the page with the API's own words and the upstream status. */
+class ApiErrorHandlerTest {
+
+    private final ApiErrorHandler handler = new ApiErrorHandler();
+
+    @Test
+    void aProblemPassesItsStatusTitleDetailAndTypeThrough() {
+        ConnectApiException e = new ConnectApiException(ConnectApiException.Kind.PROBLEM, 422,
+            "https://connect.example/problems/case-update-error", "Unprocessable Entity", "OPEN cases cannot be closed.", null, null);
+
+        ResponseEntity<Map<String, String>> response = handler.handleConnectApi(e);
+
+        assertThat(response.getStatusCode().value()).isEqualTo(422);
+        assertThat(response.getBody()).containsEntry("error", "Unprocessable Entity")
+            .containsEntry("detail", "OPEN cases cannot be closed.")
+            .containsEntry("type", "https://connect.example/problems/case-update-error")
+            .containsEntry("kind", "PROBLEM");
+    }
+
+    @Test
+    void aLegacyAnswerKeepsItsStatusAndMessage() {
+        ConnectApiException e = new ConnectApiException(ConnectApiException.Kind.LEGACY, 500, null, null,
+            "Only the receiving partner can approve a case.", null, null);
+
+        ResponseEntity<Map<String, String>> response = handler.handleConnectApi(e);
+
+        assertThat(response.getStatusCode().value()).isEqualTo(500);
+        assertThat(response.getBody()).containsEntry("error", e.getMessage())
+            .containsEntry("detail", "Only the receiving partner can approve a case.")
+            .doesNotContainKey("type");
+    }
+
+    @Test
+    void connectivityIsABadGateway() {
+        ConnectApiException e = ConnectApiException.connectivity(new java.net.ConnectException("refused"));
+
+        ResponseEntity<Map<String, String>> response = handler.handleConnectApi(e);
+
+        assertThat(response.getStatusCode().value()).isEqualTo(502);
+        assertThat(response.getBody()).containsEntry("kind", "CONNECTIVITY")
+            .containsEntry("detail", "ConnectException");
+    }
+}

--- a/docs/RUNBOOK.md
+++ b/docs/RUNBOOK.md
@@ -63,7 +63,7 @@ Credentials persist to `~/.tsanet-demo-ui/credentials.properties` (mode 600, nev
 Badge decoder:
 - **Green "Company — email"** — authenticated, everything live
 - **Amber "Not configured"** — no credentials saved yet
-- **Amber "Auth failed: Connect API returned 500 — Error processing request"** — the environment rejected the credentials (BETA's legacy error mode returns 500, not 401; a wrong password looks like this)
+- **Amber "Auth failed: Authentication Failed — …"** — the environment rejected the credentials (HTTP 401 problem details; a wrong password looks like this)
 
 ## 4. First-session verification sweep (once, with the first real credentials)
 

--- a/docs/USER_GUIDE.md
+++ b/docs/USER_GUIDE.md
@@ -28,7 +28,7 @@ The badge in the top-right corner is the connection truth:
 |---|---|
 | Green — "Company — email" | Authenticated; shows who BETA thinks you are |
 | Amber — "Not configured" | No credentials saved yet (Settings tab) |
-| Amber — "Auth failed: Connect API returned 500 — Error processing request" | BETA rejected the credentials. The API's legacy error mode returns 500 (not 401) for bad logins, so this is almost always a wrong username/password |
+| Amber — "Auth failed: Authentication Failed — …" | BETA rejected the credentials (HTTP 401). The SDK asks the API for RFC 7807 problem details and shows the API's own title and detail, so this is almost always a wrong username/password |
 
 ## 3. Settings — environments and credentials
 
@@ -110,9 +110,12 @@ Opens from the Dashboard or after creating a case.
         receiver must still approve/reject — close is invalid while pending)
   ```
 
-  Invalid transitions come back as the legacy 500 with a meaningful message,
-  e.g. `{"message":"INFORMATION cases cannot be closed."}` — that's the
-  business contract enforcing itself, shown verbatim.
+  Invalid transitions come back as a 4xx problem-details answer, shown as the
+  API's title and detail, e.g. `Unprocessable Entity — INFORMATION cases cannot
+  be closed.` — that's the business contract enforcing itself. (The API's legacy
+  500 with a `{"message"}` body appears only to clients that do not send the
+  `application/problem+json` Accept header; the SDK does, and classifies a legacy
+  body by its content if one ever arrives.)
 - **Notes Timeline** and **Response History** — the full conversation and
   every engineer response on the case. System-generated notes (e.g.
   "Case accepted.") arrive as HTML; the demo renders them formatted through a
@@ -141,8 +144,8 @@ manages subscriptions and shows TSANet's delivery attempts outward.
 | Symptom | Cause / action |
 |---|---|
 | Everything says "BETA credentials not configured" | No credentials saved — Settings tab |
-| Badge: "Auth failed … 500 Error processing request" | Wrong BETA credentials (legacy error mode — 500 means login rejected) |
-| Actions fail with "Connect API returned 4xx/5xx — …" | Upstream validation: wrong case state, off-domain engineer email, or the legacy-500 quirk. The response body is shown verbatim |
+| Badge: "Auth failed: Authentication Failed — …" | Wrong BETA credentials (HTTP 401 problem details) |
+| Actions fail with "<title> — <detail>" | Upstream validation: wrong case state, off-domain engineer email. The API's problem-details title and detail are shown; a legacy `{"message"}` body is classified and shown the same way |
 | Case list loads but partner search errors | Partner search requires a valid session — re-check the badge first |
 | Build fails: `cannot find symbol … WebhooksApi` | Sibling `Connect-API-Code` checkout is on the wrong branch — needs `beta` |
 

--- a/skills/connect-sdk-deploy/SKILL.md
+++ b/skills/connect-sdk-deploy/SKILL.md
@@ -101,11 +101,14 @@ versions. Do not build from the historical `oauth` branch: it merged to `main` i
 
 These bite regardless of path, and none of them are visible in the OpenAPI schema:
 
-- **Bad credentials return HTTP 500, not 401.** The Connect API's legacy error mode
-  answers a wrong username or password with
-  `500 "Error processing request"`. Sending `Accept: application/problem+json` opts
-  into structured RFC 7807 errors. Do not let a member burn an afternoon debugging
-  their network for what is a typo in a password.
+- **Two error modes, and the SDK is on the right one.** By default the Connect API's
+  legacy error mode answers a wrong username or password with
+  `500 "Error processing request"`; sending `Accept: application/json, application/problem+json`
+  opts into RFC 7807 errors with the documented status codes. The SDK sends that header
+  on every call and maps the answer into `ConnectApiException` (kind, status, type, title,
+  detail), so through the SDK a bad login reads `HTTP 401 Authentication Failed`. A
+  member calling the API directly without the header still sees the 500. Do not let a
+  member burn an afternoon debugging their network for what is a typo in a password.
 - **Test-mode asymmetry.** You *write* the `testSubmission` flag when creating a case
   but *read* it back as `testCase`. The library's create API takes an explicit
   per-call `testSubmission` flag with no silent default; older always-test method

--- a/skills/connect-sdk-deploy/references/demo-deploy.md
+++ b/skills/connect-sdk-deploy/references/demo-deploy.md
@@ -41,10 +41,9 @@ The server listens on **http://localhost:8090**. Ctrl+C stops it, or
 2. The header badge is the connection truth:
    - **Green "Company — email"**: authenticated; that is the live `/api/me` answer
    - **Amber "Not configured"**: nothing saved yet
-   - **Amber "Auth failed: Connect API returned 500 — Error processing request"**: the
-     environment rejected the credentials. The API's legacy error mode returns 500 for
-     bad logins, so this almost always means a wrong username or password, not an
-     outage.
+   - **Amber "Auth failed: Authentication Failed — …"**: the environment rejected the
+     credentials with a 401 problem-details answer, shown as the API's title and detail.
+     This almost always means a wrong username or password, not an outage.
 
 Credentials persist per environment to `~/.tsanet-demo-ui/` (mode 600, never in git),
 with an isolated SQLite cache per environment, so restarts skip this step. Settings →

--- a/skills/connect-sdk-deploy/references/troubleshooting.md
+++ b/skills/connect-sdk-deploy/references/troubleshooting.md
@@ -36,10 +36,12 @@ The build wants JDK 21. On macOS with Homebrew, `openjdk@21` is keg-only: export
 
 ## Runtime, demo
 
-**Badge says: Auth failed: Connect API returned 500 — Error processing request**
-Almost always wrong credentials. The Connect API's legacy error mode answers bad
-logins with 500, not 401. Re-enter the username and password before suspecting the
-platform.
+**Badge says: Auth failed: Authentication Failed — …**
+Almost always wrong credentials: the API answered the login with a 401 problem-details
+body, and the badge shows its title and detail. Re-enter the username and password
+before suspecting the platform. (A raw client that does not send the
+`application/problem+json` Accept header sees the legacy `500 Error processing request`
+for the same mistake; the SDK always sends the header.)
 
 **Everything authenticates but the dashboard is empty or case actions 403**
 Authentication is not authorization. `/me` succeeds for any valid account, while
@@ -72,9 +74,12 @@ time, or move the bridge (`tsanet.webhook.port`).
 ## Interpreting API errors generally
 
 The API has two error personalities. By default (legacy mode) failures collapse into
-`500 Error processing request`. Sending `Accept: application/problem+json` opts into
-RFC 7807 structured errors with a usable `detail`. When debugging anything
-API-side, turn that on first; it converts guessing into reading.
+`500 Error processing request`. Sending `Accept: application/json, application/problem+json`
+opts into RFC 7807 structured errors with a usable `detail`. The SDK sends that header on
+every call and surfaces the answer as `ConnectApiException` (status, type, title, detail;
+a legacy `{"message"}` body is classified by content if one arrives; a transport failure
+names only its cause, never the URL). When debugging anything API-side with a raw client,
+turn the header on first; it converts guessing into reading.
 
 Test-mode note for anyone wiring their own client: you *write* `testSubmission` on
 create but *read* the flag back as `testCase`. Filtering on the write-side name


### PR DESCRIPTION
Closes #20. Connection hardening, re-scoped on 2026-09-07 to the three items still undone: the shipped plaintext default, password-mode token lifecycle plus `/v1/me` after login, and problem-details mapping.

## What this changes, by item

**1. TLS default.** The console app and the scripted demo shipped `base-url: "http://localhost:8080"`, a plaintext target for a bearer token. Both now default to the https BETA host, the same default the demo-ui already uses. The console rejects a non-https base URL at startup with the fix in the message, unless `tsanet.api.allow-insecure-http` is true; the test profile opts in for its local mock. No guard in the library, since library tests and members' mocks use http and the acceptance names the shipped app configuration. Sweep receipt: `grep -rn 'http://' */src/main/resources` now finds only the console's own local webhook-receiver address, which is not a Connect target.

**2. Password lifecycle and `/v1/me`.** Login returns the token and its `expiresIn`; the store keeps the expiry for password mode too, so the 60-second skew and `isAuthorized` now apply to both modes. The token manager renews on expiry in both modes. For password mode it re-logins transparently with the configured credentials, only when the session belongs to that user; otherwise it fails with a clear "log in again", because an interactively typed password is never retained. The 401 retry interceptor is wired for both modes and asks the token manager whether renewal is possible. Login rides its own unauthenticated client, without the bearer supplier or the 401 retry: on the session client a re-login on an expired token would recurse into itself through both. An expiry that cannot be renewed surfaces from the bearer supplier as a classified 401 rather than a bare exception, so the console and the demo render it like every other failure. Both login paths end in one method that fetches `/v1/me` through the session client, keeps the company and user on the session (`AuthFacade.currentUserContext()`), and on failure clears the store and rethrows: a login is not a login until a protected call has answered.

**Verified live this session:** on BETA, `/v1/me` answers a client-credentials token with HTTP 200 and the company (user null), so fetching it after every login is safe in both modes. The advisor had flagged this as the one thing that could brick client-credentials mode; the probe settles it.

**3. Problem-details mapping.** A public `ConnectApiException` (kind, status, type, title, detail, instance; value-free message; `isProblem(typeSuffix)`), thrown by a response error handler on the library's one `RestTemplate` factory and classified by the body alone: RFC 7807 fields mean `PROBLEM`; a `message` field means `LEGACY`, the API's default shape that arrives with a 500 where a 4xx belongs (`tsanetgit/Connect-API-Code#122`, with `validationErrors` folded into the detail); anything else is `OTHER` with a 200-character excerpt, the request URL and path scrubbed out of it first because intermediaries echo the request URI. A connectivity interceptor, installed first so it also wraps the 401 retry, turns transport failures into the same exception naming only the cause class: once an `IOException` reaches `RestTemplate` its message carries the request URL, and the URL carries the case token. The generated client already sends `Accept: application/json, application/problem+json` on every call except health (checked in the generated sources this session), which is why the API answers with the documented 4xx; nothing had parsed the answer. The V2 attachment client converts the classified exception first, so its typed contract holds in production. The console prints the exception's message, which reads `HTTP 422 Unprocessable Entity (case-update-error): OPEN cases cannot be closed.`; the demo's error handler passes the upstream status through with the API's title, detail, type and the kind.

**Docs.** The user guide, runbook, deploy skill and its references described a bad login as "Connect API returned 500 — Error processing request". Through the SDK that is now `HTTP 401 Authentication Failed` with the API's detail; the text says so and keeps the legacy 500 as what a raw client without the header sees.

## Verification

- Reactor, `mvn test`: **connect-library 156 run, 0 failures, 1 skipped** (25 new offline tests; the one skip is the env-gated attachments live test), **attachment-receiver 182 / 0 / 40**, **demo-ui 18 / 0** (3 new), **console 37 / 0** (4 new), **scripted demo 6 / 0**.
- `ConnectApiResponseErrorHandlerTest` (8), through the generated client on the library's own `RestTemplate`, every request path carrying a marker token: the #122 shapes (422 problem on closure, legacy 500 with message, validation errors folded, 401 problem on login), an HTML body as excerpt, an intermediary page that echoes the request path scrubbed, a closed port as connectivity, and the body-first rule on a problem body riding a 500. No message carries the marker or the host.
- `TokenManagerTest` (+6): expiry from `expiresIn`, none when absent, transparent re-login for the configured user, a different typed user refused, interactive login tracked, refresh refused without a matching session.
- `OAuth401RetryInterceptorTest` (3, the first for this class): retry once with the renewed bearer, pass-through when renewal is impossible, non-401 untouched.
- `DefaultTsaNetApiSessionLoginTest` (5): interactive, configured and client-credentials logins all fetch `/v1/me` and keep the context; a failing `/v1/me` clears the store and rethrows; logout forgets the context. `TsaNetApiRuntimeBearerTest` (3): the bearer supplier's classified 401.
- `ConnectApiAttachmentsV2ApiTest` (+1): the classified exception keeps its type through the attachment client on the runtime template. `ConnectFacadeConfigurationTest` (4) and `ApiErrorHandlerTest` (3) for the guard and the demo rendering.
- Live: the `/v1/me` client-credentials probe above. The error mapping was not run against BETA; the shapes are the ones recorded on #122 on 2026-07-10, which the same API still returns per the memory verified 2026-07-09.

## Prose claims and the lines that make them true

| claim | line |
|---|---|
| login cannot recurse through re-login | `TsaNetApiRuntime`: `loginApiClient` on `ConnectApiRestTemplates.create()`, no bearer supplier, no 401 interceptor |
| password re-login only for the configured user | `TokenManager.canReloginWithConfiguredPassword`; `itNeverRenewsASessionOpenedByADifferentTypedUser` |
| a login is not a login until `/v1/me` answered | `DefaultTsaNetApiSession.completeLogin`; `aFailingCurrentUserCallFailsTheLoginAndClearsTheStore` |
| classification is by body, not status | `ConnectApiResponseErrorHandler.classify`; `classificationIsByBodyFirstEvenWhenAProblemBodyRidesOnAFiveHundred` |
| the URL never reaches a message | `scrub`, `ConnectApiException.connectivity`; every handler test's `doesNotContain("MARKER")` |
| the 401 retry fires before classification | interceptor chain order (connectivity, then retry) runs inside `execute`; the error handler runs on the returned response |
| the generated client sends the problem+json Accept | `localVarAccepts` in every generated API except `HealthApi` (checked in `target/generated-sources`) |
| the console renders type, title, detail | `ConsoleShellRunner` prints `ex.getMessage()`, which `ConnectApiException.format` builds from those fields |

## Blast radius (`pre-pr-artifacts.py`, base `origin/main`)

No mechanical detector fired. Judgment lines:

- **Positional and interface contracts.** `AuthFacade` gained `currentUserContext()`; implementers by command, `git grep -ln "implements AuthFacade"`: the default session (via `TsaNetApiSession`'s facade set) and the account-scoped session's inner facade, both updated. `ConnectApiAuthGateway.login` changed return type; callers by command: `TokenManager` only in main (the session now goes through `tokenManager.loginWithPassword`), plus the gateway test and the token-manager test, all updated. `ConnectApiSessionStore.savePassword` kept its two-argument form, so the four test call sites are untouched.
- **Guard vs representation.** `requireHttps` is a guard on operator configuration; the representation alternative, a URL type that cannot hold http, would reject every local mock. The opt-out is the escape hatch, in config, on purpose.
- **Newly reachable failures.** Every non-2xx and every transport failure now surfaces as `ConnectApiException`; receiving handlers are the console's `Command failed:` line, the login command's `Login failed:` line, and the demo's `handleConnectApi`. The demo's `handleUpstream(RestClientResponseException)` is now mostly unreachable from library calls and stays as a fallback.
- **Abstraction introduced.** The error handler centralizes classification; old form swept by command, `grep -rn 'catch (RestClientException\|catch (HttpStatusCodeException\|catch (RestClientResponseException'` over main sources: the OAuth token gateway (its own client, untouched) and the V2 attachment client, whose arms now sit behind the new catch.
- **Behavior change to state plainly.** Anyone running the console or the scripted demo against a local http mock must now set `tsanet.api.allow-insecure-http=true` or startup fails, by design. Password-mode sessions now expire on the API's `expiresIn`, so `isAuthorized` can flip to false where it never did before.
- **Schema / stored shape.** None. The SQLite user-context table was already written by the user gateway; it is now written on every login.

## Gate dispositions (CONCERNS, first run)

- *Concurrent 401s each trigger a re-login; no single-flight.* Acknowledged as a follow-up. Same class as the pre-existing client-credentials refresh; password mode widens it to a live login per concurrent 401. Correct, wasteful under load; a single-flight around `refreshAccessToken` is the fix when it matters.
- *`completeLogin` clears the store on a transient connectivity failure to `/v1/me`.* Designed. The acceptance says the context is available after login; a login whose first protected call did not answer is not a login yet, and the caller retries the login. Stated here rather than softened.
- *Confirm the multi-module build.* The reactor above is that receipt: all five modules green, including the console's context test on the opted-in http mock.

## Follow-ups (not in this PR)

- Single-flight on `refreshAccessToken` across concurrent 401s, and atomic writes in `ConnectApiSessionStore` (a concurrent reader can see a new token beside a stale username or expiry).
- The demo-ui and the scripted demo build their own sessions and have no https guard; both ship https values. A guard in each is a one-liner if wanted.
- A failure while reading a 2xx body happens after the interceptor chain, so it can still surface Spring's URL-bearing `ResourceAccessException`. Rare; same residual class the scrub closes for non-2xx.
- Optional retry of `/v1/me` on an unattended client-credentials startup, where a blip on one endpoint now turns a working start into a hard failure.
- Once `tsanetgit/Connect-API-Code#125` fixes the spec's crossed error modes, the generated models will carry `ProblemDetail`; the handler can then deserialize instead of reading the tree.

## Advisor and gate

QA round at `4174d45`: two blockers (context dropped on renewal; lifetime at or below the skew born expired) fixed in `d0cc011`, disposition per note in the PR comments. Library suite at `d0cc011`: 163 run, 0 failures, 1 skipped.

Advisor consulted twice. Orientation: the login-recursion trap and its structural fix (a separate unauthenticated client), fail the login when `/v1/me` fails, do not retain typed passwords, keep the guard out of the library, BETA as the shipped default. Pre-done: blocked on whether `/v1/me` answers a client-credentials token (settled by the live probe, plus a client-credentials login test), the unrenewable-expiry exception reaching the demo unclassified (fixed at the bearer supplier), and the excerpt echoing the request path (fixed with the scrub). Pre-PR gate: **CONCERNS**, dispositions above. Review is CI plus a QA-persona pass from a separate session.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

