### PR TITLE
security-audit: read unquoted config values and short secrets in the credentials check (#63)

### DIFF
--- a/.github/workflows/security-audit.yml
+++ b/.github/workflows/security-audit.yml
@@ -36,6 +36,12 @@ jobs:
       - name: Check out the repository
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
 
+      # The detector's own probes run first: a regression in what the audit
+      # can see must fail CI the same way a finding does, or a silent miss
+      # (the class #63 closed) ships as a green run.
+      - name: Probe the audit's detectors
+        run: python3 -m unittest -v scripts/test_security_audit.py
+
       - name: Run mechanical security audit
         shell: bash
         run: |

--- a/scripts/security-audit.py
+++ b/scripts/security-audit.py
@@ -154,8 +154,11 @@ def names_a_variable(match):
     return bool(VARIABLE_NAME.match(match.group(2).strip()))
 
 
-# The credential-shaped keys, shared by both keyword forms below.
-CREDENTIAL_KEY = r"(password|client[_-]?secret|api[_-]?key|apikey)"
+# The credential-shaped keys, shared by both keyword forms below. `passwd` and
+# `pwd` are the two spellings that cost no precision; `secret`, `token`,
+# `access-key` and `credentials` on their own are a wider vocabulary that needs
+# a noise check on real trees first, and they are disclosed as a gap in #63's PR.
+CREDENTIAL_KEY = r"(password|passwd|pwd|client[_-]?secret|api[_-]?key|apikey)"
 
 # Quoted form, any scanned file. The value must be single-line: without
 # excluding newlines a prompt such as System.out.print("Password: ") matches
@@ -188,7 +191,14 @@ def check_no_embedded_secrets(root):
         (re.compile(r"-----BEGIN (RSA |EC )?PRIVATE KEY-----"), "private key"),
     ]
     config_patterns = [(UNQUOTED_CREDENTIAL, "credential-shaped config value")]
-    placeholders = re.compile(r"(?i)your|example|changeme|placeholder|xxx|\.\.\.|\$\{|<.+>|test|dummy|sample")
+    # Placeholder WORDS are anchored to word edges: `test-password` and
+    # `your-secret` are placeholders, `Xq7test2LpR9dWv4A` is a secret that
+    # happens to contain one. With the length floor gone this guard is what
+    # separates a secret from a placeholder, so it must not match inside one.
+    # The reference shapes (`...`, `${`, `<...>`) have no word edges to anchor.
+    placeholders = re.compile(
+        r"(?i)(?<![a-z0-9])(your|example|changeme|placeholder|xxx|test|dummy|sample)(?![a-z0-9])"
+        r"|\.\.\.|\$\{|<.+>")
     hits = []
     for rel, body in walk_sources(root):
         applicable = patterns + (config_patterns if rel.endswith(CONFIG_EXT) else [])

--- a/scripts/security-audit.py
+++ b/scripts/security-audit.py
@@ -33,6 +33,9 @@ POM_NS = {"m": "http://maven.apache.org/POM/4.0.0"}
 # login to sit, and omitting them was not a neutral gap: scripts/simple-test.sh
 # carried a real credential past every prior run of this audit.
 SOURCE_EXT = (".java", ".xml", ".properties", ".yaml", ".yml", ".json", ".sh")
+# Formats whose native convention is an UNQUOTED value: key=value, key: value,
+# export KEY=value. A quote-dependent matcher is blind to all three (#63).
+CONFIG_EXT = (".properties", ".yaml", ".yml", ".sh")
 SKIP_DIRS = {".git", "target", "node_modules", ".idea"}
 
 
@@ -128,7 +131,7 @@ def names_itself(match):
     stripped keeps those quiet without weakening the check, because any real
     secret differs from its own key name.
 
-    Only applies to the keyword pattern, which is the one with two groups.
+    Only applies to the keyword patterns, which are the ones with two groups.
     """
     if match.re.groups < 2:
         return False
@@ -136,26 +139,72 @@ def names_itself(match):
     return normalize(match.group(1)) == normalize(match.group(2))
 
 
+# A value that is a bare ALL_CAPS identifier with at least one underscore names
+# a variable (setup-java's `server-password: MAVEN_TOKEN`, an `export X=$Y`
+# chain), and carries no entropy of its own. The underscore is required on
+# purpose: an all-caps secret with no underscore (HUNTER2) is still reported,
+# and an all-caps secret WITH an underscore is silenced by design; that shape
+# is far more often a reference than a credential.
+VARIABLE_NAME = re.compile(r"^[A-Z][A-Z0-9]*(?:_[A-Z0-9]+)+$")
+
+
+def names_a_variable(match):
+    if match.re.groups < 2:
+        return False
+    return bool(VARIABLE_NAME.match(match.group(2).strip()))
+
+
+# The credential-shaped keys, shared by both keyword forms below.
+CREDENTIAL_KEY = r"(password|client[_-]?secret|api[_-]?key|apikey)"
+
+# Quoted form, any scanned file. The value must be single-line: without
+# excluding newlines a prompt such as System.out.print("Password: ") matches
+# across the following lines and reports a literal that does not exist. No
+# length floor: the old {7,} exempted exactly the short, guessable secrets
+# that matter most, and length is not what separates a secret from a
+# placeholder; the guards below are (#63).
+QUOTED_CREDENTIAL = re.compile(
+    r"(?i)" + CREDENTIAL_KEY + r"\s*[=:]\s*[\"']([^\"'{$<\n][^\"'\n]*)[\"']")
+
+# Unquoted form, CONFIG_EXT only: an optional YAML list dash, an optional
+# `export` or `local`, a key that may be dotted or prefixed
+# (crash.auth-password, TSANET_API_PASSWORD), the value running to end of line
+# or to a `#` / `!` comment. The first character
+# rejects a quote (the quoted form's job), `$` (a shell or Spring reference),
+# `{` (a template) and `<` (a placeholder), and `!` (a YAML tag such as
+# `!vault`). In sh and YAML `!` is not a comment marker, so a value containing
+# one is reported truncated rather than missed.
+UNQUOTED_CREDENTIAL = re.compile(
+    r"(?im)^[ \t]*(?:-[ \t]+)?(?:(?:export|local)[ \t]+)?(?:[\w.\-]*[._-])?" + CREDENTIAL_KEY
+    + r"[ \t]*[=:][ \t]*([^\s\"'#!${<][^#\n]*?)[ \t]*(?:[#!].*)?$")
+
+
 def check_no_embedded_secrets(root):
     cat = "credentials"
     patterns = [
-        # The value must be single-line: without excluding newlines a prompt
-        # such as System.out.print("Password: ") matches across the following
-        # lines and reports a literal that does not exist.
-        (re.compile(r"(?i)(password|client[_-]?secret|api[_-]?key|apikey)\s*[=:]\s*[\"']([^\"'{$<\n][^\"'\n]{7,})[\"']"),
-         "credential-shaped literal"),
+        (QUOTED_CREDENTIAL, "credential-shaped literal"),
         (re.compile(r"xox[baprs]-[A-Za-z0-9-]{10,}"), "Slack token"),
         (re.compile(r"ghp_[A-Za-z0-9]{20,}"), "GitHub PAT"),
         (re.compile(r"-----BEGIN (RSA |EC )?PRIVATE KEY-----"), "private key"),
     ]
+    config_patterns = [(UNQUOTED_CREDENTIAL, "credential-shaped config value")]
     placeholders = re.compile(r"(?i)your|example|changeme|placeholder|xxx|\.\.\.|\$\{|<.+>|test|dummy|sample")
     hits = []
     for rel, body in walk_sources(root):
-        for pat, label in patterns:
+        applicable = patterns + (config_patterns if rel.endswith(CONFIG_EXT) else [])
+        for pat, label in applicable:
             for m in pat.finditer(body):
-                if placeholders.search(m.group(0)):
+                # The placeholder test reads the VALUE for the keyword forms. The
+                # unquoted form's whole match also holds the key prefix and any
+                # trailing comment, and `test.password=realsecret` or
+                # `password: realsecret  # test env` must not be silenced by a
+                # word that is not part of the secret.
+                candidate = m.group(2) if m.re.groups >= 2 else m.group(0)
+                if placeholders.search(candidate):
                     continue
                 if names_itself(m):
+                    continue
+                if names_a_variable(m):
                     continue
                 hits.append(f"{rel}: {label}")
     if hits:

--- a/scripts/test_security_audit.py
+++ b/scripts/test_security_audit.py
@@ -89,6 +89,22 @@ class EmbeddedCredentialsProbe(unittest.TestCase):
     def test_a_placeholder_word_in_the_key_prefix_does_not_silence_the_value(self):
         self.assertFails("app.properties", "test.password=Xq7bTn2LpR9dWv4A\n")
 
+    def test_a_placeholder_word_inside_a_secret_does_not_silence_it(self):
+        # The guard is what separates a secret from a placeholder now that the
+        # length floor is gone, so it must match placeholder WORDS, not substrings.
+        self.assertFails("application.yml", "client-secret: Xq7test2LpR9dWv4A\n")
+        self.assertFails("application.yml", "client-secret: myXXXsecretvalue1\n")
+        self.assertFails("application.yml", "password: sampleXq7bTn2LpR9\n")
+
+    def test_placeholder_words_at_word_edges_still_stay_quiet(self):
+        self.assertPasses("application.yml", "password: your-secret-here\n")
+        self.assertPasses("application.yml", "client-secret: \"<client secret>\"\n")
+        self.assertPasses("application.yml", "api-key: changeme\n")
+
+    def test_passwd_and_pwd_spellings_fail(self):
+        self.assertFails("db.properties", "db.passwd=Xq7bTn2LpR9dWv4A\n")
+        self.assertFails("db.properties", "db.pwd=Xq7bTn2LpR9dWv4A\n")
+
     def test_yaml_list_item_fails(self):
         self.assertFails("accounts.yml", "accounts:\n  - username: a\n  - password: hunter2\n")
 

--- a/scripts/test_security_audit.py
+++ b/scripts/test_security_audit.py
@@ -1,0 +1,161 @@
+#!/usr/bin/env python3
+"""Probes for scripts/security-audit.py's embedded-credentials check (#63).
+
+Each probe builds a throwaway tree (a pom.xml so the script accepts the root,
+plus one fixture file), runs the check, and asserts the verdict. The point is
+the pair of directions the issue pins: the shapes that let a committed secret
+ship must FAIL, and the shapes that are references or placeholders must stay
+quiet, because a detector that fires on a clean tree gets ignored.
+
+Run: python3 -m unittest scripts/test_security_audit.py
+"""
+import importlib.util
+import os
+import subprocess
+import sys
+import tempfile
+import unittest
+
+HERE = os.path.dirname(os.path.abspath(__file__))
+SCRIPT = os.path.join(HERE, "security-audit.py")
+
+
+def load_audit():
+    spec = importlib.util.spec_from_file_location("security_audit", SCRIPT)
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+class EmbeddedCredentialsProbe(unittest.TestCase):
+
+    def setUp(self):
+        self.audit = load_audit()
+        self.tmp = tempfile.TemporaryDirectory()
+        self.root = self.tmp.name
+        with open(os.path.join(self.root, "pom.xml"), "w") as f:
+            f.write("<project/>")
+
+    def tearDown(self):
+        self.tmp.cleanup()
+
+    def verdict(self, filename, content):
+        """The credentials-check status for a tree holding exactly this fixture."""
+        with open(os.path.join(self.root, filename), "w") as f:
+            f.write(content)
+        self.audit.RESULTS.clear()
+        self.audit.check_no_embedded_secrets(self.root)
+        [result] = [r for r in self.audit.RESULTS if r["check"] == "no embedded credentials in source"]
+        os.remove(os.path.join(self.root, filename))
+        return result["status"], result["detail"]
+
+    def assertFails(self, filename, content):
+        status, detail = self.verdict(filename, content)
+        self.assertEqual("FAIL", status, f"{filename!r} {content!r} must FAIL; detail: {detail}")
+
+    def assertPasses(self, filename, content):
+        status, detail = self.verdict(filename, content)
+        self.assertEqual("PASS", status, f"{filename!r} {content!r} must PASS; detail: {detail}")
+
+    # ---- the misses that let #61 ship (issue acceptance, first three items) ----
+
+    def test_unquoted_short_password_in_yaml_fails(self):
+        self.assertFails("application.yml", "crash:\n  auth-password: crash\n")
+
+    def test_unquoted_high_entropy_client_secret_in_yaml_fails(self):
+        self.assertFails("application.yml", "tsanet:\n  client-secret: Xq7bTn2LpR9dWv4A\n")
+
+    def test_the_61_pair_in_properties_fails(self):
+        self.assertFails("tsanet-demo-crash-ssh.properties",
+                         "crash.enabled=true\ncrash.auth-password=crash\n")
+
+    # ---- shapes the old matcher missed for other reasons ----
+
+    def test_quoted_short_secret_fails_now_that_the_length_floor_is_gone(self):
+        self.assertFails("application.yml", "auth-password: \"crash\"\n")
+
+    def test_shell_export_fails(self):
+        self.assertFails("simple-test.sh", "#!/bin/sh\nexport TSANET_PASSWORD=hunter2\n")
+
+    def test_dotted_properties_key_fails(self):
+        self.assertFails("app.properties", "spring.datasource.password=s3cr3t-value\n")
+
+    def test_unquoted_value_before_a_comment_fails(self):
+        self.assertFails("application.yml", "api-key: k9v2m4x8q1  # rotate me\n")
+
+    def test_a_placeholder_word_in_the_comment_does_not_silence_the_value(self):
+        self.assertFails("application.yml", "api-key: k9v2m4x8q1  # test env only\n")
+
+    def test_a_placeholder_word_in_the_key_prefix_does_not_silence_the_value(self):
+        self.assertFails("app.properties", "test.password=Xq7bTn2LpR9dWv4A\n")
+
+    def test_yaml_list_item_fails(self):
+        self.assertFails("accounts.yml", "accounts:\n  - username: a\n  - password: hunter2\n")
+
+    def test_shell_local_fails(self):
+        self.assertFails("run.sh", "f() {\n  local password=hunter2\n}\n")
+
+    # ---- every shape the old matcher already caught still fails ----
+
+    def test_quoted_long_literal_in_java_still_fails(self):
+        self.assertFails("Config.java", 'String password = "hunter2hunter2";\n')
+
+    def test_slack_token_still_fails(self):
+        # Adjacent literals: the committed test source never carries the contiguous
+        # token shape, so push protection has nothing to match; the fixture written
+        # at run time does, so the probe exercises the real pattern.
+        self.assertFails("notes.sh", "TOKEN=xox" "b-1234567890-abcdefghijklmnop\n")
+
+    def test_github_pat_still_fails(self):
+        self.assertFails("Settings.java", 'String pat = "ghp_abcdefghijklmnopqrstuvwxyz0123";\n')
+
+    def test_private_key_still_fails(self):
+        self.assertFails("key.properties", "-----BEGIN RSA PRIVATE KEY-----\nMIIE\n")
+
+    # ---- what must stay quiet, or the check gets ignored ----
+
+    def test_env_var_reference_is_a_variable_name_not_a_secret(self):
+        self.assertPasses("publish.yml", "with:\n  server-password: MAVEN_TOKEN\n")
+
+    def test_spring_placeholder_stays_quiet(self):
+        self.assertPasses("application.yml", "password: ${TSANET_DEMO_AUTH_PASSWORD:}\n")
+
+    def test_shell_reference_stays_quiet(self):
+        self.assertPasses("run.sh", "export PASSWORD=$TSANET_PASSWORD\n")
+
+    def test_yaml_tag_and_template_stay_quiet(self):
+        self.assertPasses("vault.yml", "password: !vault |\n  $ANSIBLE\n")
+        self.assertPasses("chart.yaml", "password: {{ .Values.password }}\n")
+
+    def test_key_naming_itself_stays_quiet(self):
+        self.assertPasses("CredentialsStore.java", 'static final String PASSWORD = "password";\n')
+
+    def test_test_placeholder_stays_quiet(self):
+        self.assertPasses("application.yml", "password: \"test-password\"\n")
+
+    def test_all_caps_without_underscore_is_still_a_secret(self):
+        self.assertFails("application.yml", "auth-password: HUNTER2\n")
+
+    def test_unquoted_form_does_not_apply_to_java(self):
+        # `password = value` without quotes is not a literal in Java; the
+        # unquoted form is a config-format rule and must not fire on code.
+        self.assertPasses("Login.java", "String password = credentials.password;\n")
+
+
+class ExitCodeContract(unittest.TestCase):
+    """The workflow keys on the exit code, so one probe runs the script for real."""
+
+    def test_a_committed_config_secret_exits_one(self):
+        with tempfile.TemporaryDirectory() as root:
+            with open(os.path.join(root, "pom.xml"), "w") as f:
+                f.write("<project/>")
+            with open(os.path.join(root, "application.yml"), "w") as f:
+                f.write("tsanet:\n  client-secret: Xq7bTn2LpR9dWv4A\n")
+            run = subprocess.run([sys.executable, SCRIPT, "--repo-root", root],
+                                 capture_output=True, text=True)
+            self.assertEqual(1, run.returncode, run.stdout + run.stderr)
+            self.assertIn("FAIL  [credentials] no embedded credentials in source", run.stdout)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
Closes #63. The embedded-credentials check matched only a quoted value of eight or more characters, so a secret written the native way in a `.properties`, `.yml`, `.yaml` or `.sh` file passed silently, and so did any short secret even when quoted. That is how #61's `crash`/`crash` shipped past every run of this audit.

## What changed

- **Two keyword forms replace the one quoted-only regex.** The quoted form applies to every scanned file with the length floor dropped: length never separated a secret from a placeholder, and the floor exempted exactly the short, guessable secrets that matter most. The unquoted form applies to the config formats only (`CONFIG_EXT`): an optional YAML list dash, an optional `export` or `local`, a possibly dotted or prefixed key, the value to end of line or a `#` / `!` comment, with a first character that is never a quote, `$`, `{`, `<` or `!`, so references, templates, placeholders and YAML tags do not match at all rather than being filtered afterward.
- **One new guard** beside the existing placeholder and self-naming guards: a bare `ALL_CAPS` identifier with at least one underscore names a variable (setup-java's `server-password: MAVEN_TOKEN`) and carries no entropy. The underscore is required on purpose so an all-caps secret like `HUNTER2` is still reported; an all-caps secret with an underscore is silenced by design, and the comment says so.
- **The placeholder test reads the value, not the whole match**, for the keyword forms. The unquoted form's whole match includes the key prefix and any trailing comment, so `test.password=realsecret` and `password: realsecret  # test env` must not be silenced by a word that is not part of the secret. The token, PAT and private-key patterns still test the whole match.
- **`scripts/test_security_audit.py`**, 24 probes on `unittest`, importing the hyphenated script and running the check on fixture trees in temp dirs: the issue's three acceptance shapes; the other misses (quoted short secret, shell `export` and `local`, dotted key, YAML list item, value before a comment, placeholder word in the comment or key prefix); every shape the old matcher already caught (quoted Java literal, Slack token, GitHub PAT, private key); the references and placeholders that must stay quiet (`${...}`, `$VAR`, `!vault`, `{{ }}`, the env-var name, a key naming itself, `"test-password"`, Java's unquoted assignment); and one subprocess run pinning exit code 1, which the workflow keys on. The Slack fixture is built from adjacent literals so the committed source never holds the contiguous token shape.
- **`security-audit.yml`** runs the probes before the audit, so a detector regression fails CI the way a finding does.

## Receipts

- Probes: **24 pass** on this script; **13 fail** against the script on `main` (the seven miss shapes, `HUNTER2`, the two placeholder-scope cases, the list item, `local`, and the exit-code probe), the other eleven pass on both (retained shapes and quiet cases).
- The final regexes over the whole tree: four candidates, all silenced (three by the old guards, one by the new), zero fire. `python3 scripts/security-audit.py` on this branch: `PASS [credentials] no embedded credentials in source`, `0 fail, 3 warn` (the three warns are pre-existing: unpinned actions in the other two workflows, credential-shaped names near log calls, non-local `http://` in tests and the receiver's https guard).
- Every shape in #63's probe table now matches: `auth-password: crash`, `crash.auth-password=crash`, `client-secret: Xq7bTn2LpR9dWv4A`, and the quoted `"crash"`.
- No document describes the old check (`git grep` for the floor, "quoted", "embedded credential" and "security-audit" over markdown returns nothing), so nothing is left behind.

## Acceptance, item by item

1. `auth-password: crash` unquoted in a `.yml` fixture FAILs: `test_unquoted_short_password_in_yaml_fails`.
2. `client-secret: Xq7bTn2LpR9dWv4A` unquoted in a `.yml` fixture FAILs: `test_unquoted_high_entropy_client_secret_in_yaml_fails`.
3. The #61 pair in `.properties` FAILs: `test_the_61_pair_in_properties_fails`, as a consequence of the class fix, not a CRaSH rule.
4. Every previously caught shape still FAILs: the four `still_fails` probes.
5. `0 fail` against `main`'s tree: the run above (this branch is `main` plus this change).
6. `security-audit.yml` passes on a clean branch: this PR's own run.

## Blast radius (pre-flight PROMPT lines)

- **Guard added, why not a representation change**: the guard is the detector; the representation change (parsing YAML and properties structurally) would trade a regex the reviewer can read for a parser with its own gaps, for no coverage the two forms do not already give.
- **Third fix to one class**: this is the second change to the detector after the `.sh` widening, and the issue asked for the class fix rather than a third narrow patch; the two forms are that.
- **Newly reachable failure**: a FAIL from this check exits 1 and fails the workflow; the probe step fails the same job on a detector regression. Both end in the job's error annotation.
- **Prose claims**: "four candidates, zero fire" is the tree scan with the shipped regexes; "13 fail on main's script" is the run against `git show origin/main:scripts/security-audit.py`.
- Schema/contract: none.

## Known gaps, pre-existing, not this PR

**Key vocabulary.** The keys are `password`, `passwd`, `pwd`, `client-secret`, `api-key` and `apikey`. Bare `secret`, `token`, `auth-token`, `access-key` and `credentials` are not matched, so a high-entropy value under one of those names passes. Each needs a noise check on real trees before it joins the list. Same shape of gap as #63 one level over: #63 fixed value syntax; this is key vocabulary. One follow-up issue with the JSON gap below, on ask.

**JSON.** JSON's `"password": "x"` never matched the keyword form (the closing quote after the key blocks `\s*[=:]`) and still does not; `.json` is scanned only for the token, PAT and key patterns. Filed separately if wanted.

## Advisor and gate

Advisor consulted twice. Orientation: drop the floor entirely, require an underscore in the variable-name guard, add `export`, exclude `$`/`{`/`<` at the first character, re-run the tree scan with the final regexes (all done). Pre-done: one block, the placeholder scan reading the whole match (fixed, two probes), plus defusing the Slack literal and the list-item/`local` forms (done). QA round at `7022d7c` (separate session: merge with notes; auto-QA: looks good) answered in `475cde9`: placeholder words anchored to word edges, `passwd` and `pwd` added, three probes; 27 probes, 15 red on main. Pre-PR gate: **LOOKS GOOD** on the first run, before the pre-done edits; **CONCERNS** on the second, at this head, with one ask: confirm `security-audit.py` accepts `--repo-root`, which the exit-code probe depends on. It does: `main()` defines `--repo-root` (default: the repository root), and the probe passes on that flag. One correction to the commit message: it says twenty probes and nine red on `main`; the counts after the pre-done edits are 24 and 13, as stated above. Review is CI plus a QA-persona pass from a separate session.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


