### PR TITLE
Build the two library mappers with JsonMapper and test the primitive-null setting in both apps

### DIFF
--- a/TSANet-integration-app/src/test/java/com/tsanet/facade/config/JacksonPrimitiveNullConfigTest.java
+++ b/TSANet-integration-app/src/test/java/com/tsanet/facade/config/JacksonPrimitiveNullConfigTest.java
@@ -1,0 +1,42 @@
+package com.tsanet.facade.config;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import tools.jackson.databind.ObjectMapper;
+
+/**
+ * Pins the Jackson 3 default flip that the Boot 4 upgrade worked around: main
+ * application.yml sets {@code fail-on-null-for-primitives: false} so an explicit
+ * JSON null on a primitive still binds to the Jackson 2 default instead of
+ * rejecting the payload. Nothing else exercises that line (Connect_SDK#87).
+ *
+ * <p>The test-resources application.yml shadows the main one on the classpath,
+ * so a plain {@code @SpringBootTest} would never load the setting under test.
+ * {@code spring.config.location} lists the main file first and the test file
+ * second: later locations override earlier ones, so the test overrides (mock
+ * base URL, tmp storage, CLI off) still apply while the main file supplies the
+ * Jackson setting. Remove that line from the main file and this test goes red.
+ * The {@code file:} paths resolve against the module directory, surefire's default
+ * working directory; {@code spring.config.location} replaces the default search
+ * locations entirely, which is intended here.
+ */
+@SpringBootTest(properties = {
+    "spring.config.location=file:./src/main/resources/application.yml,file:./src/test/resources/application.yml"
+})
+class JacksonPrimitiveNullConfigTest {
+
+    record Probe(int count) {
+    }
+
+    @Autowired
+    private ObjectMapper mapper;
+
+    @Test
+    void anExplicitNullOnAPrimitiveBindsToTheDefaultInsteadOfThrowing() {
+        Probe probe = mapper.readValue("{\"count\":null}", Probe.class);
+        assertThat(probe.count()).isZero();
+    }
+}

--- a/TSANet-integration-demo/src/test/java/com/tsanet/application/config/JacksonPrimitiveNullConfigTest.java
+++ b/TSANet-integration-demo/src/test/java/com/tsanet/application/config/JacksonPrimitiveNullConfigTest.java
@@ -1,0 +1,43 @@
+package com.tsanet.application.config;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import tools.jackson.databind.ObjectMapper;
+
+/**
+ * Pins the Jackson 3 default flip that the Boot 4 upgrade worked around: main
+ * application.yml sets {@code fail-on-null-for-primitives: false} so an explicit
+ * JSON null on a primitive still binds to the Jackson 2 default instead of
+ * rejecting the payload. Nothing else exercises that line (Connect_SDK#87).
+ *
+ * <p>The test-resources application.yml shadows the main one on the classpath,
+ * so a plain {@code @SpringBootTest} would never load the setting under test.
+ * {@code spring.config.location} lists the main file first and the test file
+ * second: later locations override earlier ones, so the test overrides (mock
+ * base URL, tmp storage, setup and sync off) still apply while the main file
+ * supplies the Jackson setting. Remove that line from the main file and this
+ * test goes red.
+ * The {@code file:} paths resolve against the module directory, surefire's default
+ * working directory; {@code spring.config.location} replaces the default search
+ * locations entirely, which is intended here.
+ */
+@SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.NONE, properties = {
+    "spring.config.location=file:./src/main/resources/application.yml,file:./src/test/resources/application.yml"
+})
+class JacksonPrimitiveNullConfigTest {
+
+    record Probe(int count) {
+    }
+
+    @Autowired
+    private ObjectMapper mapper;
+
+    @Test
+    void anExplicitNullOnAPrimitiveBindsToTheDefaultInsteadOfThrowing() {
+        Probe probe = mapper.readValue("{\"count\":null}", Probe.class);
+        assertThat(probe.count()).isZero();
+    }
+}

--- a/connect-library/src/main/java/com/tsanet/api/connectapi/internal/OAuthTokenGateway.java
+++ b/connect-library/src/main/java/com/tsanet/api/connectapi/internal/OAuthTokenGateway.java
@@ -2,6 +2,7 @@ package com.tsanet.api.connectapi.internal;
 
 import tools.jackson.databind.JsonNode;
 import tools.jackson.databind.ObjectMapper;
+import tools.jackson.databind.json.JsonMapper;
 import com.tsanet.api.auth.ClientCredentialsAuthConfig;
 import com.tsanet.api.auth.OAuthAccessToken;
 import java.util.List;
@@ -15,7 +16,7 @@ import org.springframework.web.client.RestClientResponseException;
 import org.springframework.web.client.RestTemplate;
 
 public class OAuthTokenGateway {
-    private static final ObjectMapper OBJECT_MAPPER = new ObjectMapper();
+    private static final ObjectMapper OBJECT_MAPPER = JsonMapper.builder().build();
 
     private final RestTemplate restTemplate;
 

--- a/connect-library/src/main/java/com/tsanet/api/webhook/WebhookPayloadParser.java
+++ b/connect-library/src/main/java/com/tsanet/api/webhook/WebhookPayloadParser.java
@@ -2,10 +2,11 @@ package com.tsanet.api.webhook;
 
 import tools.jackson.databind.JsonNode;
 import tools.jackson.databind.ObjectMapper;
+import tools.jackson.databind.json.JsonMapper;
 import com.tsanet.api.connectapi.dto.WebhookPayloadDto;
 
 public final class WebhookPayloadParser {
-    private static final ObjectMapper MAPPER = new ObjectMapper();
+    private static final ObjectMapper MAPPER = JsonMapper.builder().build();
 
     private WebhookPayloadParser() {
     }


### PR DESCRIPTION
Closes tsanetgit/Connect_SDK#87. The two Jackson 3 follow-ups carried on tsanetgit/Fin-Intercom_App#76.

## What

- **connect-library**, `OAuthTokenGateway` and `WebhookPayloadParser`: `new ObjectMapper()` becomes `JsonMapper.builder().build()`, initializer and import only. Field names, types and visibility unchanged.
- **TSANet-integration-app** and **TSANet-integration-demo**: one new `@SpringBootTest` each, `JacksonPrimitiveNullConfigTest`, that deserializes `{"count":null}` into an `int` record component through the Boot-injected `tools.jackson.databind.ObjectMapper` and asserts `0`. That pins the `fail-on-null-for-primitives: false` line in each main `application.yml`, which nothing tested.

No yml, dependency, or existing-test change. 4 files, +89/-2.

## The design point a reviewer should check

Both apps ship a `src/test/resources/application.yml`. On the classpath it shadows the main one, so a plain `@SpringBootTest` in either app never loads the main file, and a test written the obvious way would pin nothing. The new tests set

```
spring.config.location=file:./src/main/resources/application.yml,file:./src/test/resources/application.yml
```

Later locations override earlier ones, so every test override (mock base URL, tmp storage, CLI/setup/sync off) still applies, and the main file supplies the setting under test. `spring.config.location` replaces the default search locations entirely; that is intended and stated in the javadoc. The `file:` paths resolve against the module directory, surefire's default working directory in a reactor or `-pl` run; a location that does not resolve fails the context loudly (`ConfigDataLocationNotFoundException`), never a false pass.

## Receipts (this session, JDK 21, reactor build)

| Claim | Receipt |
|---|---|
| Green | `mvn -pl connect-library,TSANet-integration-app,TSANet-integration-demo -am test`: BUILD SUCCESS; connect-library 181 tests (1 skipped, pre-existing), app 9, demo 38; both new tests ran and passed. Re-run on the committed state after the last javadoc edit: green. |
| Red probe, app | Main yml line removed, test run through the reactor: `MismatchedInput Cannot map null into type int (set DeserializationFeature.FAIL_ON_NULL_FOR_PRIMITIVES to 'false' to allow)`. File restored, `git status` clean on it. |
| Red probe, demo | Same procedure, same error. Restored. |
| Acceptance grep | `git grep 'new ObjectMapper()' -- connect-library/src/main` is empty. No occurrence remains anywhere in the repo's Java. |
| Library change is behavior-neutral | Both classes call only `readTree` (grep: one call each, no `readValue`/`convertValue`/`treeToValue`). `WebhookPayloadDto` is four `String` components; the token gateway takes `expires_in` via `asLong(3600)` on the tree node. No primitive is ever bound through these mappers, so the Jackson 3 defaults they now carry unchanged, including `FAIL_ON_NULL_FOR_PRIMITIVES` on, cannot fire. No builder feature set, on purpose. |
| Existing coverage of the two classes still green | `WebhookPayloadParserTest` 2, `OAuthTokenGatewayTest` 1, `TokenManagerTest` in the green run. |

## Blast radius (generated)

`scripts/pre-pr-artifacts.py --base origin/main`: no detector fired (no positional contract, vocabulary, guard, check or duplication change). Judgment lines:

- **Guard / third+ fix / abstraction introduced:** none.
- **Newly reachable failure:** none in production code. In tests, a missing main yml line now fails `JacksonPrimitiveNullConfigTest` with the Jackson message above; the receiving handler is surefire, the outcome is a red build.
- **Schema, contract, or stored shape:** none.
- **Prose claims, with the line that makes each true:** "test-resources application.yml shadows the main one": both files exist at those paths and Spring loads the first classpath match. "Later locations override earlier ones": Spring Boot config-data semantics for `spring.config.location`; the red/green pair above is the empirical receipt. "Jackson 2 default": `FAIL_ON_NULL_FOR_PRIMITIVES` was off in 2.x, on in 3.x, as the main yml comment records. "Remove that line and this test goes red": the two red-probe rows.

## Pre-PR gate

`scripts/qa-review.py --local`: LOOKS GOOD. Its one unverified edge, whether the main yml is self-sufficient when loaded as the base under the test overrides, is answered by the green run: both contexts boot with exactly that layering.

## Not done here

- Test webEnvironment differs between the apps (`MOCK` default in the app, `NONE` in the demo) because each mirrors its module's existing `@SpringBootTest` convention; the app's test yml also sets `web-application-type: none`, so the effective environment is the same.
- IDE runs whose working directory is not the module directory will fail the new tests at context start; that is the loud failure mode, and surefire is the contract.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
