### PR TITLE
Publish attachment-receiver alongside connect-library on release (#82)

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -3,9 +3,10 @@ name: publish
 # A published GitHub Release is what cuts a version, deliberately rather than on
 # every push: consumers pin a version, so a library change reaches them only when
 # someone decides it should. Same pattern as Connect_Gateway's connector-core
-# publish. Publishes the root pom (connect-library's parent, which consumers must
-# be able to resolve) and connect-library ONLY; the app and demo modules are
-# never published.
+# publish. Publishes the root pom (the parent, which consumers must be able to
+# resolve), connect-library, and attachment-receiver (the storage SPI and adapters
+# the gateway's attachments-only profile will consume, tsanetgit/Connect_Gateway#35;
+# a plain library jar) ONLY; the app and demo modules are never published.
 on:
   release:
     types: [published]
@@ -92,14 +93,16 @@ jobs:
           mvn -B --no-transfer-progress versions:set \
             -DnewVersion="${{ steps.v.outputs.version }}" -DgenerateBackupPoms=false
 
-      # `deploy` runs the full lifecycle, so connect-library's tests gate the
-      # release: a broken client cannot be published. Reactor selection publishes
-      # the parent pom and the library only.
-      - name: Build, test and publish connect-library
+      # `deploy` runs the full lifecycle, so each published module's tests gate
+      # the release: a broken client cannot be published. Reactor selection
+      # publishes the parent pom, the library and the receiver only. The
+      # receiver's live adapter tests are gated on environment variables and skip
+      # here; its unit and contract tests run.
+      - name: Build, test and publish connect-library and attachment-receiver
         working-directory: Connect_SDK
         env:
           MAVEN_USERNAME: ${{ github.actor }}
           MAVEN_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         # -Dmaven.deploy.skip=false arms the deploy that the root pom disarms by
         # default, so this workflow is the only path that publishes.
-        run: mvn -B --no-transfer-progress -pl .,connect-library deploy -Dmaven.deploy.skip=false
+        run: mvn -B --no-transfer-progress -pl .,connect-library,attachment-receiver deploy -Dmaven.deploy.skip=false

--- a/attachment-receiver/pom.xml
+++ b/attachment-receiver/pom.xml
@@ -20,15 +20,6 @@
         tsanetgit/Connect_Gateway#35), and nothing in this module may assume its wire shape.
     </description>
 
-    <properties>
-        <!-- The Boot parent pins httpclient5 5.3.x; the AWS SDK's apache5 HTTP client
-             needs TlsSocketStrategy, which exists only from httpclient5 5.4. Without
-             this override every real S3Client construction dies with
-             NoClassDefFoundError - found by the live acceptance, invisible offline. -->
-        <httpclient5.version>5.6.1</httpclient5.version>
-        <httpcore5.version>5.4.2</httpcore5.version>
-    </properties>
-
     <dependencyManagement>
         <dependencies>
             <dependency>
@@ -55,6 +46,12 @@
         </dependencies>
     </dependencyManagement>
 
+    <!-- All four adapters are required, not optional: RegisteringStorageFactory links every
+         one of them, so a consumer takes all four cloud SDKs (about 170 runtime artifacts).
+         A per-provider split is a deliberate follow-up, not something to do by marking
+         these optional. The AWS SDK's apache5 client needs httpclient5 5.4 or later for
+         TlsSocketStrategy; the Boot 4 parent pins 5.6.x, so no override is needed here, and
+         RegisteringStorageFactoryTest constructs a real S3Client to prove the class links. -->
     <dependencies>
         <dependency>
             <groupId>software.amazon.awssdk</groupId>

--- a/attachment-receiver/pom.xml
+++ b/attachment-receiver/pom.xml
@@ -13,9 +13,11 @@
     <artifactId>attachment-receiver</artifactId>
     <name>attachment-receiver</name>
     <description>
-        Receive side of TSANet Connect case attachments: the AttachmentStorage SPI and its
-        storage adapters. The normalized HTTPS ingest endpoint is a separate, gated concern
-        (tsanetgit/Connect-API-Code#140) and nothing in this module may assume its wire shape.
+        Receive side of TSANet Connect case attachments: the AttachmentStorage SPI, its
+        storage adapters (S3, Azure Files, Azure Blob, GCS), the tenant config model and the
+        go-live verifier. A plain library with no main class. The HTTPS ingest endpoint that
+        feeds it is built in tsanetgit/Connect_Gateway (its attachments-only profile,
+        tsanetgit/Connect_Gateway#35), and nothing in this module may assume its wire shape.
     </description>
 
     <properties>

--- a/pom.xml
+++ b/pom.xml
@@ -38,8 +38,9 @@
     </properties>
 
     <!-- Where `mvn deploy` publishes. The workflow deploys the root pom (this file is
-         connect-library's parent, so consumers need it resolvable) plus connect-library
-         only, via reactor selection (-pl .,connect-library); the app and demo modules
+         the parent, so consumers need it resolvable) plus connect-library and
+         attachment-receiver only, via reactor selection
+         (-pl .,connect-library,attachment-receiver); the app and demo modules
          are never published. The server id `github` is wired to credentials by the
          publish workflow's setup-java step. -->
     <distributionManagement>

--- a/skills/connect-sdk-deploy/SKILL.md
+++ b/skills/connect-sdk-deploy/SKILL.md
@@ -33,7 +33,7 @@ the release version, branch names, and module list against the live repository.
 | `TSANet-integration-app` | Console reference app exposing the library as CLI commands (`login`, `requests`, `notes add`, `webhooks create`, ...) | Spring Boot jar |
 | `TSANet-integration-demo` | Scripted demo scenarios over the library | Spring Boot jar |
 | `demo-ui` | The branded web demo: dashboard, partner search, dynamic process forms, full case lifecycle from the browser. This is "the SDK demo" most people mean. | Spring Boot jar, port 8090 |
-| `attachment-receiver` | The storage half of receiving pushed files: a streaming storage SPI with AWS S3, Azure Files (backend id `azure`), Azure Blob Storage (backend id `azure_blob`), and Google Cloud Storage adapters, an encrypted per-tenant config store, and a go-live verifier. The HTTPS endpoint that accepts the push is not built yet; no standalone docs yet. | Spring Boot jar |
+| `attachment-receiver` | The storage half of receiving pushed files: a streaming storage SPI with AWS S3, Azure Files (backend id `azure`), Azure Blob Storage (backend id `azure_blob`), and Google Cloud Storage adapters, an encrypted per-tenant config store, and a go-live verifier. The HTTPS endpoint that accepts the push is being built in tsanetgit/Connect_Gateway's attachments-only profile (tsanetgit/Connect_Gateway#35), not here; no standalone docs yet. | Library only (published alongside connect-library) |
 
 ## Access model (read this first, it shapes everything)
 

--- a/skills/connect-sdk-deploy/references/consume-artifact.md
+++ b/skills/connect-sdk-deploy/references/consume-artifact.md
@@ -13,7 +13,10 @@ that carries it: the receive side's `AttachmentStorage` SPI, the S3, Azure Files
 Blob and GCS adapters, the tenant config model and the go-live verifier. A plain library
 jar with no main class; bring your own runtime. Its intended consumer is the gateway's
 attachments-only profile (`tsanetgit/Connect_Gateway`); a member deploying its own receiver
-is the other. It does not depend on `connect-library`.
+is the other. It does not depend on `connect-library`. Taking it means taking all four cloud
+SDKs at once: about 170 runtime artifacts, including AWS SDK, Azure, Google Cloud, Netty,
+gRPC and OpenTelemetry, because the storage factory links every adapter. A per-provider
+split is a follow-up, not something the first release offers.
 
 Always point people at the **latest release** for the current version number:
 <https://github.com/tsanetgit/Connect_SDK/releases/latest>. Do not hardcode a version

--- a/skills/connect-sdk-deploy/references/consume-artifact.md
+++ b/skills/connect-sdk-deploy/references/consume-artifact.md
@@ -8,6 +8,13 @@ access to the private spec repository.
 `com.tsanet:connect-library`, published to
 `https://maven.pkg.github.com/tsanetgit/Connect_SDK`.
 
+`com.tsanet:attachment-receiver`, same repository and same version from the first release
+that carries it: the receive side's `AttachmentStorage` SPI, the S3, Azure Files, Azure
+Blob and GCS adapters, the tenant config model and the go-live verifier. A plain library
+jar with no main class; bring your own runtime. Its intended consumer is the gateway's
+attachments-only profile (`tsanetgit/Connect_Gateway`); a member deploying its own receiver
+is the other. It does not depend on `connect-library`.
+
 Always point people at the **latest release** for the current version number:
 <https://github.com/tsanetgit/Connect_SDK/releases/latest>. Do not hardcode a version
 into docs you write for them; quote the coordinates pattern and let the release page


### PR DESCRIPTION
Closes #82. Unblocks `tsanetgit/Connect_Gateway#35` and `#36`, which consume the receiver as a published artifact.

## What changed

- **`publish.yml`**: the deploy step's reactor selection is `-pl .,connect-library,attachment-receiver`. The header comment, the step name and the step comment say the receiver is published too, that its environment-gated live tests skip in CI while its unit and contract tests gate the release, and that the app and demo modules are still never published.
- **Root pom**: the `distributionManagement` comment names the new selection.
- **Receiver pom description** (ships inside the published pom, and package versions are immutable): no longer calls the HTTPS ingest a gated concern under `Connect-API-Code#140`; says it is built in `tsanetgit/Connect_Gateway#35`, and that this is a plain library with no main class.
- **Docs**: `consume-artifact.md` gains `com.tsanet:attachment-receiver` (same repository and version, plain library, gateway as intended consumer, no dependency on `connect-library`); the deploy skill's module map row for the receiver says "Library only" instead of "Spring Boot jar" and points the ingest endpoint at the gateway.

Same version and same release as the library. No sources or javadoc jars, matching the library.

## Receipts

Rehearsed the workflow's two steps locally, exactly as they run in CI, against a file-based deployment target:

```
mvn versions:set -DnewVersion=0.0.1-TEST -DgenerateBackupPoms=false
mvn -pl .,connect-library,attachment-receiver deploy -Dmaven.deploy.skip=false -DaltDeploymentRepository=local::file://<scratch>/repo
```

- The file repository received `tsanet-client-parent`, `connect-library` and `attachment-receiver`, each at `0.0.1-TEST`, pom + jar + checksums.
- The receiver's deployed pom carries `<parent><version>0.0.1-TEST` (the workflow's `versions:set` has no module selection, so every module's parent reference is bumped) and the new description.
- The receiver jar: 29 classes, `META-INF/MANIFEST.MF` only under `META-INF`, no `BOOT-INF`, no `Main-Class`. A plain library jar.
- Receiver tests in that deploy run: **182 run, 0 failures, 40 skipped** (the environment-gated live adapter tests).
- Version restored afterward; `git diff` is the five files above and nothing else.

## Blast radius (pre-flight PROMPT lines)

- **Prose claims, line that makes each true.** "Does not depend on `connect-library`": `grep -n connect-library attachment-receiver/pom.xml` returns nothing. "No main class": `grep -rln '@SpringBootApplication\|public static void main' attachment-receiver/src/main` returns nothing, and no `spring-boot-maven-plugin` in its pom. "Live tests skip in CI": the 40 skipped in the rehearsal, all under `@EnabledIfEnvironmentVariable`. "`versions:set` bumps the parent reference": the deployed receiver pom above.
- **Left-behind sweep** for statements that only the library is published: `git grep -n -i -e 'never published' -e 'library only' -e '-pl \.,connect-library' -e 'published alongside'`. Hits are the two files this PR updates, `verify.yml`'s "ones never published" (still true of the app and demo modules), a dated historical line in the root README about v0.1.0, a build-command comment in the skill, and the consume-artifact line about the parent pom (still true). Nothing stale left.
- **Guard / representation / schema / newly reachable failure**: not applicable; no code, no contract. The one new failure mode is intended: a receiver test failure now fails the release, the same rule the library already had.

## QA round at `a010000`

Separate-session QA: merge with notes; auto-QA: looks good. Second commit `bda310b` drops the stale `httpclient5` override (the factory test proves the platform pin links, and fails on the old 5.3 line with the exact `TlsSocketStrategy` error), adds the dependency-footprint sentence to the consumption reference, and records in the pom why all four adapters stay required. Disposition per note in the PR comments.

## Follow-up (not in this PR)

Per-provider packaging of the receiver (one artifact per adapter over a core SPI artifact, or classpath discovery of adapters), so the gateway profile takes only the backends its tenants use. File once `tsanetgit/Connect_Gateway#35` has a consumer shape.

## Advisor and gate

Advisor consulted twice. Orientation: verify `versions:set` carries no module selection (it does not), rehearse the exact deploy selection to a file repository, same version and release as the library, no sources/javadoc, and fix both the skill row and the pom description now because the description ships inside an immutable package version. Pre-done: three blocks resolved before opening: the dependency claim (grep receipt above), a present-tense contradiction between the pom description and the skill row's "not built yet" (both now say the endpoint is built in the gateway, with the issue number), and the left-behind sweep (above). Pre-PR gate: **LOOKS GOOD**, first run.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

