### PR TITLE
Connection hardening follow-ups: single-flight renewal, atomic session store, value-free 2xx read failure, /v1/me retry, https guard in both demos (#79)

### DIFF
--- a/TSANet-integration-app/src/main/java/com/tsanet/facade/config/ConnectFacadeConfiguration.java
+++ b/TSANet-integration-app/src/main/java/com/tsanet/facade/config/ConnectFacadeConfiguration.java
@@ -1,5 +1,6 @@
 package com.tsanet.facade.config;
 
+import com.tsanet.api.ConnectApiBaseUrl;
 import com.tsanet.api.TsaNetApi;
 import com.tsanet.api.TsaNetApiConnectionSettings;
 import com.tsanet.api.TsaNetApiSession;
@@ -24,22 +25,15 @@ public class ConnectFacadeConfiguration {
 
     /**
      * A bearer over plain http is a credential on the wire. Fail at startup, with the fix in
-     * the message, rather than at the first request.
+     * the message, rather than at the first request. The decision itself lives in the library
+     * ({@link ConnectApiBaseUrl}) so the console and both demos make it the same way.
      */
     static void requireHttps(ConnectFacadeProperties.Api api) {
-        String baseUrl = api == null ? null : api.baseUrl();
-        if (baseUrl == null || baseUrl.isBlank()) {
-            throw new IllegalStateException("tsanet.api.base-url is required");
-        }
-        if (baseUrl.regionMatches(true, 0, "https://", 0, 8)) {
-            return;
-        }
-        if (api.insecureHttpAllowed()) {
-            return;
-        }
-        throw new IllegalStateException("tsanet.api.base-url must use https; the Connect API is HTTPS-only in every real "
-            + "environment and a bearer token must not travel in plain text. Set tsanet.api.allow-insecure-http=true "
-            + "only for a local mock.");
+        ConnectApiBaseUrl.requireHttps(
+            api == null ? null : api.baseUrl(),
+            api != null && api.insecureHttpAllowed(),
+            "tsanet.api.allow-insecure-http"
+        );
     }
 
     @Bean

--- a/TSANet-integration-app/src/main/java/com/tsanet/facade/config/ConnectFacadeConfiguration.java
+++ b/TSANet-integration-app/src/main/java/com/tsanet/facade/config/ConnectFacadeConfiguration.java
@@ -32,6 +32,7 @@ public class ConnectFacadeConfiguration {
         ConnectApiBaseUrl.requireHttps(
             api == null ? null : api.baseUrl(),
             api != null && api.insecureHttpAllowed(),
+            "tsanet.api.base-url",
             "tsanet.api.allow-insecure-http"
         );
     }

--- a/TSANet-integration-app/src/test/java/com/tsanet/facade/config/ConnectFacadeConfigurationTest.java
+++ b/TSANet-integration-app/src/test/java/com/tsanet/facade/config/ConnectFacadeConfigurationTest.java
@@ -35,6 +35,6 @@ class ConnectFacadeConfigurationTest {
     void aMissingBaseUrlIsItsOwnError() {
         assertThatThrownBy(() -> ConnectFacadeConfiguration.requireHttps(new ConnectFacadeProperties.Api(" ", true)))
             .isInstanceOf(IllegalStateException.class)
-            .hasMessageContaining("required");
+            .hasMessageContaining("tsanet.api.base-url is required");
     }
 }

--- a/TSANet-integration-demo/src/main/java/com/tsanet/application/config/TsaNetApiConfigurationBean.java
+++ b/TSANet-integration-demo/src/main/java/com/tsanet/application/config/TsaNetApiConfigurationBean.java
@@ -1,6 +1,7 @@
 package com.tsanet.application.config;
 
 import com.tsanet.api.ApplicationUserAccountRegistry;
+import com.tsanet.api.ConnectApiBaseUrl;
 import com.tsanet.api.TsaNetApi;
 import com.tsanet.api.TsaNetApiConnectionSettings;
 import com.tsanet.api.TsaNetApiSession;
@@ -15,6 +16,12 @@ import org.springframework.context.annotation.Configuration;
 public class TsaNetApiConfigurationBean {
     @Bean
     TsaNetApiSessionFactory tsaNetApiSessionFactory(TsaNetApplicationProperties properties) {
+        // A bearer over plain http is a credential on the wire; refuse at startup, same rule as the console.
+        ConnectApiBaseUrl.requireHttps(
+            properties.api() == null ? null : properties.api().baseUrl(),
+            properties.api() != null && properties.api().insecureHttpAllowed(),
+            "tsanet.api.allow-insecure-http"
+        );
         return TsaNetApi.sessionFactory(TsaNetApiConnectionSettings.of(
             properties.api().baseUrl(),
             properties.storage() != null ? properties.storage().sqlitePath() : "data.db"

--- a/TSANet-integration-demo/src/main/java/com/tsanet/application/config/TsaNetApiConfigurationBean.java
+++ b/TSANet-integration-demo/src/main/java/com/tsanet/application/config/TsaNetApiConfigurationBean.java
@@ -20,6 +20,7 @@ public class TsaNetApiConfigurationBean {
         ConnectApiBaseUrl.requireHttps(
             properties.api() == null ? null : properties.api().baseUrl(),
             properties.api() != null && properties.api().insecureHttpAllowed(),
+            "tsanet.api.base-url",
             "tsanet.api.allow-insecure-http"
         );
         return TsaNetApi.sessionFactory(TsaNetApiConnectionSettings.of(

--- a/TSANet-integration-demo/src/main/java/com/tsanet/application/config/TsaNetApplicationProperties.java
+++ b/TSANet-integration-demo/src/main/java/com/tsanet/application/config/TsaNetApplicationProperties.java
@@ -13,7 +13,14 @@ public record TsaNetApplicationProperties(
     Storage storage,
     List<ApplicationUserAccountConfig> accounts
 ) {
-    public record Api(String baseUrl) {
+    /**
+     * @param baseUrl           the Connect API base URL; https in every real environment
+     * @param allowInsecureHttp opt-out of the https requirement for a local mock; null means false
+     */
+    public record Api(String baseUrl, Boolean allowInsecureHttp) {
+        public boolean insecureHttpAllowed() {
+            return Boolean.TRUE.equals(allowInsecureHttp);
+        }
     }
 
     public record Auth(String username, String password) {

--- a/TSANet-integration-demo/src/main/resources/application.yml
+++ b/TSANet-integration-demo/src/main/resources/application.yml
@@ -14,7 +14,10 @@ server:
 tsanet:
   api:
     # HTTPS-only in every real environment; BETA is the shipped default (see the console app).
+    # A plain-http base URL is rejected at startup unless allow-insecure-http is true. That
+    # switch exists for a local mock; it admits any non-https host, so it stays false elsewhere.
     base-url: "https://connect2.tsanet.net"
+    allow-insecure-http: false
   storage:
     sqlite-path: "${user.home}/.tsanet-client-demo"
   # No accounts are configured here. This is a public repository, so credentials

--- a/TSANet-integration-demo/src/test/java/com/tsanet/application/config/TsaNetApiConfigurationBeanTest.java
+++ b/TSANet-integration-demo/src/test/java/com/tsanet/application/config/TsaNetApiConfigurationBeanTest.java
@@ -1,0 +1,35 @@
+package com.tsanet.application.config;
+
+import static org.assertj.core.api.Assertions.assertThatCode;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import org.junit.jupiter.api.Test;
+
+/** The scripted demo refuses a plain-http base URL at startup unless the operator opted in, same rule as the console. */
+class TsaNetApiConfigurationBeanTest {
+
+    private static TsaNetApplicationProperties propertiesFor(String baseUrl, Boolean allowInsecureHttp) {
+        return new TsaNetApplicationProperties(
+            new TsaNetApplicationProperties.Api(baseUrl, allowInsecureHttp),
+            null,
+            new TsaNetApplicationProperties.Storage(System.getProperty("java.io.tmpdir") + "/tsanet-bean-test"),
+            null
+        );
+    }
+
+    @Test
+    void aPlainHttpBaseUrlFailsAtStartupWithTheFixInTheMessage() {
+        assertThatThrownBy(() -> new TsaNetApiConfigurationBean().tsaNetApiSessionFactory(propertiesFor("http://connect.example", null)))
+            .isInstanceOf(IllegalStateException.class)
+            .hasMessageContaining("https")
+            .hasMessageContaining("tsanet.api.allow-insecure-http=true");
+    }
+
+    @Test
+    void anHttpsBaseUrlAndAnOptedInHttpMockBothStart() {
+        assertThatCode(() -> new TsaNetApiConfigurationBean().tsaNetApiSessionFactory(propertiesFor("https://connect.example", null)))
+            .doesNotThrowAnyException();
+        assertThatCode(() -> new TsaNetApiConfigurationBean().tsaNetApiSessionFactory(propertiesFor("http://localhost:8080", true)))
+            .doesNotThrowAnyException();
+    }
+}

--- a/TSANet-integration-demo/src/test/resources/application.yml
+++ b/TSANet-integration-demo/src/test/resources/application.yml
@@ -1,6 +1,8 @@
 tsanet:
   api:
     base-url: "http://localhost:8080"
+    # The tests run against a local mock; the console's rule would otherwise refuse this URL.
+    allow-insecure-http: true
   storage:
     sqlite-path: "${java.io.tmpdir}/tsanet-test"
   accounts:

--- a/connect-library/src/main/java/com/tsanet/api/ConnectApiBaseUrl.java
+++ b/connect-library/src/main/java/com/tsanet/api/ConnectApiBaseUrl.java
@@ -17,12 +17,13 @@ public final class ConnectApiBaseUrl {
     /**
      * @param baseUrl           the configured base URL
      * @param allowInsecureHttp the operator's opt-in to plain http
-     * @param optOutSetting     the application's name for that opt-in, so the message names the fix
+     * @param baseUrlSetting    the application's name for the base URL setting, so a missing one names the fix
+     * @param optOutSetting     the application's name for the opt-in, so a rejected one names the fix
      * @throws IllegalStateException when the URL is missing, or is not https and the opt-in is off
      */
-    public static void requireHttps(String baseUrl, boolean allowInsecureHttp, String optOutSetting) {
+    public static void requireHttps(String baseUrl, boolean allowInsecureHttp, String baseUrlSetting, String optOutSetting) {
         if (baseUrl == null || baseUrl.isBlank()) {
-            throw new IllegalStateException("Connect API base URL is required");
+            throw new IllegalStateException(baseUrlSetting + " is required");
         }
         if (baseUrl.regionMatches(true, 0, "https://", 0, 8)) {
             return;

--- a/connect-library/src/main/java/com/tsanet/api/ConnectApiBaseUrl.java
+++ b/connect-library/src/main/java/com/tsanet/api/ConnectApiBaseUrl.java
@@ -1,0 +1,37 @@
+package com.tsanet.api;
+
+/**
+ * The one place an application decides whether a Connect API base URL may be used: https
+ * always, plain http only when the operator opted in, in configuration, on purpose. A bearer
+ * over plain http is a credential on the wire, so the check runs at startup, with the fix in
+ * the message, rather than at the first request.
+ *
+ * <p>This is a helper applications call from their configuration; the library's own request
+ * paths never invoke it, so tests and local mocks stay free to use http.
+ */
+public final class ConnectApiBaseUrl {
+
+    private ConnectApiBaseUrl() {
+    }
+
+    /**
+     * @param baseUrl           the configured base URL
+     * @param allowInsecureHttp the operator's opt-in to plain http
+     * @param optOutSetting     the application's name for that opt-in, so the message names the fix
+     * @throws IllegalStateException when the URL is missing, or is not https and the opt-in is off
+     */
+    public static void requireHttps(String baseUrl, boolean allowInsecureHttp, String optOutSetting) {
+        if (baseUrl == null || baseUrl.isBlank()) {
+            throw new IllegalStateException("Connect API base URL is required");
+        }
+        if (baseUrl.regionMatches(true, 0, "https://", 0, 8)) {
+            return;
+        }
+        if (allowInsecureHttp) {
+            return;
+        }
+        throw new IllegalStateException("Connect API base URL must use https; the Connect API is HTTPS-only in every "
+            + "real environment and a bearer token must not travel in plain text. Set " + optOutSetting
+            + "=true only for a local mock; it admits any non-https host.");
+    }
+}

--- a/connect-library/src/main/java/com/tsanet/api/connectapi/internal/ConnectApiConnectivityInterceptor.java
+++ b/connect-library/src/main/java/com/tsanet/api/connectapi/internal/ConnectApiConnectivityInterceptor.java
@@ -13,6 +13,11 @@ import org.springframework.http.client.ClientHttpResponse;
  * {@code RestTemplate} it becomes a {@code ResourceAccessException} whose message embeds the
  * request URL, and the URL carries the case token. Installed first, so it also wraps the
  * 401 re-auth retry.
+ *
+ * <p>The response body is read here too. The library's request factory buffers responses, so
+ * this read fills the buffer the extractor and the error handler later read from; without it a
+ * body that fails mid-read would fail after the chain has returned, in the extractor, and
+ * surface with the URL in the same way.
  */
 public final class ConnectApiConnectivityInterceptor implements ClientHttpRequestInterceptor {
 
@@ -20,7 +25,9 @@ public final class ConnectApiConnectivityInterceptor implements ClientHttpReques
     public ClientHttpResponse intercept(HttpRequest request, byte[] body, ClientHttpRequestExecution execution)
         throws IOException {
         try {
-            return execution.execute(request, body);
+            ClientHttpResponse response = execution.execute(request, body);
+            response.getBody();
+            return response;
         } catch (IOException e) {
             throw ConnectApiException.connectivity(e);
         }

--- a/connect-library/src/main/java/com/tsanet/api/connectapi/internal/ConnectApiConnectivityInterceptor.java
+++ b/connect-library/src/main/java/com/tsanet/api/connectapi/internal/ConnectApiConnectivityInterceptor.java
@@ -17,9 +17,11 @@ import org.springframework.http.client.ClientHttpResponse;
  * <p>The response body is read here too. The library's request factory buffers responses, so
  * this read fills the buffer the extractor and the error handler later read from; without it a
  * body that fails mid-read would fail after the chain has returned, in the extractor, and
- * surface with the URL in the same way.
+ * surface with the URL in the same way. On an unbuffered template this read would consume the
+ * body instead, which is why the class is package-private: only
+ * {@link ConnectApiRestTemplates#create()}, which installs the buffering factory, can add it.
  */
-public final class ConnectApiConnectivityInterceptor implements ClientHttpRequestInterceptor {
+final class ConnectApiConnectivityInterceptor implements ClientHttpRequestInterceptor {
 
     @Override
     public ClientHttpResponse intercept(HttpRequest request, byte[] body, ClientHttpRequestExecution execution)

--- a/connect-library/src/main/java/com/tsanet/api/connectapi/internal/ConnectApiSessionStore.java
+++ b/connect-library/src/main/java/com/tsanet/api/connectapi/internal/ConnectApiSessionStore.java
@@ -6,43 +6,73 @@ import java.time.Instant;
 import java.util.Objects;
 import java.util.Optional;
 
+/**
+ * The session's authentication state, held as one immutable {@link Snapshot} behind a single
+ * reference. Every write replaces the whole snapshot and every read takes one, so a reader
+ * never sees a bearer from one login beside the username or expiry of another, and
+ * {@link #isExpired} and {@link #isAuthorized} judge a token against its own expiry.
+ */
 public class ConnectApiSessionStore {
-    private volatile String bearerToken;
-    private volatile String username;
-    private volatile String accountId;
-    private volatile AuthMode authMode;
-    private volatile Instant expiresAt;
-    private volatile UserContextDto userContext;
+
+    /** One coherent view of the session. Package-private so the token manager can read it whole. */
+    record Snapshot(
+        String bearerToken,
+        String username,
+        String accountId,
+        AuthMode authMode,
+        Instant expiresAt,
+        UserContextDto userContext
+    ) {
+        static final Snapshot EMPTY = new Snapshot(null, null, null, null, null, null);
+
+        boolean isExpired(Instant now) {
+            if (expiresAt == null) {
+                return false;
+            }
+            return !now.isBefore(expiresAt.minus(TokenManager.EXPIRY_SKEW));
+        }
+
+        boolean hasBearer() {
+            return bearerToken != null && !bearerToken.isBlank();
+        }
+    }
+
+    private volatile Snapshot snapshot = Snapshot.EMPTY;
 
     public void savePassword(String username, String bearerToken) {
         savePassword(username, bearerToken, null);
     }
 
     /** {@code expiresAt} null means the API stated no lifetime; expiry then surfaces only as a 401. */
-    public void savePassword(String username, String bearerToken, Instant expiresAt) {
-        forgetUserContextUnlessSamePrincipal(AuthMode.CONNECT1_PASSWORD, username);
-        this.username = username;
-        this.bearerToken = bearerToken;
-        this.authMode = AuthMode.CONNECT1_PASSWORD;
-        this.expiresAt = expiresAt;
+    public synchronized void savePassword(String username, String bearerToken, Instant expiresAt) {
+        Snapshot current = snapshot;
+        snapshot = new Snapshot(
+            bearerToken,
+            username,
+            current.accountId(),
+            AuthMode.CONNECT1_PASSWORD,
+            expiresAt,
+            userContextUnlessPrincipalChanged(current, AuthMode.CONNECT1_PASSWORD, username)
+        );
+    }
+
+    public synchronized void saveOAuth(String accountId, String bearerToken, Instant expiresAt) {
+        Snapshot current = snapshot;
+        snapshot = new Snapshot(
+            bearerToken,
+            accountId,
+            accountId,
+            AuthMode.CLIENT_CREDENTIALS,
+            expiresAt,
+            userContextUnlessPrincipalChanged(current, AuthMode.CLIENT_CREDENTIALS, accountId)
+        );
     }
 
     /** The company and user behind the session, fetched from {@code /v1/me} right after login. */
-    public void saveUserContext(UserContextDto userContext) {
-        this.userContext = userContext;
-    }
-
-    public Optional<UserContextDto> getUserContext() {
-        return Optional.ofNullable(userContext);
-    }
-
-    public void saveOAuth(String accountId, String bearerToken, Instant expiresAt) {
-        forgetUserContextUnlessSamePrincipal(AuthMode.CLIENT_CREDENTIALS, accountId);
-        this.accountId = accountId;
-        this.username = accountId;
-        this.bearerToken = bearerToken;
-        this.authMode = AuthMode.CLIENT_CREDENTIALS;
-        this.expiresAt = expiresAt;
+    public synchronized void saveUserContext(UserContextDto userContext) {
+        Snapshot current = snapshot;
+        snapshot = new Snapshot(current.bearerToken(), current.username(), current.accountId(),
+            current.authMode(), current.expiresAt(), userContext);
     }
 
     /**
@@ -50,49 +80,51 @@ public class ConnectApiSessionStore {
      * client-credentials token) leaves the {@code /v1/me} context in place: it describes the
      * principal, not the token. Only a different principal, or a change of mode, invalidates it.
      */
-    private void forgetUserContextUnlessSamePrincipal(AuthMode mode, String principal) {
-        if (this.authMode != mode || !Objects.equals(this.username, principal)) {
-            this.userContext = null;
+    private static UserContextDto userContextUnlessPrincipalChanged(Snapshot current, AuthMode mode, String principal) {
+        if (current.authMode() != mode || !Objects.equals(current.username(), principal)) {
+            return null;
         }
+        return current.userContext();
+    }
+
+    Snapshot snapshot() {
+        return snapshot;
+    }
+
+    public Optional<UserContextDto> getUserContext() {
+        return Optional.ofNullable(snapshot.userContext());
     }
 
     public Optional<String> getBearerToken() {
-        return Optional.ofNullable(bearerToken);
+        return Optional.ofNullable(snapshot.bearerToken());
     }
 
     public Optional<String> getUsername() {
-        return Optional.ofNullable(username);
+        return Optional.ofNullable(snapshot.username());
     }
 
     public Optional<String> getAccountId() {
-        return Optional.ofNullable(accountId);
+        return Optional.ofNullable(snapshot.accountId());
     }
 
     public Optional<AuthMode> getAuthMode() {
-        return Optional.ofNullable(authMode);
+        return Optional.ofNullable(snapshot.authMode());
     }
 
     public Optional<Instant> getExpiresAt() {
-        return Optional.ofNullable(expiresAt);
+        return Optional.ofNullable(snapshot.expiresAt());
     }
 
     public boolean isAuthorized() {
-        return bearerToken != null && !bearerToken.isBlank() && !isExpired(Instant.now());
+        Snapshot current = snapshot;
+        return current.hasBearer() && !current.isExpired(Instant.now());
     }
 
     public boolean isExpired(Instant now) {
-        if (expiresAt == null) {
-            return false;
-        }
-        return !now.isBefore(expiresAt.minus(TokenManager.EXPIRY_SKEW));
+        return snapshot.isExpired(now);
     }
 
     public void clear() {
-        this.username = null;
-        this.bearerToken = null;
-        this.accountId = null;
-        this.authMode = null;
-        this.expiresAt = null;
-        this.userContext = null;
+        snapshot = Snapshot.EMPTY;
     }
 }

--- a/connect-library/src/main/java/com/tsanet/api/connectapi/internal/ConnectApiSessionStore.java
+++ b/connect-library/src/main/java/com/tsanet/api/connectapi/internal/ConnectApiSessionStore.java
@@ -125,10 +125,14 @@ public class ConnectApiSessionStore {
     }
 
     /**
-     * Logout. A renewal already past its network call when this runs will store its result
-     * afterwards and repopulate the session; that window predates the snapshot and is left as is.
+     * Logout. Synchronized like the saves, so a save's read-modify-write cannot straddle it and
+     * write back the pre-logout session. What it does not prevent: a renewal already past its
+     * network call stores its token afterwards, and a straggling 401 on a client-credentials
+     * session finds an empty store and logs in again (the 401 path renews on an empty store,
+     * see {@link TokenManager#renewUnlessAlreadyRenewed}). Both predate this class's snapshot
+     * and are left as they were.
      */
-    public void clear() {
+    public synchronized void clear() {
         snapshot = Snapshot.EMPTY;
     }
 }

--- a/connect-library/src/main/java/com/tsanet/api/connectapi/internal/ConnectApiSessionStore.java
+++ b/connect-library/src/main/java/com/tsanet/api/connectapi/internal/ConnectApiSessionStore.java
@@ -124,6 +124,10 @@ public class ConnectApiSessionStore {
         return snapshot.isExpired(now);
     }
 
+    /**
+     * Logout. A renewal already past its network call when this runs will store its result
+     * afterwards and repopulate the session; that window predates the snapshot and is left as is.
+     */
     public void clear() {
         snapshot = Snapshot.EMPTY;
     }

--- a/connect-library/src/main/java/com/tsanet/api/connectapi/internal/OAuth401RetryInterceptor.java
+++ b/connect-library/src/main/java/com/tsanet/api/connectapi/internal/OAuth401RetryInterceptor.java
@@ -9,8 +9,10 @@ import org.springframework.http.client.ClientHttpResponse;
 
 /**
  * Re-sends a request once with a renewed bearer after a 401, when the token manager can renew.
- * Concurrent 401s share one renewal: each passes the bearer it sent, and the manager renews
- * only if the store still holds that bearer.
+ * Concurrent 401s share one renewal: each passes the bearer it sent, and the manager reuses a
+ * different unexpired bearer already in the store instead of renewing. It renews when the store
+ * still holds the bearer that was rejected, when the store is empty, or when the bearer it holds
+ * has itself expired.
  */
 public final class OAuth401RetryInterceptor implements ClientHttpRequestInterceptor {
     private final TokenManager tokenManager;

--- a/connect-library/src/main/java/com/tsanet/api/connectapi/internal/OAuth401RetryInterceptor.java
+++ b/connect-library/src/main/java/com/tsanet/api/connectapi/internal/OAuth401RetryInterceptor.java
@@ -7,6 +7,11 @@ import org.springframework.http.client.ClientHttpRequestExecution;
 import org.springframework.http.client.ClientHttpRequestInterceptor;
 import org.springframework.http.client.ClientHttpResponse;
 
+/**
+ * Re-sends a request once with a renewed bearer after a 401, when the token manager can renew.
+ * Concurrent 401s share one renewal: each passes the bearer it sent, and the manager renews
+ * only if the store still holds that bearer.
+ */
 public final class OAuth401RetryInterceptor implements ClientHttpRequestInterceptor {
     private final TokenManager tokenManager;
 
@@ -22,8 +27,17 @@ public final class OAuth401RetryInterceptor implements ClientHttpRequestIntercep
             return response;
         }
         response.close();
-        String refreshedToken = tokenManager.refreshAccessToken();
+        String refreshedToken = tokenManager.renewUnlessAlreadyRenewed(bearerSent(request));
         request.getHeaders().set(HttpHeaders.AUTHORIZATION, "Bearer " + refreshedToken);
         return execution.execute(request, body);
+    }
+
+    /** The bearer this request carried, so a renewal another caller already made is reused. */
+    private static String bearerSent(HttpRequest request) {
+        String authorization = request.getHeaders().getFirst(HttpHeaders.AUTHORIZATION);
+        if (authorization == null) {
+            return null;
+        }
+        return authorization.regionMatches(true, 0, "Bearer ", 0, 7) ? authorization.substring(7) : authorization;
     }
 }

--- a/connect-library/src/main/java/com/tsanet/api/connectapi/internal/TokenManager.java
+++ b/connect-library/src/main/java/com/tsanet/api/connectapi/internal/TokenManager.java
@@ -89,7 +89,17 @@ public final class TokenManager {
      * caller holds the renewal lock, the store already holds a different unexpired bearer,
      * another caller's renewal has answered this 401 too and that bearer is returned with no
      * network call. If the store still holds the observed bearer it is bad server-side whatever
-     * its expiry says, and one renewal runs.
+     * its expiry says, and one renewal runs. An empty store (logged out, or never logged in)
+     * also renews: a 401 on a session with no bearer is answered with a fresh login, which is
+     * what the previous 401 path did too.
+     *
+     * <p>Two bounded edges of keying on the token rather than the principal. A 401 raised under
+     * one principal can be answered with another's bearer; {@link #supportsRefresh()} bounds
+     * that to a shared session where a login as the configured user overlaps a request issued
+     * under a different typed user, where the previous code re-logged in and reached the same
+     * bearer. And an identity provider that reissues the same token until it truly expires
+     * defeats the reuse check, since every caller finds its own token still stored; the
+     * shared-renewal property then degrades to one fetch per caller, never to a failure.
      */
     public String renewUnlessAlreadyRenewed(String observedToken) {
         renewal.lock();

--- a/connect-library/src/main/java/com/tsanet/api/connectapi/internal/TokenManager.java
+++ b/connect-library/src/main/java/com/tsanet/api/connectapi/internal/TokenManager.java
@@ -79,28 +79,17 @@ public final class TokenManager {
     }
 
     /**
-     * Renews the bearer: a fresh client-credentials token, or a transparent re-login with the
-     * configured password. The platform has no refresh endpoint, so re-login is the strategy,
+     * The 401 path's renewal: a fresh client-credentials token, or a transparent re-login with
+     * the configured password. The platform has no refresh endpoint, so re-login is the strategy,
      * and it is offered only when the session belongs to the configured user; a session opened
      * by an interactively typed password is never renewed silently, because that password was
-     * never retained. Always renews, even when another caller just did; see
-     * {@link #renewUnlessAlreadyRenewed(String)} for the 401 path.
-     */
-    public String refreshAccessToken() {
-        renewal.lock();
-        try {
-            return renew();
-        } finally {
-            renewal.unlock();
-        }
-    }
-
-    /**
-     * The 401 path's renewal. {@code observedToken} is the bearer the rejected request carried.
-     * If, by the time this caller holds the renewal lock, the store already holds a different
-     * unexpired bearer, another caller's renewal has answered this 401 too and that bearer is
-     * returned with no network call. If the store still holds the observed bearer it is bad
-     * server-side whatever its expiry says, and one renewal runs.
+     * never retained.
+     *
+     * <p>{@code observedToken} is the bearer the rejected request carried. If, by the time this
+     * caller holds the renewal lock, the store already holds a different unexpired bearer,
+     * another caller's renewal has answered this 401 too and that bearer is returned with no
+     * network call. If the store still holds the observed bearer it is bad server-side whatever
+     * its expiry says, and one renewal runs.
      */
     public String renewUnlessAlreadyRenewed(String observedToken) {
         renewal.lock();

--- a/connect-library/src/main/java/com/tsanet/api/connectapi/internal/TokenManager.java
+++ b/connect-library/src/main/java/com/tsanet/api/connectapi/internal/TokenManager.java
@@ -9,6 +9,7 @@ import java.time.Clock;
 import java.time.Duration;
 import java.time.Instant;
 import java.util.Optional;
+import java.util.concurrent.locks.ReentrantLock;
 
 public final class TokenManager {
     static final Duration EXPIRY_SKEW = Duration.ofSeconds(60);
@@ -19,6 +20,8 @@ public final class TokenManager {
     private final AccountAuthConfig authConfig;
     private final String accountId;
     private final Clock clock;
+    /** Renewals run one at a time; a caller who waited re-reads the store before renewing again. */
+    private final ReentrantLock renewal = new ReentrantLock();
 
     public TokenManager(
         ConnectApiSessionStore sessionStore,
@@ -53,12 +56,26 @@ public final class TokenManager {
         };
     }
 
-    /** The bearer for the next request, renewed first when the session knows it has expired. */
+    /**
+     * The bearer for the next request, renewed first when the session knows it has expired.
+     * Concurrent callers that all find the token expired share one renewal: the first renews,
+     * the rest wait and then read the token it stored.
+     */
     public String ensureValidAccessToken() {
-        if (sessionStore.isExpired(clock.instant())) {
-            return refreshAccessToken();
+        ConnectApiSessionStore.Snapshot seen = sessionStore.snapshot();
+        if (!seen.isExpired(clock.instant())) {
+            return bearerOf(seen);
         }
-        return sessionStore.getBearerToken().orElseThrow(() -> new IllegalStateException("Not authenticated"));
+        renewal.lock();
+        try {
+            ConnectApiSessionStore.Snapshot current = sessionStore.snapshot();
+            if (!current.isExpired(clock.instant())) {
+                return bearerOf(current);
+            }
+            return renew();
+        } finally {
+            renewal.unlock();
+        }
     }
 
     /**
@@ -66,9 +83,48 @@ public final class TokenManager {
      * configured password. The platform has no refresh endpoint, so re-login is the strategy,
      * and it is offered only when the session belongs to the configured user; a session opened
      * by an interactively typed password is never renewed silently, because that password was
-     * never retained.
+     * never retained. Always renews, even when another caller just did; see
+     * {@link #renewUnlessAlreadyRenewed(String)} for the 401 path.
      */
     public String refreshAccessToken() {
+        renewal.lock();
+        try {
+            return renew();
+        } finally {
+            renewal.unlock();
+        }
+    }
+
+    /**
+     * The 401 path's renewal. {@code observedToken} is the bearer the rejected request carried.
+     * If, by the time this caller holds the renewal lock, the store already holds a different
+     * unexpired bearer, another caller's renewal has answered this 401 too and that bearer is
+     * returned with no network call. If the store still holds the observed bearer it is bad
+     * server-side whatever its expiry says, and one renewal runs.
+     */
+    public String renewUnlessAlreadyRenewed(String observedToken) {
+        renewal.lock();
+        try {
+            ConnectApiSessionStore.Snapshot current = sessionStore.snapshot();
+            if (current.hasBearer()
+                && !current.bearerToken().equals(observedToken)
+                && !current.isExpired(clock.instant())) {
+                return current.bearerToken();
+            }
+            return renew();
+        } finally {
+            renewal.unlock();
+        }
+    }
+
+    private static String bearerOf(ConnectApiSessionStore.Snapshot snapshot) {
+        if (!snapshot.hasBearer()) {
+            throw new IllegalStateException("Not authenticated");
+        }
+        return snapshot.bearerToken();
+    }
+
+    private String renew() {
         return switch (authConfig.mode()) {
             case CLIENT_CREDENTIALS -> authenticateClientCredentials((ClientCredentialsAuthConfig) authConfig);
             case CONNECT1_PASSWORD -> {

--- a/connect-library/src/main/java/com/tsanet/api/internal/DefaultTsaNetApiSession.java
+++ b/connect-library/src/main/java/com/tsanet/api/internal/DefaultTsaNetApiSession.java
@@ -1,5 +1,6 @@
 package com.tsanet.api.internal;
 
+import com.tsanet.api.ConnectApiException;
 import com.tsanet.api.TsaNetApiConfiguration;
 import com.tsanet.api.TsaNetApiSession;
 import com.tsanet.api.connectapi.dto.AttachmentConfigDto;
@@ -67,6 +68,10 @@ import java.util.Optional;
 
 final class DefaultTsaNetApiSession implements TsaNetApiSession, AuthFacade, CollaborationRequestsFacade,
     CaseNotesFacade, CaseResponsesFacade, UserFacade, WebhooksFacade, PartnersFacade, AttachmentsFacade {
+    /** Unattended logins retry {@code /v1/me} on connectivity failures: three attempts, 250 ms then 500 ms apart. */
+    static final int UNATTENDED_CURRENT_USER_ATTEMPTS = 3;
+    static final long[] UNATTENDED_CURRENT_USER_BACKOFF_MS = {250, 500};
+
 
     private final TsaNetApiConfiguration configuration;
     private final ConnectApiSessionStore sessionStore;
@@ -198,7 +203,7 @@ final class DefaultTsaNetApiSession implements TsaNetApiSession, AuthFacade, Col
     @Override
     public String authenticate() {
         String token = tokenManager.authenticate();
-        completeLogin();
+        completeLogin(true);
         return token;
     }
 
@@ -208,7 +213,7 @@ final class DefaultTsaNetApiSession implements TsaNetApiSession, AuthFacade, Col
             throw new IllegalStateException("Password login is not configured for this session. Use authenticate().");
         }
         String token = tokenManager.loginWithPassword(username, password);
-        completeLogin();
+        completeLogin(false);
         return token;
     }
 
@@ -217,14 +222,44 @@ final class DefaultTsaNetApiSession implements TsaNetApiSession, AuthFacade, Col
      * which proves the bearer against a protected call and yields the company and user the
      * session routes for. If that call fails the login has failed: the store is cleared so
      * nothing downstream can run half-authenticated, and the failure surfaces as it is.
+     *
+     * <p>An unattended login (configured credentials, typically a service starting up) retries
+     * that one call a bounded number of times when the failure is connectivity: a blip on one
+     * endpoint should not turn a working start into a hard failure. An interactive login, and
+     * any failure the API answered, fail at once.
      */
-    private void completeLogin() {
+    private void completeLogin(boolean unattended) {
+        int attempt = 0;
+        while (true) {
+            try {
+                UserContextDto context = userGateway.getCurrentUser();
+                sessionStore.saveUserContext(context);
+                return;
+            } catch (ConnectApiException e) {
+                attempt++;
+                boolean retry = unattended
+                    && e.kind() == ConnectApiException.Kind.CONNECTIVITY
+                    && attempt < UNATTENDED_CURRENT_USER_ATTEMPTS
+                    && pause(UNATTENDED_CURRENT_USER_BACKOFF_MS[attempt - 1]);
+                if (!retry) {
+                    sessionStore.clear();
+                    throw e;
+                }
+            } catch (RuntimeException e) {
+                sessionStore.clear();
+                throw e;
+            }
+        }
+    }
+
+    /** Sleeps for the backoff; false when interrupted, with the interrupt restored so the login fails at once. */
+    private static boolean pause(long millis) {
         try {
-            UserContextDto context = userGateway.getCurrentUser();
-            sessionStore.saveUserContext(context);
-        } catch (RuntimeException e) {
-            sessionStore.clear();
-            throw e;
+            Thread.sleep(millis);
+            return true;
+        } catch (InterruptedException interrupted) {
+            Thread.currentThread().interrupt();
+            return false;
         }
     }
 

--- a/connect-library/src/main/java/com/tsanet/api/internal/DefaultTsaNetApiSession.java
+++ b/connect-library/src/main/java/com/tsanet/api/internal/DefaultTsaNetApiSession.java
@@ -68,10 +68,9 @@ import java.util.Optional;
 
 final class DefaultTsaNetApiSession implements TsaNetApiSession, AuthFacade, CollaborationRequestsFacade,
     CaseNotesFacade, CaseResponsesFacade, UserFacade, WebhooksFacade, PartnersFacade, AttachmentsFacade {
-    /** Unattended logins retry {@code /v1/me} on connectivity failures: three attempts, 250 ms then 500 ms apart. */
-    static final int UNATTENDED_CURRENT_USER_ATTEMPTS = 3;
+    /** Unattended logins retry {@code /v1/me} on connectivity failures: one pause per retry, so three attempts. */
     static final long[] UNATTENDED_CURRENT_USER_BACKOFF_MS = {250, 500};
-
+    static final int UNATTENDED_CURRENT_USER_ATTEMPTS = UNATTENDED_CURRENT_USER_BACKOFF_MS.length + 1;
 
     private final TsaNetApiConfiguration configuration;
     private final ConnectApiSessionStore sessionStore;

--- a/connect-library/src/test/java/com/tsanet/api/ConnectApiBaseUrlTest.java
+++ b/connect-library/src/test/java/com/tsanet/api/ConnectApiBaseUrlTest.java
@@ -10,15 +10,15 @@ class ConnectApiBaseUrlTest {
 
     @Test
     void anHttpsBaseUrlPassesWhateverTheCase() {
-        assertThatCode(() -> ConnectApiBaseUrl.requireHttps("https://connect.example", false, "x.allow-insecure-http"))
+        assertThatCode(() -> ConnectApiBaseUrl.requireHttps("https://connect.example", false, "x.base-url", "x.allow-insecure-http"))
             .doesNotThrowAnyException();
-        assertThatCode(() -> ConnectApiBaseUrl.requireHttps("HTTPS://connect.example", false, "x.allow-insecure-http"))
+        assertThatCode(() -> ConnectApiBaseUrl.requireHttps("HTTPS://connect.example", false, "x.base-url", "x.allow-insecure-http"))
             .doesNotThrowAnyException();
     }
 
     @Test
     void aPlainHttpBaseUrlFailsNamingTheApplicationsOwnOptIn() {
-        assertThatThrownBy(() -> ConnectApiBaseUrl.requireHttps("http://connect.example", false, "tsanet.demo.allow-insecure-http"))
+        assertThatThrownBy(() -> ConnectApiBaseUrl.requireHttps("http://connect.example", false, "tsanet.demo.x.api-base-url", "tsanet.demo.allow-insecure-http"))
             .isInstanceOf(IllegalStateException.class)
             .hasMessageContaining("https")
             .hasMessageContaining("tsanet.demo.allow-insecure-http=true");
@@ -26,15 +26,15 @@ class ConnectApiBaseUrlTest {
 
     @Test
     void theOptInAdmitsAnyNonHttpsHost() {
-        assertThatCode(() -> ConnectApiBaseUrl.requireHttps("http://localhost:8080", true, "x")).doesNotThrowAnyException();
+        assertThatCode(() -> ConnectApiBaseUrl.requireHttps("http://localhost:8080", true, "x.base-url", "x")).doesNotThrowAnyException();
     }
 
     @Test
     void aMissingBaseUrlIsItsOwnErrorEvenWithTheOptIn() {
-        assertThatThrownBy(() -> ConnectApiBaseUrl.requireHttps(" ", true, "x"))
+        assertThatThrownBy(() -> ConnectApiBaseUrl.requireHttps(" ", true, "tsanet.api.base-url", "x"))
             .isInstanceOf(IllegalStateException.class)
-            .hasMessageContaining("required");
-        assertThatThrownBy(() -> ConnectApiBaseUrl.requireHttps(null, true, "x"))
+            .hasMessageContaining("tsanet.api.base-url is required");
+        assertThatThrownBy(() -> ConnectApiBaseUrl.requireHttps(null, true, "tsanet.api.base-url", "x"))
             .isInstanceOf(IllegalStateException.class)
             .hasMessageContaining("required");
     }

--- a/connect-library/src/test/java/com/tsanet/api/ConnectApiBaseUrlTest.java
+++ b/connect-library/src/test/java/com/tsanet/api/ConnectApiBaseUrlTest.java
@@ -1,0 +1,41 @@
+package com.tsanet.api;
+
+import static org.assertj.core.api.Assertions.assertThatCode;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import org.junit.jupiter.api.Test;
+
+/** The shared https guard the console and both demos call at startup. */
+class ConnectApiBaseUrlTest {
+
+    @Test
+    void anHttpsBaseUrlPassesWhateverTheCase() {
+        assertThatCode(() -> ConnectApiBaseUrl.requireHttps("https://connect.example", false, "x.allow-insecure-http"))
+            .doesNotThrowAnyException();
+        assertThatCode(() -> ConnectApiBaseUrl.requireHttps("HTTPS://connect.example", false, "x.allow-insecure-http"))
+            .doesNotThrowAnyException();
+    }
+
+    @Test
+    void aPlainHttpBaseUrlFailsNamingTheApplicationsOwnOptIn() {
+        assertThatThrownBy(() -> ConnectApiBaseUrl.requireHttps("http://connect.example", false, "tsanet.demo.allow-insecure-http"))
+            .isInstanceOf(IllegalStateException.class)
+            .hasMessageContaining("https")
+            .hasMessageContaining("tsanet.demo.allow-insecure-http=true");
+    }
+
+    @Test
+    void theOptInAdmitsAnyNonHttpsHost() {
+        assertThatCode(() -> ConnectApiBaseUrl.requireHttps("http://localhost:8080", true, "x")).doesNotThrowAnyException();
+    }
+
+    @Test
+    void aMissingBaseUrlIsItsOwnErrorEvenWithTheOptIn() {
+        assertThatThrownBy(() -> ConnectApiBaseUrl.requireHttps(" ", true, "x"))
+            .isInstanceOf(IllegalStateException.class)
+            .hasMessageContaining("required");
+        assertThatThrownBy(() -> ConnectApiBaseUrl.requireHttps(null, true, "x"))
+            .isInstanceOf(IllegalStateException.class)
+            .hasMessageContaining("required");
+    }
+}

--- a/connect-library/src/test/java/com/tsanet/api/connectapi/internal/ConnectApiConnectivityInterceptorBodyReadTest.java
+++ b/connect-library/src/test/java/com/tsanet/api/connectapi/internal/ConnectApiConnectivityInterceptorBodyReadTest.java
@@ -1,0 +1,126 @@
+package com.tsanet.api.connectapi.internal;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import com.tsanet.api.ConnectApiException;
+import com.tsanet.api.generated.api.CaseResponsesApi;
+import com.tsanet.api.generated.api.IdentityApi;
+import com.tsanet.api.generated.invoker.ApiClient;
+import com.tsanet.api.generated.model.LoginRequestDTO;
+import java.io.ByteArrayInputStream;
+import java.io.IOException;
+import java.io.InputStream;
+import java.net.URI;
+import java.nio.charset.StandardCharsets;
+import org.junit.jupiter.api.Test;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.HttpMethod;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.HttpStatusCode;
+import org.springframework.http.MediaType;
+import org.springframework.http.client.BufferingClientHttpRequestFactory;
+import org.springframework.http.client.ClientHttpRequestFactory;
+import org.springframework.http.client.ClientHttpResponse;
+import org.springframework.mock.http.client.MockClientHttpRequest;
+import org.springframework.web.client.RestTemplate;
+
+/**
+ * A 2xx whose body fails while being read used to escape the interceptor chain and surface as
+ * Spring's {@code ResourceAccessException}, whose message embeds the request URL and with it the
+ * case token. The connectivity interceptor now reads the (buffered) body inside its own try, so
+ * the failure is classified like any other transport failure, and the extractor still receives
+ * the same bytes afterwards.
+ */
+class ConnectApiConnectivityInterceptorBodyReadTest {
+
+    private static final String BASE = "https://connect.example";
+    private static final String TOKEN = "CASETOKEN-MARKER";
+
+    @Test
+    void aBodyThatFailsMidReadIsAConnectivityFailureNamingOnlyTheClass() {
+        ApiClient apiClient = clientAnswering(response(HttpStatus.OK, MediaType.APPLICATION_JSON, new InputStream() {
+            private int served;
+
+            @Override
+            public int read() throws IOException {
+                if (served++ < 3) {
+                    return '{';
+                }
+                throw new IOException("Connection reset by peer while reading " + BASE + "/" + TOKEN);
+            }
+        }));
+
+        assertThatThrownBy(() -> new CaseResponsesApi(apiClient).closeCollaborationRequest(TOKEN))
+            .isInstanceOf(ConnectApiException.class)
+            .satisfies(e -> {
+                ConnectApiException ex = (ConnectApiException) e;
+                assertThat(ex.kind()).isEqualTo(ConnectApiException.Kind.CONNECTIVITY);
+                assertThat(ex.detail()).isEqualTo("IOException");
+                assertThat(ex.getMessage()).doesNotContain("MARKER").doesNotContain("connect.example");
+            });
+    }
+
+    @Test
+    void theExtractorStillReceivesTheWholeBodyAfterTheInterceptorReadIt() {
+        byte[] body = "{\"accessToken\":\"tok-1\",\"expiresIn\":3600}".getBytes(StandardCharsets.UTF_8);
+        ApiClient apiClient = clientAnswering(response(HttpStatus.OK, MediaType.APPLICATION_JSON, new ByteArrayInputStream(body)));
+
+        assertThat(new IdentityApi(apiClient).login(new LoginRequestDTO().username("u").password("p")).getAccessToken())
+            .isEqualTo("tok-1");
+    }
+
+    @Test
+    void anEmptyNoContentAnswerIsNotAFailure() {
+        ApiClient apiClient = clientAnswering(response(HttpStatus.NO_CONTENT, null, InputStream.nullInputStream()));
+
+        assertThat(new CaseResponsesApi(apiClient).closeCollaborationRequest(TOKEN)).isNull();
+    }
+
+    /** The library's own template, with production's buffering factory over a canned response. */
+    private static ApiClient clientAnswering(ClientHttpResponse canned) {
+        RestTemplate restTemplate = ConnectApiRestTemplates.create();
+        ClientHttpRequestFactory answering = (URI uri, HttpMethod method) -> {
+            MockClientHttpRequest request = new MockClientHttpRequest(method, uri);
+            request.setResponse(canned);
+            return request;
+        };
+        restTemplate.setRequestFactory(new BufferingClientHttpRequestFactory(answering));
+        ApiClient apiClient = new ApiClient(restTemplate);
+        apiClient.setBasePath(BASE);
+        apiClient.setBearerToken(() -> "bearer-1");
+        return apiClient;
+    }
+
+    private static ClientHttpResponse response(HttpStatus status, MediaType contentType, InputStream body) {
+        HttpHeaders headers = new HttpHeaders();
+        if (contentType != null) {
+            headers.setContentType(contentType);
+        }
+        return new ClientHttpResponse() {
+            @Override
+            public HttpStatusCode getStatusCode() {
+                return status;
+            }
+
+            @Override
+            public String getStatusText() {
+                return status.getReasonPhrase();
+            }
+
+            @Override
+            public void close() {
+            }
+
+            @Override
+            public InputStream getBody() {
+                return body;
+            }
+
+            @Override
+            public HttpHeaders getHeaders() {
+                return headers;
+            }
+        };
+    }
+}

--- a/connect-library/src/test/java/com/tsanet/api/connectapi/internal/ConnectApiSessionStoreTest.java
+++ b/connect-library/src/test/java/com/tsanet/api/connectapi/internal/ConnectApiSessionStoreTest.java
@@ -68,6 +68,60 @@ class ConnectApiSessionStoreTest {
     }
 
     @Test
+    void aReaderSeesOneLoginWholeNeverATokenBesideAnotherLoginsExpiry() throws Exception {
+        // Two logins alternate as fast as a writer can go; every snapshot a reader takes must pair
+        // a token with its own expiry and username. Field-by-field writes let this tear.
+        ConnectApiSessionStore store = new ConnectApiSessionStore();
+        Instant expiresA = Instant.parse("2026-01-01T12:00:00Z");
+        Instant expiresB = Instant.parse("2026-06-01T12:00:00Z");
+        store.saveOAuth("a", "token-a", expiresA);
+        java.util.concurrent.atomic.AtomicBoolean stop = new java.util.concurrent.atomic.AtomicBoolean();
+        Thread writer = new Thread(() -> {
+            boolean a = false;
+            while (!stop.get()) {
+                if (a) {
+                    store.saveOAuth("a", "token-a", expiresA);
+                } else {
+                    store.savePassword("b", "token-b", expiresB);
+                }
+                a = !a;
+            }
+        });
+        writer.start();
+        try {
+            for (int i = 0; i < 200_000; i++) {
+                ConnectApiSessionStore.Snapshot seen = store.snapshot();
+                if ("token-a".equals(seen.bearerToken())) {
+                    assertThat(seen.expiresAt()).isEqualTo(expiresA);
+                    assertThat(seen.username()).isEqualTo("a");
+                    assertThat(seen.authMode()).isEqualTo(AuthMode.CLIENT_CREDENTIALS);
+                } else {
+                    assertThat(seen.bearerToken()).isEqualTo("token-b");
+                    assertThat(seen.expiresAt()).isEqualTo(expiresB);
+                    assertThat(seen.username()).isEqualTo("b");
+                    assertThat(seen.authMode()).isEqualTo(AuthMode.CONNECT1_PASSWORD);
+                }
+            }
+        } finally {
+            stop.set(true);
+            writer.join(5_000);
+        }
+    }
+
+    @Test
+    void aPasswordLoginKeepsTheAccountIdOfTheSessionItRenews() {
+        ConnectApiSessionStore store = new ConnectApiSessionStore();
+        store.saveOAuth("production", "o1", Instant.parse("2026-01-01T12:00:00Z"));
+
+        store.savePassword("user@test.com", "t1");
+
+        assertThat(store.getAccountId()).contains("production");
+        assertThat(store.getUsername()).contains("user@test.com");
+        assertThat(store.getAuthMode()).contains(AuthMode.CONNECT1_PASSWORD);
+        assertThat(store.getExpiresAt()).isEmpty();
+    }
+
+    @Test
     void itClearsAuthorizationOnLogout() {
         ConnectApiSessionStore store = new ConnectApiSessionStore();
         store.saveOAuth("production", "oauth-token", Instant.parse("2026-01-01T12:00:00Z"));
@@ -76,5 +130,10 @@ class ConnectApiSessionStoreTest {
 
         assertThat(store.isAuthorized()).isFalse();
         assertThat(store.getBearerToken()).isEmpty();
+        assertThat(store.getUsername()).isEmpty();
+        assertThat(store.getAccountId()).isEmpty();
+        assertThat(store.getAuthMode()).isEmpty();
+        assertThat(store.getExpiresAt()).isEmpty();
+        assertThat(store.getUserContext()).isEmpty();
     }
 }

--- a/connect-library/src/test/java/com/tsanet/api/connectapi/internal/OAuth401RetryInterceptorTest.java
+++ b/connect-library/src/test/java/com/tsanet/api/connectapi/internal/OAuth401RetryInterceptorTest.java
@@ -61,7 +61,7 @@ class OAuth401RetryInterceptorTest {
         new OAuth401RetryInterceptor(tokenManager).intercept(request, new byte[0], execution);
 
         assertThat(request.getHeaders().getFirst(HttpHeaders.AUTHORIZATION)).isEqualTo("Bearer already-fresh");
-        verify(tokenManager, never()).refreshAccessToken();
+        verify(tokenManager, times(1)).renewUnlessAlreadyRenewed("stale");
     }
 
     @Test

--- a/connect-library/src/test/java/com/tsanet/api/connectapi/internal/OAuth401RetryInterceptorTest.java
+++ b/connect-library/src/test/java/com/tsanet/api/connectapi/internal/OAuth401RetryInterceptorTest.java
@@ -30,7 +30,7 @@ class OAuth401RetryInterceptorTest {
     void aFourOhOneIsRetriedOnceWithTheRenewedBearerWhenRenewalIsPossible() throws IOException {
         TokenManager tokenManager = mock(TokenManager.class);
         when(tokenManager.supportsRefresh()).thenReturn(true);
-        when(tokenManager.refreshAccessToken()).thenReturn("fresh");
+        when(tokenManager.renewUnlessAlreadyRenewed("stale")).thenReturn("fresh");
         ClientHttpRequestExecution execution = mock(ClientHttpRequestExecution.class);
         when(execution.execute(any(), any()))
             .thenReturn(new MockClientHttpResponse(new byte[0], HttpStatus.UNAUTHORIZED))
@@ -43,7 +43,25 @@ class OAuth401RetryInterceptorTest {
         assertThat(response.getStatusCode()).isEqualTo(HttpStatus.OK);
         assertThat(request.getHeaders().getFirst(HttpHeaders.AUTHORIZATION)).isEqualTo("Bearer fresh");
         verify(execution, times(2)).execute(any(), any());
-        verify(tokenManager).refreshAccessToken();
+        verify(tokenManager).renewUnlessAlreadyRenewed("stale");
+    }
+
+    @Test
+    void theBearerItSentIsPassedWithoutThePrefixSoARenewalAlreadyMadeIsReused() throws IOException {
+        TokenManager tokenManager = mock(TokenManager.class);
+        when(tokenManager.supportsRefresh()).thenReturn(true);
+        when(tokenManager.renewUnlessAlreadyRenewed("stale")).thenReturn("already-fresh");
+        ClientHttpRequestExecution execution = mock(ClientHttpRequestExecution.class);
+        when(execution.execute(any(), any()))
+            .thenReturn(new MockClientHttpResponse(new byte[0], HttpStatus.UNAUTHORIZED))
+            .thenReturn(new MockClientHttpResponse(new byte[0], HttpStatus.OK));
+        MockClientHttpRequest request = new MockClientHttpRequest(HttpMethod.GET, URI.create("https://connect.example/v1/me"));
+        request.getHeaders().set(HttpHeaders.AUTHORIZATION, "bearer stale");
+
+        new OAuth401RetryInterceptor(tokenManager).intercept(request, new byte[0], execution);
+
+        assertThat(request.getHeaders().getFirst(HttpHeaders.AUTHORIZATION)).isEqualTo("Bearer already-fresh");
+        verify(tokenManager, never()).refreshAccessToken();
     }
 
     @Test
@@ -58,7 +76,7 @@ class OAuth401RetryInterceptorTest {
 
         assertThat(response.getStatusCode()).isEqualTo(HttpStatus.UNAUTHORIZED);
         verify(execution, times(1)).execute(any(), any());
-        verify(tokenManager, never()).refreshAccessToken();
+        verify(tokenManager, never()).renewUnlessAlreadyRenewed(any());
     }
 
     @Test
@@ -71,6 +89,6 @@ class OAuth401RetryInterceptorTest {
         ClientHttpResponse response = new OAuth401RetryInterceptor(tokenManager).intercept(request, new byte[0], execution);
 
         assertThat(response.getStatusCode()).isEqualTo(HttpStatus.FORBIDDEN);
-        verify(tokenManager, never()).refreshAccessToken();
+        verify(tokenManager, never()).renewUnlessAlreadyRenewed(any());
     }
 }

--- a/connect-library/src/test/java/com/tsanet/api/connectapi/internal/TokenManagerTest.java
+++ b/connect-library/src/test/java/com/tsanet/api/connectapi/internal/TokenManagerTest.java
@@ -260,4 +260,84 @@ class TokenManagerTest {
 
         assertThat(sessionStore.getUserContext()).contains(context);
     }
+
+    @Test
+    void concurrentCallersWhoAllFindTheTokenExpiredShareOneRenewal() throws Exception {
+        int callers = 8;
+        ConnectApiSessionStore sessionStore = new ConnectApiSessionStore();
+        sessionStore.savePassword("user@test.com", "stale", NOW.minusSeconds(1));
+        java.util.concurrent.CountDownLatch release = new java.util.concurrent.CountDownLatch(1);
+        java.util.concurrent.atomic.AtomicInteger logins = new java.util.concurrent.atomic.AtomicInteger();
+        ConnectApiAuthGateway authGateway = mock(ConnectApiAuthGateway.class);
+        when(authGateway.login("user@test.com", "secret")).thenAnswer(inv -> {
+            logins.incrementAndGet();
+            release.await(5, java.util.concurrent.TimeUnit.SECONDS);
+            return new PasswordLogin("fresh", 3600);
+        });
+        TokenManager tokenManager = new TokenManager(sessionStore, authGateway, mock(OAuthTokenGateway.class),
+            "default", new PasswordAuthConfig("user@test.com", "secret"), CLOCK);
+
+        java.util.concurrent.CyclicBarrier allStarted = new java.util.concurrent.CyclicBarrier(callers + 1);
+        java.util.List<java.util.concurrent.Future<String>> results = new java.util.ArrayList<>();
+        java.util.concurrent.ExecutorService pool = java.util.concurrent.Executors.newFixedThreadPool(callers);
+        try {
+            for (int i = 0; i < callers; i++) {
+                results.add(pool.submit(() -> {
+                    allStarted.await(5, java.util.concurrent.TimeUnit.SECONDS);
+                    return tokenManager.ensureValidAccessToken();
+                }));
+            }
+            allStarted.await(5, java.util.concurrent.TimeUnit.SECONDS);
+            release.countDown();
+            for (java.util.concurrent.Future<String> result : results) {
+                assertThat(result.get(5, java.util.concurrent.TimeUnit.SECONDS)).isEqualTo("fresh");
+            }
+        } finally {
+            pool.shutdownNow();
+        }
+
+        assertThat(logins.get()).isEqualTo(1);
+        verify(authGateway, times(1)).login(any(), any());
+    }
+
+    @Test
+    void aFourOhOneRenewalIsSkippedWhenAnotherCallerAlreadyRenewed() {
+        ConnectApiSessionStore sessionStore = new ConnectApiSessionStore();
+        sessionStore.savePassword("user@test.com", "fresh", NOW.plusSeconds(3600));
+        ConnectApiAuthGateway authGateway = mock(ConnectApiAuthGateway.class);
+        TokenManager tokenManager = new TokenManager(sessionStore, authGateway, mock(OAuthTokenGateway.class),
+            "default", new PasswordAuthConfig("user@test.com", "secret"), CLOCK);
+
+        assertThat(tokenManager.renewUnlessAlreadyRenewed("stale")).isEqualTo("fresh");
+
+        verify(authGateway, never()).login(any(), any());
+    }
+
+    @Test
+    void aFourOhOneOnTheCurrentTokenRenewsWhateverItsExpirySays() {
+        ConnectApiSessionStore sessionStore = new ConnectApiSessionStore();
+        sessionStore.savePassword("user@test.com", "rejected", NOW.plusSeconds(3600));
+        ConnectApiAuthGateway authGateway = mock(ConnectApiAuthGateway.class);
+        when(authGateway.login("user@test.com", "secret")).thenReturn(new PasswordLogin("fresh", 3600));
+        TokenManager tokenManager = new TokenManager(sessionStore, authGateway, mock(OAuthTokenGateway.class),
+            "default", new PasswordAuthConfig("user@test.com", "secret"), CLOCK);
+
+        assertThat(tokenManager.renewUnlessAlreadyRenewed("rejected")).isEqualTo("fresh");
+
+        verify(authGateway, times(1)).login(any(), any());
+    }
+
+    @Test
+    void aFourOhOneRenewsWhenTheOtherCallersTokenHasAlreadyExpiredToo() {
+        ConnectApiSessionStore sessionStore = new ConnectApiSessionStore();
+        sessionStore.savePassword("user@test.com", "other-but-expired", NOW.minusSeconds(1));
+        ConnectApiAuthGateway authGateway = mock(ConnectApiAuthGateway.class);
+        when(authGateway.login("user@test.com", "secret")).thenReturn(new PasswordLogin("fresh", 3600));
+        TokenManager tokenManager = new TokenManager(sessionStore, authGateway, mock(OAuthTokenGateway.class),
+            "default", new PasswordAuthConfig("user@test.com", "secret"), CLOCK);
+
+        assertThat(tokenManager.renewUnlessAlreadyRenewed("stale")).isEqualTo("fresh");
+
+        verify(authGateway, times(1)).login(any(), any());
+    }
 }

--- a/connect-library/src/test/java/com/tsanet/api/connectapi/internal/TokenManagerTest.java
+++ b/connect-library/src/test/java/com/tsanet/api/connectapi/internal/TokenManagerTest.java
@@ -113,7 +113,7 @@ class TokenManagerTest {
         );
 
         assertThat(tokenManager.supportsRefresh()).isFalse();
-        assertThatThrownBy(tokenManager::refreshAccessToken)
+        assertThatThrownBy(() -> tokenManager.renewUnlessAlreadyRenewed(null))
             .isInstanceOf(IllegalStateException.class)
             .hasMessageContaining("log in again");
     }

--- a/connect-library/src/test/java/com/tsanet/api/connectapi/internal/TokenManagerTest.java
+++ b/connect-library/src/test/java/com/tsanet/api/connectapi/internal/TokenManagerTest.java
@@ -328,6 +328,25 @@ class TokenManagerTest {
     }
 
     @Test
+    void aFourOhOneOnAnEmptyStoreLogsInAgainAsThePreviousPathDid() {
+        // Logged out, or never logged in: the 401 path renews. Pinned so the behavior is a decision,
+        // not an accident; clear() documents the straggling-401-after-logout consequence.
+        ConnectApiSessionStore sessionStore = new ConnectApiSessionStore();
+        OAuthTokenGateway oauthTokenGateway = mock(OAuthTokenGateway.class);
+        ClientCredentialsAuthConfig config = new ClientCredentialsAuthConfig(
+            "tenant", null, "client-id", "client-secret", "api://audience", null);
+        when(oauthTokenGateway.fetchClientCredentialsToken(config)).thenReturn(new OAuthAccessToken("fresh", 3600));
+        TokenManager tokenManager = new TokenManager(sessionStore, mock(ConnectApiAuthGateway.class),
+            oauthTokenGateway, "production", config, CLOCK);
+
+        assertThat(tokenManager.supportsRefresh()).isTrue();
+        assertThat(tokenManager.renewUnlessAlreadyRenewed(null)).isEqualTo("fresh");
+
+        assertThat(sessionStore.getBearerToken()).contains("fresh");
+        verify(oauthTokenGateway, times(1)).fetchClientCredentialsToken(any());
+    }
+
+    @Test
     void aFourOhOneRenewsWhenTheOtherCallersTokenHasAlreadyExpiredToo() {
         ConnectApiSessionStore sessionStore = new ConnectApiSessionStore();
         sessionStore.savePassword("user@test.com", "other-but-expired", NOW.minusSeconds(1));

--- a/connect-library/src/test/java/com/tsanet/api/internal/DefaultTsaNetApiSessionLoginTest.java
+++ b/connect-library/src/test/java/com/tsanet/api/internal/DefaultTsaNetApiSessionLoginTest.java
@@ -178,6 +178,71 @@ class DefaultTsaNetApiSessionLoginTest {
     }
 
     @Test
+    void anUnattendedLoginRetriesAConnectivityFailureOnCurrentUser() {
+        when(tokenManager.authenticate()).thenAnswer(inv -> {
+            sessionStore.savePassword("user@test.com", "token-6");
+            return "token-6";
+        });
+        when(userGateway.getCurrentUser())
+            .thenThrow(ConnectApiException.connectivity(new java.net.ConnectException("refused")))
+            .thenThrow(ConnectApiException.connectivity(new java.net.SocketTimeoutException("read")))
+            .thenReturn(CONTEXT);
+
+        assertThat(session.authenticate()).isEqualTo("token-6");
+
+        assertThat(session.currentUserContext()).contains(CONTEXT);
+        assertThat(session.isAuthorized()).isTrue();
+        verify(userGateway, org.mockito.Mockito.times(3)).getCurrentUser();
+    }
+
+    @Test
+    void anUnattendedLoginGivesUpAfterThreeConnectivityFailuresAndClearsTheStore() {
+        when(tokenManager.authenticate()).thenAnswer(inv -> {
+            sessionStore.savePassword("user@test.com", "token-7");
+            return "token-7";
+        });
+        ConnectApiException down = ConnectApiException.connectivity(new java.net.ConnectException("refused"));
+        when(userGateway.getCurrentUser()).thenThrow(down);
+
+        assertThatThrownBy(session::authenticate).isSameAs(down);
+
+        assertThat(sessionStore.getBearerToken()).isEmpty();
+        assertThat(session.currentUserContext()).isEmpty();
+        verify(userGateway, org.mockito.Mockito.times(DefaultTsaNetApiSession.UNATTENDED_CURRENT_USER_ATTEMPTS)).getCurrentUser();
+    }
+
+    @Test
+    void anInteractiveLoginDoesNotRetryCurrentUser() {
+        when(tokenManager.loginWithPassword("user@test.com", "secret")).thenAnswer(inv -> {
+            sessionStore.savePassword("user@test.com", "token-8");
+            return "token-8";
+        });
+        ConnectApiException down = ConnectApiException.connectivity(new java.net.ConnectException("refused"));
+        when(userGateway.getCurrentUser()).thenThrow(down);
+
+        assertThatThrownBy(() -> session.login("user@test.com", "secret")).isSameAs(down);
+
+        assertThat(sessionStore.getBearerToken()).isEmpty();
+        verify(userGateway, org.mockito.Mockito.times(1)).getCurrentUser();
+    }
+
+    @Test
+    void aFailureTheApiAnsweredIsNotRetriedEvenUnattended() {
+        when(tokenManager.authenticate()).thenAnswer(inv -> {
+            sessionStore.savePassword("user@test.com", "token-9");
+            return "token-9";
+        });
+        ConnectApiException forbidden = new ConnectApiException(ConnectApiException.Kind.PROBLEM, 403, "about:blank",
+            "Forbidden", "no role", null, null);
+        when(userGateway.getCurrentUser()).thenThrow(forbidden);
+
+        assertThatThrownBy(session::authenticate).isSameAs(forbidden);
+
+        assertThat(sessionStore.getBearerToken()).isEmpty();
+        verify(userGateway, org.mockito.Mockito.times(1)).getCurrentUser();
+    }
+
+    @Test
     void logoutForgetsTheContext() {
         when(tokenManager.authenticate()).thenAnswer(inv -> {
             sessionStore.savePassword("user@test.com", "token-4");

--- a/connect-library/src/test/java/com/tsanet/api/internal/DefaultTsaNetApiSessionLoginTest.java
+++ b/connect-library/src/test/java/com/tsanet/api/internal/DefaultTsaNetApiSessionLoginTest.java
@@ -254,6 +254,6 @@ class DefaultTsaNetApiSessionLoginTest {
         session.logout();
 
         assertThat(session.currentUserContext()).isEmpty();
-        verify(tokenManager, never()).refreshAccessToken();
+        verify(tokenManager, never()).renewUnlessAlreadyRenewed(org.mockito.ArgumentMatchers.any());
     }
 }

--- a/demo-ui/src/main/java/com/tsanet/demo/config/DemoProperties.java
+++ b/demo-ui/src/main/java/com/tsanet/demo/config/DemoProperties.java
@@ -7,8 +7,14 @@ import org.springframework.boot.context.properties.ConfigurationProperties;
 public record DemoProperties(
     Map<String, EnvironmentDef> environments,
     String defaultEnvironment,
-    String dataDir
+    String dataDir,
+    Boolean allowInsecureHttp
 ) {
+
+    /** The operator's opt-out of the https requirement, for a local mock; null means false. */
+    public boolean insecureHttpAllowed() {
+        return Boolean.TRUE.equals(allowInsecureHttp);
+    }
 
     /**
      * One Connect environment. The Entra tenant and audience are fixed per

--- a/demo-ui/src/main/java/com/tsanet/demo/config/EnvironmentService.java
+++ b/demo-ui/src/main/java/com/tsanet/demo/config/EnvironmentService.java
@@ -48,7 +48,7 @@ public class EnvironmentService {
         if (properties.environments() != null) {
             for (DemoProperties.EnvironmentDef def : properties.environments().values()) {
                 ConnectApiBaseUrl.requireHttps(def.apiBaseUrl(), properties.insecureHttpAllowed(),
-                    "tsanet.demo.allow-insecure-http");
+                    "tsanet.demo.environments.<env>.api-base-url", "tsanet.demo.allow-insecure-http");
             }
         }
         this.properties = properties;

--- a/demo-ui/src/main/java/com/tsanet/demo/config/EnvironmentService.java
+++ b/demo-ui/src/main/java/com/tsanet/demo/config/EnvironmentService.java
@@ -1,5 +1,6 @@
 package com.tsanet.demo.config;
 
+import com.tsanet.api.ConnectApiBaseUrl;
 import com.tsanet.api.TsaNetApi;
 import com.tsanet.api.TsaNetApiConfiguration;
 import com.tsanet.api.TsaNetApiSession;
@@ -42,6 +43,14 @@ public class EnvironmentService {
     private volatile String activeEnvironment;
 
     public EnvironmentService(DemoProperties properties) {
+        // Environments are configuration, not user input, so every base URL is checked once,
+        // here at startup: a bearer over plain http is a credential on the wire.
+        if (properties.environments() != null) {
+            for (DemoProperties.EnvironmentDef def : properties.environments().values()) {
+                ConnectApiBaseUrl.requireHttps(def.apiBaseUrl(), properties.insecureHttpAllowed(),
+                    "tsanet.demo.allow-insecure-http");
+            }
+        }
         this.properties = properties;
         this.activeEnvFile = dataDir().resolve("active-environment");
         this.activeEnvironment = loadPersistedEnvironment();

--- a/demo-ui/src/main/resources/application.yml
+++ b/demo-ui/src/main/resources/application.yml
@@ -24,6 +24,10 @@ tsanet:
     # marker all live under this directory.
     data-dir: ${TSANET_DEMO_DATA_DIR:${user.home}/.tsanet-demo-ui}
     default-environment: beta
+    # Every environment's api-base-url must be https; a plain-http one is rejected at startup
+    # unless allow-insecure-http is true. That switch exists for a local mock; it admits any
+    # non-https host, so it stays false elsewhere.
+    allow-insecure-http: false
     # Production is connect2.tsanet.org — deliberately NOT listed here.
     # entra-tenant-id / entra-audience enable the OAuth client-credentials
     # login mode for an environment. Tenant is shared; audiences differ per

--- a/demo-ui/src/test/java/com/tsanet/demo/config/EnvironmentServiceTest.java
+++ b/demo-ui/src/test/java/com/tsanet/demo/config/EnvironmentServiceTest.java
@@ -1,6 +1,8 @@
 package com.tsanet.demo.config;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatCode;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 import com.tsanet.api.TsaNetApiSession;
 import java.nio.file.Files;
@@ -36,9 +38,31 @@ class EnvironmentServiceTest {
                 "dev", new DemoProperties.EnvironmentDef("Dev", "http://localhost:9", null, null)
             ),
             "beta",
-            dataDir.toString()
+            dataDir.toString(),
+            true  // the tests point at a local http mock that is never contacted
         );
         service = new EnvironmentService(properties);
+    }
+
+    @Test
+    void aPlainHttpEnvironmentIsRefusedAtStartupUnlessTheOperatorOptedIn() {
+        DemoProperties http = new DemoProperties(
+            Map.of("beta", new DemoProperties.EnvironmentDef("Beta", "http://connect.example", null, null)),
+            "beta",
+            dataDir.toString(),
+            null
+        );
+
+        assertThatThrownBy(() -> new EnvironmentService(http))
+            .isInstanceOf(IllegalStateException.class)
+            .hasMessageContaining("https")
+            .hasMessageContaining("tsanet.demo.allow-insecure-http=true");
+        assertThatCode(() -> new EnvironmentService(new DemoProperties(
+            Map.of("beta", new DemoProperties.EnvironmentDef("Beta", "https://connect.example", null, null)),
+            "beta",
+            dataDir.toString(),
+            null
+        ))).doesNotThrowAnyException();
     }
 
     @Test

--- a/demo-ui/src/test/java/com/tsanet/demo/web/SessionGuardTest.java
+++ b/demo-ui/src/test/java/com/tsanet/demo/web/SessionGuardTest.java
@@ -26,7 +26,8 @@ class SessionGuardTest {
         environments = new EnvironmentService(new DemoProperties(
             Map.of("beta", new DemoProperties.EnvironmentDef("Beta", "http://localhost:9", null, null)),
             "beta",
-            dataDir.toString()
+            dataDir.toString(),
+            true  // the tests point at a local http mock that is never contacted
         ));
         guard = new SessionGuard(environments);
     }

--- a/demo-ui/src/test/java/com/tsanet/demo/web/SettingsControllerTest.java
+++ b/demo-ui/src/test/java/com/tsanet/demo/web/SettingsControllerTest.java
@@ -36,7 +36,8 @@ class SettingsControllerTest {
         environments = new EnvironmentService(new DemoProperties(
             Map.of("beta", new DemoProperties.EnvironmentDef("Beta", "http://localhost:9", null, null)),
             "beta",
-            dataDir.toString()
+            dataDir.toString(),
+            true  // the tests point at a local http mock that is never contacted
         ));
         mvc = MockMvcBuilders.standaloneSetup(new SettingsController(environments))
             .setControllerAdvice(new ApiErrorHandler())


### PR DESCRIPTION
Closes #79. The five follow-ups deferred from `tsanetgit/Connect_SDK#78`, one commit each, in dependency order, plus one pre-PR review commit.

## What changed

1. **Atomic session store.** `ConnectApiSessionStore` holds one immutable `Snapshot` behind a single volatile reference; writes are synchronized and replace it whole, every getter reads one, `clear()` installs the empty one. A reader can no longer see a bearer beside another login's username or expiry, and `isAuthorized` judges a token against its own expiry. Public surface unchanged.
2. **Single-flight renewal.** `TokenManager` serializes renewals behind one lock. `ensureValidAccessToken` re-reads the snapshot under the lock and returns the token a previous caller stored. The 401 interceptor passes the bearer the rejected request carried (prefix stripped) to `renewUnlessAlreadyRenewed`: a different unexpired bearer already in the store answers the 401 with no network call; the same bearer is bad server-side whatever its expiry says, and one renewal runs.
3. **Value-free 2xx body-read failure.** The connectivity interceptor reads the response body inside its try. The library's buffering factory caches it there; the extractor and the error handler read the cached bytes; a mid-read failure is classified `CONNECTIVITY` naming only the failure's class, instead of Spring's `ResourceAccessException` with the request URL and the case token in it.
4. **`/v1/me` retry on unattended login.** `authenticate()` (configured credentials) retries the post-login `/v1/me` call on `CONNECTIVITY` failures only: three attempts, 250 ms then 500 ms, interrupt restored and failed at once. `login()` with a typed password does not retry, nothing the API answered is retried, the final failure still clears the store. No new config key.
5. **One https decision, three apps.** `ConnectApiBaseUrl.requireHttps(baseUrl, allowInsecureHttp, optOutSetting)` in the library: pure, no Spring, message names the caller's own setting. The console delegates to it (behavior and tests unchanged). The scripted demo gains `tsanet.api.allow-insecure-http` (false shipped, true in its test config) checked when the session factory bean is built. The demo-ui gains `tsanet.demo.allow-insecure-http` (false shipped) and checks every configured environment's `api-base-url` once in `EnvironmentService`'s constructor. The library's own request paths never call the helper, so tests and local mocks keep using http.
6. **Review round.** `refreshAccessToken` had no production caller left and is removed; the retry count derives from the backoff table's length; `clear()` documents the pre-existing logout-during-renewal window it does not close.

## Behavior changes an operator sees

- The scripted demo and the demo-ui now refuse a plain-http base URL at startup, with the fix in the message. Both ship https values; a local mock needs the opt-in.
- A service using configured credentials waits up to 750 ms longer before a login fails when `/v1/me` is unreachable.

## Receipts

Whole reactor at `016f6f8` (and connect-library again after the review commit):

| module | run | failures | skipped |
|---|---|---|---|
| connect-library | 181 | 0 | 1 |
| attachment-receiver | 182 | 0 | 40 |
| demo-ui | 19 | 0 | 0 |
| TSANet-integration-app | 37 | 0 | 0 |
| TSANet-integration-demo | 8 | 0 | 0 |

Red-first probes: the eight-caller renewal test fails with the lock removed (more than one login); the body-read test fails before the interceptor change with `ResourceAccessException: I/O error on POST request for "https://connect.example/v1/collaboration-requests/CASETOKEN-MARKER/closure"`, the exact residual the #78 QA named.

## Blast radius (pre-flight PROMPT lines)

- **Abstraction introduced (`ConnectApiBaseUrl`), old form grepped:** `grep -rn 'regionMatches(true, 0, "https://"\|startsWith("https\|startsWith("http\|"https://"'` over every module's main code returns nothing outside the helper. The console's inline check was the only prior site and it now delegates.
- **Guard added, why not a representation change:** the https rule is policy over a configured string; there is no representation that makes http unrepresentable without also breaking the local-mock case, hence a guard with an explicit opt-in.
- **Newly reachable failures, receiving handler:** the scripted demo and demo-ui startup failures are `IllegalStateException` out of bean construction, the same shape the console already produced, surfaced by Spring Boot's startup failure report. The `CONNECTIVITY` classification of a body-read failure lands in the same handlers every other connectivity failure does (console renderer, demo `ApiErrorHandler.handleConnectApi` → 502).
- **Positional contracts:** `TsaNetApplicationProperties.Api` and `DemoProperties` each gained a component. `grep -rn 'TsaNetApplicationProperties.Api(\|new DemoProperties('` lists five sites, all tests, all updated in this diff; Spring binds both by name.
- **Prose claims, line that makes them true:** "the library's buffering factory caches it there" rests on `ConnectApiRestTemplates.create()` wrapping `SimpleClientHttpRequestFactory` in `BufferingClientHttpRequestFactory`, and `grep -rn 'ConnectApiConnectivityInterceptor\|new RestTemplate('` over main code shows that factory is the only place the interceptor is installed (the Entra token gateway's bare `RestTemplate` carries no interceptors). "No production caller" for `refreshAccessToken` rests on the same grep returning only two test `never()` verifications, both retargeted.
- **Schema/contract:** none; no stored shape changed. The `Snapshot` is in-memory.

## Not in this PR

- A renewal already past its network call when logout runs stores its token afterwards, and a straggling 401 on a client-credentials session logs an empty store in again. Both predate this PR; `clear()` and `renewUnlessAlreadyRenewed` state them, and the empty-store branch is pinned by test.
- `savePassword` carries the previous snapshot's `accountId` forward (pre-existing, pinned by test).
- A `DemoProperties` opt-in applies to all environments at once; per-environment opt-in was not asked for.

## Advisor and gate

QA round at `b32ce90` (separate session: merge with notes; auto-QA: looks good) answered in the PR comments; fixes in the seventh commit: `clear()` synchronized, two javadocs corrected, connectivity interceptor package-private, base-url setting name in the missing-URL message, empty-store 401 branch pinned. Reactor green, library 182.

Advisor consulted twice. Orientation: land the atomic store before single-flight (the observed-token comparison needs one coherent snapshot), strip the `Bearer ` prefix, make the body-read test also prove identical bytes reach the extractor and an empty 204 does not throw, keep the https helper pure and never called from the library's own paths, retry `/v1/me` only unattended and only on connectivity. Pre-done: sound on the two-monitor interplay and `saveUserContext` racing a renewal; asked for the four greps above, all clean, and the removal of the caller-less method. Pre-PR gate: **CONCERNS** on both runs (cap). Run 1: the buffering invariant and the positional enumerations, answered above; the backoff/attempt coupling, fixed in the review commit. Run 2 at `b32ce90`: the same buffering receipt (the `create()` line cited above), a console-side caller of the removed method (the grep above spans every module and finds none), the 750 ms worst-case wait and the startup failure on a plain-http config (both under behavior changes). Nothing new to change. Review is CI plus a QA-persona pass from a separate session.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
