### PR TITLE
Remove the always-test createRequest shims deprecated for removal since 0.1.0 (2.0.0)

### DIFF
--- a/connect-library/src/main/java/com/tsanet/api/facade/CollaborationRequestsFacade.java
+++ b/connect-library/src/main/java/com/tsanet/api/facade/CollaborationRequestsFacade.java
@@ -54,41 +54,6 @@ public interface CollaborationRequestsFacade {
         boolean testSubmission
     );
 
-    /**
-     * Compatibility form from before the flag was per-call; keeps the pre-existing
-     * behavior of always creating a TEST submission.
-     *
-     * @deprecated pass {@code testSubmission} explicitly; scheduled for removal at
-     *     the next release boundary.
-     */
-    @Deprecated(forRemoval = true)
-    default CollaborationRequestStatusDto createRequest(
-        long receiverCompanyId,
-        String caseNumber,
-        String summary,
-        String description
-    ) {
-        return createRequest(receiverCompanyId, caseNumber, summary, description, true);
-    }
-
-    /**
-     * Compatibility form from before the flag was per-call; keeps the pre-existing
-     * behavior of always creating a TEST submission.
-     *
-     * @deprecated pass {@code testSubmission} explicitly; scheduled for removal at
-     *     the next release boundary.
-     */
-    @Deprecated(forRemoval = true)
-    default CollaborationRequestStatusDto createRequest(
-        CollaborationRequestFormTemplateDto formTemplate,
-        String caseNumber,
-        String summary,
-        String description,
-        Map<Long, String> customFieldValues
-    ) {
-        return createRequest(formTemplate, caseNumber, summary, description, customFieldValues, true);
-    }
-
     CollaborationRequestStatusDto fetchRequestByToken(String caseToken);
 
     void syncAllDetails();

--- a/connect-library/src/test/java/com/tsanet/api/internal/DefaultTsaNetApiSessionCreateRequestTest.java
+++ b/connect-library/src/test/java/com/tsanet/api/internal/DefaultTsaNetApiSessionCreateRequestTest.java
@@ -107,13 +107,6 @@ class DefaultTsaNetApiSessionCreateRequestTest {
         assertThat(capturedForm().getTestSubmission()).isTrue();
     }
 
-    @Test
-    void theDeprecatedOverloadKeepsTheOldAlwaysTestBehavior() {
-        session.createRequest(template(), "CASE-1", "s", "d", Map.of());
-
-        assertThat(capturedForm().getTestSubmission()).isTrue();
-    }
-
     private CollaborationRequestDTO capturedForm() {
         ArgumentCaptor<CollaborationRequestDTO> captor = ArgumentCaptor.forClass(CollaborationRequestDTO.class);
         verify(collaborationGateway).createCollaborationRequest(captor.capture());

--- a/skills/connect-sdk-deploy/SKILL.md
+++ b/skills/connect-sdk-deploy/SKILL.md
@@ -112,7 +112,9 @@ These bite regardless of path, and none of them are visible in the OpenAPI schem
 - **Test-mode asymmetry.** You *write* the `testSubmission` flag when creating a case
   but *read* it back as `testCase`. The library's create API takes an explicit
   per-call `testSubmission` flag with no silent default; the older always-test
-  signatures, deprecated in 0.1.0, were removed in 2.0.0.
+  signatures, deprecated in 0.1.0, were removed in 2.0.0. A consumer that bumps to
+  2.0.0 without recompiling hits `NoSuchMethodError` at the create call, which is that
+  removal, not a platform fault.
 - **Engineer emails must be on the member's registered domain.** The platform rejects
   collaboration requests whose engineer email is off the member company's registered
   domain. This is a business rule, not a schema rule, and the error is not

--- a/skills/connect-sdk-deploy/SKILL.md
+++ b/skills/connect-sdk-deploy/SKILL.md
@@ -111,9 +111,8 @@ These bite regardless of path, and none of them are visible in the OpenAPI schem
   member burn an afternoon debugging their network for what is a typo in a password.
 - **Test-mode asymmetry.** You *write* the `testSubmission` flag when creating a case
   but *read* it back as `testCase`. The library's create API takes an explicit
-  per-call `testSubmission` flag with no silent default; older always-test method
-  signatures remain as deprecated shims (still present in 1.0.0) and will be removed
-  at a later release boundary.
+  per-call `testSubmission` flag with no silent default; the older always-test
+  signatures, deprecated in 0.1.0, were removed in 2.0.0.
 - **Engineer emails must be on the member's registered domain.** The platform rejects
   collaboration requests whose engineer email is off the member company's registered
   domain. This is a business rule, not a schema rule, and the error is not

--- a/skills/connect-sdk-deploy/references/consume-artifact.md
+++ b/skills/connect-sdk-deploy/references/consume-artifact.md
@@ -218,6 +218,8 @@ Watch the release notes on each release.
   mappers (the library's cache reader keeps the old behavior); the `JsonNullable`
   accessors on `CaseApprovalUpdateDTO` and `CollaborationRequestSubmitterUpdateDTO`
   are gone (plain accessors unchanged).
-- The always-test create signatures (pre-0.1.0 behavior), deprecated for removal
-  since 0.1.0, are removed in 2.0.0: `createRequest` takes the explicit per-call
-  `testSubmission` flag in both forms.
+- **2.0.0** removes the always-test create signatures (pre-0.1.0 behavior, deprecated
+  for removal since 0.1.0): `createRequest` takes the explicit per-call `testSubmission`
+  flag in both forms. Removing a `default` interface method breaks binary compatibility
+  as well as source: a consumer that bumps the version without recompiling gets
+  `NoSuchMethodError` at the call, not a compile error. Recompile against 2.0.0.

--- a/skills/connect-sdk-deploy/references/consume-artifact.md
+++ b/skills/connect-sdk-deploy/references/consume-artifact.md
@@ -218,6 +218,6 @@ Watch the release notes on each release.
   mappers (the library's cache reader keeps the old behavior); the `JsonNullable`
   accessors on `CaseApprovalUpdateDTO` and `CollaborationRequestSubmitterUpdateDTO`
   are gone (plain accessors unchanged).
-- Known deprecation: the always-test create signatures (pre-0.1.0 behavior) are still
-  present in 1.0.0 as `@Deprecated(forRemoval = true)` shims; migrate callers to the
-  explicit per-call `testSubmission` flag before they are removed.
+- The always-test create signatures (pre-0.1.0 behavior), deprecated for removal
+  since 0.1.0, are removed in 2.0.0: `createRequest` takes the explicit per-call
+  `testSubmission` flag in both forms.


### PR DESCRIPTION
For the 2.0.0 major. Removes the two `CollaborationRequestsFacade.createRequest` default overloads that silently passed `testSubmission=true`, deprecated `forRemoval` since 0.1.0 and promised for removal at the next major, plus the test that pinned that behavior. Both forms of `createRequest` now take the explicit per-call flag only. The deploy skill and the consumption reference say the shims are gone rather than pending.

## Receipts

- Every caller in this repository already passes the flag: console `CreateRequestExecutor`, demo-ui `CollaborationRequestsController` (both forms), scripted demo `AcmeCreateCollaborationRequestsScenario`; each call read, each ends in `true`.
- `mvn test-compile` over the whole reactor succeeds without the shims (main and test sources of all five modules).
- connect-library: **181 run, 0 failures, 1 skipped** (one fewer than main: the removed shim test).
- `tsanetgit/Connect_Gateway`'s engine never calls `createRequest` (grep of `gateway-engine` main); `tsanetgit/Fin-Intercom_App` consumes the engine, not the library's facade.
- Stragglers: `git grep -i 'always-test\|shim\|forRemoval'` over skills, connect-library, docs and README returns only the two updated doc lines. No other `forRemoval` member exists in the library.
- The facade's `Map` and `CollaborationRequestFormTemplateDto` imports are still used by the remaining six-argument overload.

## Blast radius (pre-flight PROMPT lines)

- **Vocabulary lost a member; old form grepped:** the four-argument and five-argument-without-flag `createRequest` calls. In-repo: none (compile receipt). Known consumers: none (above). An un-inventoried consumer that passed no flag fails at compile against 2.0.0, which is the promised outcome of a `forRemoval` deprecation honored at its boundary.
- **Prose claims:** "deprecated since 0.1.0" per the 0.1.0 release notes and the javadoc removed here; "promised for removal at the next release boundary" is the javadoc's own words.
- Guard, representation, schema, newly reachable failure: not applicable.

## Follow-up (not in this PR)

`CollaborationRequestStatusDto` keeps a plain `@Deprecated` compatibility constructor from before the `testCase` field existed, whose javadoc also says "scheduled for removal at the next release boundary". Left in: it is not `forRemoval`, so consumers were never machine-warned; its old-arity uses have not been enumerated across the reactor's tests (14 files construct the DTO) or consumers; and it degrades safely (null `testCase` reads as unknown, never as real). To be filed: mark it `@Deprecated(forRemoval = true, since = "0.1.0")` with 3.0.0 as the target, and enumerate the call sites, so the javadoc stops promising a boundary that passed.

## Advisor and gate

Advisor consulted once, pre-done (the change is two deletions and two doc lines): ship as scoped, keep the DTO constructor out with a filed follow-up, run the straggler grep (clean, above). Pre-PR gate: **LOOKS GOOD**, first run. Release notes for 2.0.0 carry this as breaking change 5.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
